### PR TITLE
Palo fixes

### DIFF
--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -67,13 +67,6 @@ class CSR_vm(vrnetlab.VM):
 
             self.qemu_args.extend(["-cdrom", "/" + self.image_name])
 
-    def gen_nics(self):
-        """
-        override gen_nics to introduce delay
-        """
-        time.sleep(5)
-        return super(CSR_vm, self).gen_nics()
-
     def create_boot_image(self):
         """Creates a iso image with a bootstrap configuration"""
 

--- a/nxos/docker/launch.py
+++ b/nxos/docker/launch.py
@@ -49,17 +49,6 @@ class NXOS_vm(vrnetlab.VM):
         self.conn_mode = conn_mode
         self.qemu_args.extend(["-cpu", "host", "-smp", "2"])
 
-    def gen_nics(self):
-        """
-        Override gen_nics by introducing a delay to let eth1+ interfaces to appear
-        """
-        logger.debug("waiting for eth1+ interfaces to appear...")
-        while not os.path.exists("/sys/class/net/eth1"):
-            time.sleep(1)
-        logger.debug("waiting 5sec more for container interfaces to settle...")
-        time.sleep(5)
-        return super(NXOS_vm, self).gen_nics()
-
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""
 

--- a/pan/docker/launch.py
+++ b/pan/docker/launch.py
@@ -58,6 +58,13 @@ class PAN_vm(vrnetlab.VM):
         # pan wants a uuid it seems (for licensing reasons?!)
         self.qemu_args.extend(["-uuid", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"])
 
+    def gen_nics(self):
+        """
+        override gen_nics to introduce delay
+        """
+        time.sleep(5)
+        return super(PAN_vm, self).gen_nics()
+
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""
 

--- a/pan/docker/launch.py
+++ b/pan/docker/launch.py
@@ -50,7 +50,8 @@ class PAN_vm(vrnetlab.VM):
         )
         self.hostname = hostname
         self.conn_mode = conn_mode
-        self.num_nics = 8
+        # mgmt + 24 that show up in the vm, may as well populate them all in vrnetlab right away
+        self.num_nics = 25
         self.nic_type = "virtio-net-pci"
         self.qemu_args.extend(["-cpu", "host,level=9"])
         self.qemu_args.extend(["-smp", "2,sockets=1,cores=1"])

--- a/pan/docker/launch.py
+++ b/pan/docker/launch.py
@@ -190,7 +190,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--trace", action="store_true", help="enable trace level logging"
     )
-    parser.add_argument("--hostname", default="vr-xrv9k", help="Router hostname")
+    parser.add_argument("--hostname", default="vr-pan", help="Router hostname")
     parser.add_argument("--username", default="vrnetlab", help="Username")
     parser.add_argument("--password", default="VR-netlab9", help="Password")
     parser.add_argument(

--- a/pan/docker/launch.py
+++ b/pan/docker/launch.py
@@ -58,13 +58,6 @@ class PAN_vm(vrnetlab.VM):
         # pan wants a uuid it seems (for licensing reasons?!)
         self.uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
-    def gen_nics(self):
-        """
-        override gen_nics to introduce delay
-        """
-        time.sleep(5)
-        return super(PAN_vm, self).gen_nics()
-
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""
 

--- a/pan/docker/launch.py
+++ b/pan/docker/launch.py
@@ -56,7 +56,7 @@ class PAN_vm(vrnetlab.VM):
         self.qemu_args.extend(["-cpu", "host,level=9"])
         self.qemu_args.extend(["-smp", "2,sockets=1,cores=1"])
         # pan wants a uuid it seems (for licensing reasons?!)
-        self.qemu_args.extend(["-uuid", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"])
+        self.uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
     def gen_nics(self):
         """

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -471,17 +471,6 @@ class SROS_integrated(SROS_vm):
 
         return res
 
-    def gen_nics(self):
-        """
-        Override gen_nics by introducing a delay to let eth1+ interfaces to appear
-        """
-        logger.debug("waiting for eth1+ interfaces to appear...")
-        while not os.path.exists("/sys/class/net/eth1"):
-            time.sleep(1)
-        logger.debug("waiting 5sec more for container interfaces to settle...")
-        time.sleep(5)
-        return super(SROS_integrated, self).gen_nics()
-
     def bootstrap_config(self):
         """Do the actual bootstrap config"""
 
@@ -678,13 +667,6 @@ class SROS_lc(SROS_vm):
             ]
         )
         return res
-
-    def gen_nics(self):
-        """
-        Override gen_nics by introducing a delay to let eth1+ interfaces to appear
-        """
-        time.sleep(5)
-        return super(SROS_lc, self).gen_nics()
 
     def bootstrap_spin(self):
         """We have nothing to do for VSR-SIM line cards"""

--- a/veos/docker/launch.py
+++ b/veos/docker/launch.py
@@ -152,14 +152,6 @@ class VEOS_vm(vrnetlab.VM):
 
         return res
 
-    def gen_nics(self):
-        """
-        Override gen_nics by introducing a delay to let eth1+ interfaces to appear
-        """
-        time.sleep(5)
-        res = super(VEOS_vm, self).gen_nics()
-        return res
-
 
 class VEOS(vrnetlab.VR):
     def __init__(self, hostname, username, password, conn_mode):

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -110,13 +110,6 @@ class XRV_vm(vrnetlab.VM):
 
         return res
 
-    def gen_nics(self):
-        """
-        Override gen_nics by introducing a delay to let eth1+ interfaces to appear
-        """
-        time.sleep(5)
-        return super(XRV_vm, self).gen_nics()
-
     def bootstrap_spin(self):
         """"""
 


### PR DESCRIPTION
sorry, was a bit premature on the last one...

- sets num nics to the same quantity as shows up in the pan web ui
- fix hostname (had left it as xrv9k)
- make the setting of the uuid nicer
- add the delay (copied from csr) so that the syscall(?!) magic happens prior to the nics getting generated (for containerlab)

will open containerlab pr shortly, I guess maybe hold off on merging this till you have time to make sure I don't need to make any more updates here to work nicer with containerlab?


carl
