### PR TITLE
Parse embedded variants in case of no slot definiton

### DIFF
--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -556,7 +556,6 @@ class SROS_integrated(SROS_vm):
 
             # save bof config on disk
             self.wait_write("/bof save")
-            self.wait_write("/logout")
 
             self.wait_write("/admin save")
             self.wait_write(
@@ -564,6 +563,9 @@ class SROS_integrated(SROS_vm):
                     mode=self.mode
                 )
             )
+
+            # logout at the end of execution 
+            self.wait_write("/logout")
 
 
 class SROS_cp(SROS_vm):
@@ -666,7 +668,6 @@ class SROS_cp(SROS_vm):
 
             # save bof config on disk
             self.wait_write("/bof save")
-            self.wait_write("/logout")
 
             self.wait_write("/admin save")
             self.wait_write(
@@ -674,6 +675,9 @@ class SROS_cp(SROS_vm):
                     mode=self.mode
                 )
             )
+
+            # logout at the end of execution
+            self.wait_write("/logout")
 
 
 class SROS_lc(SROS_vm):

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -554,16 +554,16 @@ class SROS_integrated(SROS_vm):
             for l in iter(gen_bof_config()):
                 self.wait_write(l)
 
+            # save bof config on disk
+            self.wait_write("/bof save")
+            self.wait_write("/logout")
+
             self.wait_write("/admin save")
             self.wait_write(
                 "/configure system management-interface configuration-mode {mode}".format(
                     mode=self.mode
                 )
             )
-
-        # save bof config on disk
-        self.wait_write("/bof save")
-        self.wait_write("/logout")
 
 
 class SROS_cp(SROS_vm):
@@ -664,16 +664,16 @@ class SROS_cp(SROS_vm):
             for l in iter(gen_bof_config()):
                 self.wait_write(l)
 
+            # save bof config on disk
+            self.wait_write("/bof save")
+            self.wait_write("/logout")
+
             self.wait_write("/admin save")
             self.wait_write(
                 "/configure system management-interface configuration-mode {mode}".format(
                     mode=self.mode
                 )
             )
-
-        # save bof config on disk
-        self.wait_write("/bof save")
-        self.wait_write("/logout")
 
 
 class SROS_lc(SROS_vm):


### PR DESCRIPTION
A fix for embedded variants issue.
I extract _parser function with name parse_variant_line to become public function and not an internal function of parse_custom_variant.
I reuse parse_variant_line to get slot information from lc timos_line.
