### PR TITLE
Add support for 7.x, multi-digit 9.x, and 10.x Nexus 9000v versions

### DIFF
--- a/n9kv/Makefile
+++ b/n9kv/Makefile
@@ -3,8 +3,15 @@ NAME=NXOS 9000v
 IMAGE_FORMAT=qcow2
 IMAGE_GLOB=*.qcow2
 
-# match versions like: nxosv.9.2.4.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+\([0-9]\.[0-9]\.[0-9]\)\([^0-9].*\|$$\)/\1/')
+# Match versions similar to the following:
+# - nxosv-final.7.0.3.I7.5a.qcow2
+# - nxosv-final.7.0.3.I7.9.qcow2
+# - nxosv.9.2.1.qcow2
+# - nxosv.9.2.4.qcow2
+# - nexus9300v.9.3.9.qcow2
+# - nexus9300v.9.3.10.qcow2
+# - nexus9300v64.10.2.2.F.qcow
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+\?\.\(\(7\.0\.3\.I[0-9]\.[0-9a-z]\+\)\|\([0-9]\+\.[0-9]\+\.[0-9]\+\)\)\(\..*\|$$\)/\1/'
 
 -include ../makefile-sanity.include
 -include ../makefile.include


### PR DESCRIPTION
As the title suggests, this PR adds support for 7.x, multi-digit 9.x, and 10.x Nexus 9000v/9300v/9500v software images by enhancing the regular expression pattern used to extract the NX-OS software version (which is subsequently used to tag Nexus 9000v/9300v/9500v Docker images). The lack of support for these images was reported in #75.

This has been tested on a variety of image files through the following shell commands:
```shell
christopher@ubuntu-vm:~$ echo nxosv-final.7.0.3.I7.5a.qcow2 | sed -e 's/.\+\?\.\(\(7\.0\.3\.I[0-9]\.[0-9a-z]\+\)\|\([0-9]\+\.[0-9]\+\.[0-9]\+\)\)\(\..*\|$$\)/\1/'
7.0.3.I7.5a
christopher@ubuntu-vm:~$ echo nxosv-final.7.0.3.I7.9.qcow2 | sed -e 's/.\+\?\.\(\(7\.0\.3\.I[0-9]\.[0-9a-z]\+\)\|\([0-9]\+\.[0-9]\+\.[0-9]\+\)\)\(\..*\|$$\)/\1/'
7.0.3.I7.9
christopher@ubuntu-vm:~$ echo nxosv.9.2.1.qcow2 | sed -e 's/.\+\?\.\(\(7\.0\.3\.I[0-9]\.[0-9a-z]\+\)\|\([0-9]\+\.[0-9]\+\.[0-9]\+\)\)\(\..*\|$$\)/\1/'
9.2.1
christopher@ubuntu-vm:~$ echo nxosv.9.2.4.qcow2 | sed -e 's/.\+\?\.\(\(7\.0\.3\.I[0-9]\.[0-9a-z]\+\)\|\([0-9]\+\.[0-9]\+\.[0-9]\+\)\)\(\..*\|$$\)/\1/'
9.2.4
christopher@ubuntu-vm:~$ echo nexus9300v.9.3.9.qcow2 | sed -e 's/.\+\?\.\(\(7\.0\.3\.I[0-9]\.[0-9a-z]\+\)\|\([0-9]\+\.[0-9]\+\.[0-9]\+\)\)\(\..*\|$$\)/\1/'
9.3.9
christopher@ubuntu-vm:~$ echo nexus9300v.9.3.10.qcow2 | sed -e 's/.\+\?\.\(\(7\.0\.3\.I[0-9]\.[0-9a-z]\+\)\|\([0-9]\+\.[0-9]\+\.[0-9]\+\)\)\(\..*\|$$\)/\1/'
9.3.10
christopher@ubuntu-vm:~$ echo nexus9300v64.10.2.2.F.qcow | sed -e 's/.\+\?\.\(\(7\.0\.3\.I[0-9]\.[0-9a-z]\+\)\|\([0-9]\+\.[0-9]\+\.[0-9]\+\)\)\(\..*\|$$\)/\1/'
10.2.2
christopher@ubuntu-vm:~$
```