### PR TITLE
exluded tcp 5000 port from forwarding to sros management to enable telnet access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 *.qcow2
+*.vmdk

--- a/sros/docker/Dockerfile
+++ b/sros/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update -qy \
     dnsutils \
     openvswitch-switch \
     iptables \
+    telnet \
  && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE


### PR DESCRIPTION
all tcp ports were forwarded from container eth0 interface to sros management interface.
This prevented access to sros serial interface (tcp/5000) from outside the container

This PR adds a change to the iptables forwarding rules so that tcp/5000 is exluded from port forwarding to sros management interface.
