### PR TITLE
Docker net addr

### DIFF
--- a/sros/docker/Dockerfile
+++ b/sros/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update -qy \
     inetutils-ping \
     dnsutils \
     openvswitch-switch \
+    iptables \
  && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE


### PR DESCRIPTION
this PR adds metadata argument for SR OS images
the metadata is a list of arguments that higher level system can pass to vrnetlab

the first metadata arguement is docker-net-v4-addr which informs which network address is used by docker for management. This argument is currently used in SR OS router to configure bof static address to reach the management network 