### PR TITLE
make possible to disable default socat rules

### DIFF
--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -796,4 +796,4 @@ if __name__ == "__main__":
         variant_name=args.variant,
         conn_mode=args.connection_mode,
     )
-    ia.start()
+    ia.start(add_fwd_rules=False)


### PR DESCRIPTION
SR OS nodes do not require default socat rules routed via 127.0.0.1, as we do not use host networking

Since these default socat processes were called, we had an issue with SNMP rule doubled and blackholed