### PR TITLE
n9kv - Fix Racing of Bootstrap/Startup Config Apply

### DIFF
--- a/n9kv/docker/launch.py
+++ b/n9kv/docker/launch.py
@@ -168,6 +168,7 @@ class N9KV_vm(vrnetlab.VM):
         self.wait_write("feature grpc")
         self.wait_write("exit")
         self.wait_write("copy running-config startup-config")
+        self.wait_write("! Bootstrap Config for ContainerLab Complete.", wait="Copy complete.")
 
     def startup_config(self):
         """Load additional config provided by user."""


### PR DESCRIPTION
The current n9kv launch.py does not wait for the bootstrap_config()'s "copy running-config startup-config" to complete before launching startup_config(). This causes startup_config() to begin issuing commands to the switch, sensing the copy animation's "#" as the wait_send(wait="#") blocking character. This causes any startup-config provided via CLAB yaml to be applied pre-maturely, leading to not applying the beginning config stanzas of the startup config. 

I have confirmed this fork fixes the issue by adding ```self.wait_write("! Bootstrap config for ContainerLab Complete.", wait="Copy complete.")``` to the end of the bootstrap_config() method, causing the method to block until the switch registers the "copy" action complete.

More Details:

The output of Cisco Nexus "copy" command:
```
myhostname# copy running-config startup-config
[########################################] 100%
Copy complete, now saving to disk (please wait)...
Copy complete.
```

Logs showing the race condition between bootstrap and startup methods. Notice the copy "#" are triggering the beginning of the startup method:
```
2022-09-14 19:37:02,245: vrnetlab   TRACE    waiting for '#' on serial console
2022-09-14 19:37:02,247: vrnetlab   DEBUG    writing to serial console: configure terminal
2022-09-14 19:37:02,247: vrnetlab   TRACE    waiting for '#' on serial console
2022-09-14 19:37:02,292: vrnetlab   TRACE    read from serial console:                                        ]   1%configure terminal
[#
2022-09-14 19:37:02,292: vrnetlab   DEBUG    writing to serial console: 
2022-09-14 19:37:02,292: vrnetlab   TRACE    waiting for '#' on serial console
[#22-09-14 19:37:02,292: vrnetlab   TRACE    read from serial console:                                        ]   2%
2022-09-14 19:37:02,292: vrnetlab   DEBUG    writing to serial console: hostname myhostname
2022-09-14 19:37:02,292: vrnetlab   TRACE    waiting for '#' on serial console
2022-09-14 19:37:02,292: vrnetlab   TRACE    read from serial console: #
2022-09-14 19:37:02,292: vrnetlab   DEBUG    writing to serial console: 
2022-09-14 19:37:02,293: vrnetlab   TRACE    waiting for '#' on serial console
```

So the fix is instructing bootstrap_config to wait for "Copy complete." before returning, and thus beginning application of the startup-config.

Logs after applying this fix:
```
2022-09-14 20:42:19,715: vrnetlab   DEBUG    writing to serial console: copy running-config startup-config
2022-09-14 20:42:19,716: vrnetlab   TRACE    waiting for 'Copy complete.' on serial console
2022-09-14 20:42:27,368: vrnetlab   TRACE    read from serial console:  exit
myhostname# copy running-config startup-config
[########################################] 100%
Copy complete, now saving to disk (please wait)...
Copy complete.
2022-09-14 20:42:27,368: vrnetlab   DEBUG    writing to serial console: ! Bootstrap config for ContainerLab Complete.
2022-09-14 20:42:27,368: launch     TRACE    Startup config file /config/startup-config.cfg exists
2022-09-14 20:42:27,369: launch     TRACE    Parsed startup config file /config/startup-config.cfg
2022-09-14 20:42:27,369: launch     INFO     Writing lines from /config/startup-config.cfg
2022-09-14 20:42:27,369: vrnetlab   TRACE    waiting for '#' on serial console
2022-09-14 20:42:27,416: vrnetlab   TRACE    read from serial console: 
! Bootstrap config for ContainerLab Complete.
myhostname#
2022-09-14 20:42:27,416: vrnetlab   DEBUG    writing to serial console: configure terminal
2022-09-14 20:42:27,416: vrnetlab   TRACE    waiting for '#' on serial console
2022-09-14 20:42:27,464: vrnetlab   TRACE    read from serial console:  ! Bootstrap config for ContainerLab Complete.
myhostname#
2022-09-14 20:42:27,464: vrnetlab   DEBUG    writing to serial console: configure terminal
2022-09-14 20:42:27,464: vrnetlab   TRACE    waiting for '#' on serial console
```