### PR TITLE
refactor: replace oui for base mac generation

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -16,10 +16,11 @@ MAX_RETRIES = 60
 
 
 def gen_mac(last_octet=None):
-    """Generate a random MAC address that is in the qemu OUI space and that
-    has the given last octet.
+    """Generate a random MAC address that is in recognizable (0C:00) OUI space
+    and that has the given last octet.
     """
-    return "52:54:00:%02x:%02x:%02x" % (
+    return "0C:00:%02x:%02x:%02x:%02x" % (
+        random.randint(0x00, 0xFF),
         random.randint(0x00, 0xFF),
         random.randint(0x00, 0xFF),
         last_octet,


### PR DESCRIPTION
Currently, `gen_mac()` generates a mac address in the qemu OUI space (`52:54`) -- a very sensible and responsible decision. 

However, mac addresses starting with 52 cause a crash of the MLAG process in Arista vEOS, as it's unable to generate a virtual mac address. The same issue was experienced in the GNS3 project when they too moved to the qemu OUI space: https://github.com/GNS3/gns3-gui/issues/2475

I propose an equivalent solution: moving to a `0C:` prefixed mac address. 