### PR TITLE
sros/launch.py: don't restart VM because of too many spins

### DIFF
--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -637,15 +637,6 @@ class SROS_vm(vrnetlab.VM):
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""
 
-        if self.spins > 60:
-            # too many spins with no result, probably means SROS hasn't started
-            # successfully, so we restart it
-            self.logger.warning("no output from serial console, restarting VM")
-            self.stop()
-            self.start()
-            self.spins = 0
-            return
-
         (ridx, match, res) = self.tn.expect([b"Login:", b"^[^ ]+#"], 1)
         if match:  # got a match!
             if ridx == 0:  # matched login prompt, so should login


### PR DESCRIPTION
Some SR OS releases take above average time time to boot. Behavior can vary across different Linux Distributions (eg: CentOS 7.9 vs Rocky Linux 9). I don't know the explanation to why, but suspect it may be related to kernel or qemu versions.