### PR TITLE
vMX: support for management VRF

### DIFF
--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -201,6 +201,11 @@ class VMX_vcp(vrnetlab.VM):
         self.wait_write("set interfaces fxp0 unit 0 family inet address 10.0.0.15/24")
         self.wait_write("delete interfaces fxp0 unit 0 family inet dhcp")
         self.wait_write("delete system processes dhcp-service")
+        # set interface fxp0 on dedicated management vrf, to avoid 10.0.0.0/24 to overlap with any "testing" network
+        self.wait_write("set system management-instance")
+        self.wait_write("set routing-instances mgmt_junos description management-instance")
+        # allow NATed outgoing traffic (set the default route on the management vrf)
+        self.wait_write("set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2")
         self.wait_write("commit")
         self.wait_write("exit")
         # write another exist as sometimes the first exit from exclusive edit abrupts before command finishes


### PR DESCRIPTION
I think it’s really useful to isolate the Management traffic in a non-default VRF. This will allow to avoid mixing management and non management route tables, and will allow to better control the routing.

The Management routing-instance has a fixed name that cannot be changed: mgmt_junos. The association of the OOB port with this routing-instance is done with a special configuration keyword - so there is no need to specify the interface inside the routing-instance itself.
