### PR TITLE
set default mem for xrv to 16GB

### DIFF
--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -315,7 +315,7 @@ if __name__ == "__main__":
         "--vcpu", type=int, default=2, help="Number of cpu cores to use"
     )
     parser.add_argument(
-        "--ram", type=int, default=12228, help="Number RAM to use in MB"
+        "--ram", type=int, default=16384, help="Number RAM to use in MB"
     )
     parser.add_argument(
         "--connection-mode",


### PR DESCRIPTION
fix #86 by setting 16GB mem by default. Previous mem limit of 12GB didn't let newer xrv9k to boot in time.