### PR TITLE
initial support for multi-lc sros images

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -82,7 +82,7 @@ class VM:
         # append role to overlay name to have different overlay images for control and data plane images
         if hasattr(self, "role"):
             tokens = overlay_disk_image.split(".")
-            tokens[0] = tokens[0] + "-" + self.role
+            tokens[0] = tokens[0] + "-" + self.role + str(self.num)
             overlay_disk_image = ".".join(tokens)
 
         if not os.path.exists(overlay_disk_image):

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -44,13 +44,15 @@ SROS_VARIANTS = {
             "timos_line": "slot=A chassis=ixr-e card=cpm-ixr-e",
         },
         # line card (IOM/XCM)
-        "lc": {
-            "min_ram": 4,
-            "timos_line": "chassis=ixr-e slot=1 card=imm24-sfp++8-sfp28+2-qsfp28 mda/1=m24-sfp++8-sfp28+2-qsfp28",
-            "card_config": """/configure card 1 card-type imm24-sfp++8-sfp28+2-qsfp28
-            /configure card 1 mda 1 mda-type m24-sfp++8-sfp28+2-qsfp28
+        "lcs": [
+            {
+                "min_ram": 4,
+                "timos_line": "chassis=ixr-e slot=1 card=imm24-sfp++8-sfp28+2-qsfp28 mda/1=m24-sfp++8-sfp28+2-qsfp28",
+                "card_config": """/configure card 1 card-type imm24-sfp++8-sfp28+2-qsfp28
+                /configure card 1 mda 1 mda-type m24-sfp++8-sfp28+2-qsfp28
             """,
-        },
+            }
+        ],
     },
     #    "ixr-6": {
     #        "deployment_model": "distributed",
@@ -93,13 +95,15 @@ SROS_VARIANTS = {
             "timos_line": "slot=A chassis=ixr-s card=cpm-ixr-s",
         },
         # line card (IOM/XCM)
-        "lc": {
-            "min_ram": 4,
-            "timos_line": "chassis=ixr-s slot=1 card=imm48-sfp++6-qsfp28 mda/1=m48-sfp++6-qsfp28",
-            "card_config": """/configure card 1 card-type m48-sfp++6-qsfp28
-            /configure card 1 mda 1 mda-type m48-sfp++6-qsfp28
+        "lcs": [
+            {
+                "min_ram": 4,
+                "timos_line": "chassis=ixr-s slot=1 card=imm48-sfp++6-qsfp28 mda/1=m48-sfp++6-qsfp28",
+                "card_config": """/configure card 1 card-type m48-sfp++6-qsfp28
+                /configure card 1 mda 1 mda-type m48-sfp++6-qsfp28
             """,
-        },
+            }
+        ],
     },
     "ixr-e-small": {
         "deployment_model": "distributed",
@@ -110,12 +114,14 @@ SROS_VARIANTS = {
             "timos_line": "slot=A chassis=ixr-e card=imm14-10g-sfp++4-1g-tx",
         },
         # line card (IOM/XCM)
-        "lc": {
-            "min_ram": 4,
-            "timos_line": "chassis=ixr-e slot=1 card=imm14-10g-sfp++4-1g-tx mda/1=m14-10g-sfp++4-1g-tx",
-            "card_config": """
+        "lcs": [
+            {
+                "min_ram": 4,
+                "timos_line": "chassis=ixr-e slot=1 card=imm14-10g-sfp++4-1g-tx mda/1=m14-10g-sfp++4-1g-tx",
+                "card_config": """
             """,
-        },
+            }
+        ],
     },
     "sr-1s": {
         "deployment_model": "integrated",
@@ -140,43 +146,45 @@ SROS_VARIANTS = {
             "timos_line": "slot=A chassis=SR-14s sfm=sfm-s card=cpm2-s",
         },
         # line card (IOM/XCM)
-        "lc": {
-            "min_ram": 6,
-            "timos_line": "slot=1 chassis=SR-14s sfm=sfm-s card=xcm-14s mda/1=s36-100gb-qsfp28",
-            "card_config": """/configure system power-shelf 1 power-shelf-type ps-a10-shelf-dc
-            /configure system power-shelf 1 power-module 1 power-module-type ps-a-dc-6000
-            /configure system power-shelf 1 power-module 2 power-module-type ps-a-dc-6000
-            /configure system power-shelf 1 power-module 3 power-module-type ps-a-dc-6000
-            /configure system power-shelf 1 power-module 4 power-module-type ps-a-dc-6000
-            /configure system power-shelf 1 power-module 5 power-module-type ps-a-dc-6000
-            /configure system power-shelf 1 power-module 6 power-module-type ps-a-dc-6000
-            /configure system power-shelf 1 power-module 7 power-module-type ps-a-dc-6000
-            /configure system power-shelf 1 power-module 8 power-module-type ps-a-dc-6000
-            /configure system power-shelf 1 power-module 9 power-module-type ps-a-dc-6000
-            /configure system power-shelf 1 power-module 10 power-module-type ps-a-dc-6000
-            /configure system power-shelf 2 power-shelf-type ps-a10-shelf-dc
-            /configure system power-shelf 2 power-module 1 power-module-type ps-a-dc-6000
-            /configure system power-shelf 2 power-module 2 power-module-type ps-a-dc-6000
-            /configure system power-shelf 2 power-module 3 power-module-type ps-a-dc-6000
-            /configure system power-shelf 2 power-module 4 power-module-type ps-a-dc-6000
-            /configure system power-shelf 2 power-module 5 power-module-type ps-a-dc-6000
-            /configure system power-shelf 2 power-module 6 power-module-type ps-a-dc-6000
-            /configure system power-shelf 2 power-module 7 power-module-type ps-a-dc-6000
-            /configure system power-shelf 2 power-module 8 power-module-type ps-a-dc-6000
-            /configure system power-shelf 2 power-module 9 power-module-type ps-a-dc-6000
-            /configure system power-shelf 2 power-module 10 power-module-type ps-a-dc-6000
-            /configure sfm 1 sfm-type sfm-s
-            /configure sfm 2 sfm-type sfm-s
-            /configure sfm 3 sfm-type sfm-s
-            /configure sfm 4 sfm-type sfm-s
-            /configure sfm 5 sfm-type sfm-s
-            /configure sfm 6 sfm-type sfm-s
-            /configure sfm 7 sfm-type sfm-s
-            /configure sfm 8 sfm-type sfm-s
-            /configure card 1 card-type xcm-14s
-            /configure card 1 mda 1 mda-type s36-100gb-qsfp28
+        "lcs": [
+            {
+                "min_ram": 6,
+                "timos_line": "slot=1 chassis=SR-14s sfm=sfm-s card=xcm-14s mda/1=s36-100gb-qsfp28",
+                "card_config": """/configure system power-shelf 1 power-shelf-type ps-a10-shelf-dc
+                /configure system power-shelf 1 power-module 1 power-module-type ps-a-dc-6000
+                /configure system power-shelf 1 power-module 2 power-module-type ps-a-dc-6000
+                /configure system power-shelf 1 power-module 3 power-module-type ps-a-dc-6000
+                /configure system power-shelf 1 power-module 4 power-module-type ps-a-dc-6000
+                /configure system power-shelf 1 power-module 5 power-module-type ps-a-dc-6000
+                /configure system power-shelf 1 power-module 6 power-module-type ps-a-dc-6000
+                /configure system power-shelf 1 power-module 7 power-module-type ps-a-dc-6000
+                /configure system power-shelf 1 power-module 8 power-module-type ps-a-dc-6000
+                /configure system power-shelf 1 power-module 9 power-module-type ps-a-dc-6000
+                /configure system power-shelf 1 power-module 10 power-module-type ps-a-dc-6000
+                /configure system power-shelf 2 power-shelf-type ps-a10-shelf-dc
+                /configure system power-shelf 2 power-module 1 power-module-type ps-a-dc-6000
+                /configure system power-shelf 2 power-module 2 power-module-type ps-a-dc-6000
+                /configure system power-shelf 2 power-module 3 power-module-type ps-a-dc-6000
+                /configure system power-shelf 2 power-module 4 power-module-type ps-a-dc-6000
+                /configure system power-shelf 2 power-module 5 power-module-type ps-a-dc-6000
+                /configure system power-shelf 2 power-module 6 power-module-type ps-a-dc-6000
+                /configure system power-shelf 2 power-module 7 power-module-type ps-a-dc-6000
+                /configure system power-shelf 2 power-module 8 power-module-type ps-a-dc-6000
+                /configure system power-shelf 2 power-module 9 power-module-type ps-a-dc-6000
+                /configure system power-shelf 2 power-module 10 power-module-type ps-a-dc-6000
+                /configure sfm 1 sfm-type sfm-s
+                /configure sfm 2 sfm-type sfm-s
+                /configure sfm 3 sfm-type sfm-s
+                /configure sfm 4 sfm-type sfm-s
+                /configure sfm 5 sfm-type sfm-s
+                /configure sfm 6 sfm-type sfm-s
+                /configure sfm 7 sfm-type sfm-s
+                /configure sfm 8 sfm-type sfm-s
+                /configure card 1 card-type xcm-14s
+                /configure card 1 mda 1 mda-type s36-100gb-qsfp28
             """,
-        },
+            }
+        ],
     },
     "sr-1": {
         "deployment_model": "integrated",
@@ -196,13 +204,15 @@ SROS_VARIANTS = {
             "timos_line": "slot=A chassis=sr-1e card=cpm-e",
         },
         # line card (IOM/XCM)
-        "lc": {
-            "min_ram": 4,
-            "timos_line": "chassis=sr-1e slot=1 card=iom-e mda/1=me40-1gb-csfp",
-            "card_config": """/configure card 1 card-type iom-e
-            /configure card 1 mda 1 mda-type me40-1gb-csfp
+        "lcs": [
+            {
+                "min_ram": 4,
+                "timos_line": "chassis=sr-1e slot=1 card=iom-e mda/1=me40-1gb-csfp",
+                "card_config": """/configure card 1 card-type iom-e
+                /configure card 1 mda 1 mda-type me40-1gb-csfp
             """,
-        },
+            }
+        ],
     },
 }
 
@@ -242,7 +252,7 @@ SROS_MGMT_ADDR = "172.31.255.30"
 PREFIX_LENGTH = "30"
 
 
-def parse_custom_variant(self, cfg):
+def parse_custom_variant(cfg):
     """Parse custom variant definition from a users input returning a variant dict
     an example of user defined variant configuration
     1) integrated:  cpu=2 ram=4 max_nics=6 chassis=sr-1 slot=A card=cpm-1 slot=1 mda/1=me6-100gb-qsfp28
@@ -276,14 +286,17 @@ def parse_custom_variant(self, cfg):
     }  # some default value for num nics if it is not provided in user cfg
     if "___" in cfg:
         variant["deployment_model"] = "distributed"
+        variant["lcs"] = []
+        variant["max_nics"] = 0
         for hw_part in cfg.split("___"):
             if "cp: " in hw_part:
                 variant["cp"] = _parse(hw_part.strip(), None, skip_nics=True)
             elif "lc: " in hw_part:
-                variant["lc"] = _parse(hw_part.strip(), None)
-                if "max_nics" in variant["lc"]:
-                    variant["max_nics"] = int(variant["lc"]["max_nics"])
-                    variant["lc"].pop("max_nics")
+                lc = _parse(hw_part.strip(), None)
+                if "max_nics" in lc:
+                    variant["max_nics"] = variant["max_nics"] + int(lc["max_nics"])
+                    lc.pop("max_nics")
+                variant["lcs"].append(lc)
 
     else:
         # parsing integrated mode config
@@ -592,9 +605,10 @@ class SROS_cp(SROS_vm):
                 )
 
             # configure card/mda of a given variant
-            if "card_config" in self.variant["lc"]:
-                for l in iter(self.variant["lc"]["card_config"].splitlines()):
-                    self.wait_write(l)
+            for lc in self.variant["lcs"]:
+                if "card_config" in lc:
+                    for l in iter(lc["card_config"].splitlines()):
+                        self.wait_write(l)
 
             # configure bof
             for l in iter(gen_bof_config()):
@@ -612,14 +626,19 @@ class SROS_cp(SROS_vm):
 class SROS_lc(SROS_vm):
     """Line card for distributed VSR-SIM"""
 
-    def __init__(self, variant, conn_mode, num_nics, slot=1):
+    def __init__(self, lc_config, conn_mode, num_nics, slot=1):
         # cp - control plane. role is used to create a separate overlay image name
         self.role = "lc"
         super(SROS_lc, self).__init__(
-            None, None, 1024 * int(variant["lc"]["min_ram"]), conn_mode, num=slot
+            None,
+            None,
+            1024 * int(lc_config["min_ram"]),
+            conn_mode,
+            num=slot,
+            cpu=lc_config.get("cpu"),
         )
 
-        self.smbios = ["type=1,product=TIMOS:{}".format(variant["lc"]["timos_line"])]
+        self.smbios = ["type=1,product=TIMOS:{}".format(lc_config["timos_line"])]
         self.slot = slot
         self.num_nics = num_nics
 
@@ -680,7 +699,7 @@ class SROS(vrnetlab.VR):
         if variant_name in SROS_VARIANTS:
             variant = SROS_VARIANTS[variant_name]
         else:
-            variant = parse_custom_variant(self, variant_name)
+            variant = parse_custom_variant(variant_name)
 
         major_release = 0
 
@@ -707,6 +726,7 @@ class SROS(vrnetlab.VR):
             )
             sys.exit(1)
 
+        self.logger.debug("Raw SR OS variant: " + str(variant))
         self.logger.info("SR OS Variant: " + variant_name)
         self.logger.info(f"Number of NICs: {variant['max_nics']}")
         self.logger.info("Configuration mode: " + str(mode))
@@ -736,9 +756,12 @@ class SROS(vrnetlab.VR):
                     major_release,
                     variant,
                     conn_mode,
-                ),
-                SROS_lc(variant, conn_mode, variant["max_nics"]),
+                )
             ]
+            for i, lc in enumerate(variant["lcs"]):
+                self.vms.append(
+                    SROS_lc(lc, conn_mode, variant["max_nics"], slot=2 + i),
+                )
 
             # set up bridge for connecting CP with LCs
             vrnetlab.run_command(["brctl", "addbr", "int_cp"])


### PR DESCRIPTION
ref #37 
this PR adds intial support for multi line card images. These are the images that have multiple SROS_lc VMs defined.

The code allows to define multi-lc VMs like that:

```yaml
name: sros-test

topology:
  nodes:
    # a custom variant with many LCs
    sr1:
      kind: vr-sros
      image: vrnetlab/vr-sros:21.2.R1
      license: license-sros21.txt
      type: |
        cp: cpu=4 ram=4 chassis=sr-2s slot=A card=cpm-2s ___
        lc: cpu=2 ram=4 max_nics=8 chassis=sr-2s slot=1 card=xcm-2s xiom/x1=iom-s-1.5t mda/x1/1=ms2-400gb-qsfpdd+2-100gb-qsfp28 ___
        lc: cpu=2 ram=4 max_nics=8 chassis=sr-2s slot=2 card=xcm-2s xiom/x1=iom-s-1.5t mda/x1/1=ms2-400gb-qsfpdd+2-100gb-qsfp28
```

The problem is that additional work is needed here to make qemu strings for different SROS_lc VMs. At this point, if you attach `eth1` interface to that node, it will try to create `tap1` interface for both linecard VMs and fail.

```
2021-03-18 12:30:03,315: vrnetlab   INFO     Starting SROS_lc
2021-03-18 12:30:08,321: vrnetlab   DEBUG    joined cmd: qemu-system-x86_64 -enable-kvm -display none -machine pc -monitor tcp:0.0.0.0:4002,server,nowait -m 4096 -serial telnet:0.0.0.0:5002,server,nowait -drive if=ide,file=/sros-overlay-lc2.qcow2 -cpu host -smp 2 -uuid 00000000-0000-0000-0000-000000000000 -smbios "type=1,product=TIMOS:chassis=sr-2s slot=1 card=xcm-2s xiom/x1=iom-s-1.5t mda/x1/1=ms2-400gb-qsfpdd+2-100gb-qsfp28" -device pci-bridge,chassis_nr=1,id=pci.1 -device virtio-net-pci,netdev=mgmt,mac=52:54:00:43:a4:00 -netdev user,id=mgmt,net=10.0.0.0/24 -device virtio-net-pci,netdev=vfpc-int,mac=52:54:00:15:14:00 -netdev tap,ifname=vfpc2-int,id=vfpc-int,script=no,downscript=no -device virtio-net-pci,netdev=p01,mac=52:54:00:aa:a6:01,bus=pci.1,addr=0x2 -netdev tap,id=p01,ifname=tap1,script=/etc/tc-tap-ifup,downscript=no

2021-03-18 12:30:13,338: vrnetlab   INFO     Starting SROS_lc
2021-03-18 12:30:18,346: vrnetlab   DEBUG    joined cmd: qemu-system-x86_64 -enable-kvm -display none -machine pc -monitor tcp:0.0.0.0:4003,server,nowait -m 4096 -serial telnet:0.0.0.0:5003,server,nowait -drive if=ide,file=/sros-overlay-lc3.qcow2 -cpu host -smp 2 -uuid 00000000-0000-0000-0000-000000000000 -smbios "type=1,product=TIMOS:chassis=sr-2s slot=2 card=xcm-2s xiom/x1=iom-s-1.5t mda/x1/1=ms2-400gb-qsfpdd+2-100gb-qsfp28" -device pci-bridge,chassis_nr=1,id=pci.1 -device virtio-net-pci,netdev=mgmt,mac=52:54:00:87:c4:00 -netdev user,id=mgmt,net=10.0.0.0/24 -device virtio-net-pci,netdev=vfpc-int,mac=52:54:00:6d:48:00 -netdev tap,ifname=vfpc3-int,id=vfpc-int,script=no,downscript=no -device virtio-net-pci,netdev=p01,mac=52:54:00:db:93:01,bus=pci.1,addr=0x2 -netdev tap,id=p01,ifname=tap1,script=/etc/tc-tap-ifup,downscript=no

2021-03-18 12:30:18,451: vrnetlab   INFO     STDERR: qemu-system-x86_64: could not configure /dev/net/tun (tap1): Device or resource busy
```

We need to set a base for interface index per each linecard VM so it won't get messed up. This is not done and contributions are welcome