### PR TITLE
deprecate iptables backend in favor of nftables

### DIFF
--- a/config-engine-lite/Dockerfile
+++ b/config-engine-lite/Dockerfile
@@ -1,28 +1,28 @@
 FROM ubuntu:xenial
-MAINTAINER Kristian Larsson <kristian@spritelink.net>
+LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    libffi-dev \
-    libffi-dev \
-    libjpeg8-dev \
-    libssl-dev \
-    libxml2-dev \
-    libxslt1-dev \
-    libyaml-dev \
-    python-dev \
-    python-dev \
-    python-ipy \
-    python-lxml \
-    python-pip \
-    zlib1g-dev \
- && rm -rf /var/lib/apt/lists/* \
- && pip install napalm
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   libffi-dev \
+   libffi-dev \
+   libjpeg8-dev \
+   libssl-dev \
+   libxml2-dev \
+   libxslt1-dev \
+   libyaml-dev \
+   python-dev \
+   python-dev \
+   python-ipy \
+   python-lxml \
+   python-pip \
+   zlib1g-dev \
+   && rm -rf /var/lib/apt/lists/* \
+   && pip install napalm
 
 ADD configengine /
 

--- a/ftosv/docker/Dockerfile
+++ b/ftosv/docker/Dockerfile
@@ -4,22 +4,23 @@ LABEL maintainer="Roman Dodin <dodin.roman@gmail.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    tftpd-hpa \
-    ssh \
-    inetutils-ping \
-    dnsutils \
-    openvswitch-switch \
-    iptables \
-    telnet \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   tftpd-hpa \
+   ssh \
+   inetutils-ping \
+   dnsutils \
+   openvswitch-switch \
+   iptables \
+   nftables \
+   telnet \
+   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/n9kv/docker/Dockerfile
+++ b/n9kv/docker/Dockerfile
@@ -4,22 +4,23 @@ LABEL maintainer="Roman Dodin <dodin.roman@gmail.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    tftpd-hpa \
-    ssh \
-    inetutils-ping \
-    dnsutils \
-    openvswitch-switch \
-    iptables \
-    telnet \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   tftpd-hpa \
+   ssh \
+   inetutils-ping \
+   dnsutils \
+   openvswitch-switch \
+   iptables \
+   nftables \
+   telnet \
+   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/nxos/docker/Dockerfile
+++ b/nxos/docker/Dockerfile
@@ -1,20 +1,20 @@
 FROM ubuntu:20.04
-MAINTAINER Kristian Larsson <kristian@spritelink.net>
+LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    procps \
-    openvswitch-switch \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   procps \
+   openvswitch-switch \
+   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/ocnos/docker/Dockerfile
+++ b/ocnos/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -qy \
    dnsutils \
    openvswitch-switch \
    iptables \
+   nftables \
    telnet \
    && rm -rf /var/lib/apt/lists/*
 

--- a/pan/docker/Dockerfile
+++ b/pan/docker/Dockerfile
@@ -4,22 +4,23 @@ LABEL maintainer="Roman Dodin <dodin.roman@gmail.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    tftpd-hpa \
-    ssh \
-    inetutils-ping \
-    dnsutils \
-    openvswitch-switch \
-    iptables \
-    telnet \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   tftpd-hpa \
+   ssh \
+   inetutils-ping \
+   dnsutils \
+   openvswitch-switch \
+   iptables \
+   nftables \
+   telnet \
+   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/routeros/docker/Dockerfile
+++ b/routeros/docker/Dockerfile
@@ -1,25 +1,25 @@
 FROM ubuntu:20.04
-MAINTAINER Kristian Larsson <kristian@spritelink.net>
-MAINTAINER Roman Dodin <dodin.roman@gmail.com>
+LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    ssh \
-    inetutils-ping \
-    dnsutils \
-    iptables \
-    telnet \
-    ftp \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   ssh \
+   inetutils-ping \
+   dnsutils \
+   iptables \
+   nftables \
+   telnet \
+   ftp \
+   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/sros/docker/Dockerfile
+++ b/sros/docker/Dockerfile
@@ -1,25 +1,25 @@
 FROM ubuntu:20.04
-MAINTAINER Kristian Larsson <kristian@spritelink.net>
-MAINTAINER Roman Dodin <dodin.roman@gmail.com>
+LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    tftpd-hpa \
-    ssh \
-    inetutils-ping \
-    dnsutils \
-    openvswitch-switch \
-    iptables \
-    telnet \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   tftpd-hpa \
+   ssh \
+   inetutils-ping \
+   dnsutils \
+   openvswitch-switch \
+   iptables \
+   nftables \
+   telnet \
+   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1280,29 +1280,31 @@ if __name__ == "__main__":
 
     # redirecting incoming tcp traffic (except serial port 5000) from eth0 to SR management interface
     vrnetlab.run_command(
-        f"iptables -t nat -A PREROUTING -i eth0 -p tcp ! --dport 5000 -j DNAT --to-destination {SROS_MGMT_V4_ADDR}".split()
+        f"iptables-nft -t nat -A PREROUTING -i eth0 -p tcp ! --dport 5000 -j DNAT --to-destination {SROS_MGMT_V4_ADDR}".split()
     )
     vrnetlab.run_command(
-        f"ip6tables -t nat -A PREROUTING -i eth0 -p tcp ! --dport 5000 -j DNAT --to-destination {SROS_MGMT_V6_ADDR}".split()
+        f"ip6tables-nft -t nat -A PREROUTING -i eth0 -p tcp ! --dport 5000 -j DNAT --to-destination {SROS_MGMT_V6_ADDR}".split()
     )
     # same redirection but for UDP
     vrnetlab.run_command(
-        f"iptables -t nat -A PREROUTING -i eth0 -p udp -j DNAT --to-destination {SROS_MGMT_V4_ADDR}".split()
+        f"iptables-nft -t nat -A PREROUTING -i eth0 -p udp -j DNAT --to-destination {SROS_MGMT_V4_ADDR}".split()
     )
     vrnetlab.run_command(
-        f"ip6tables -t nat -A PREROUTING -i eth0 -p udp -j DNAT --to-destination {SROS_MGMT_V6_ADDR}".split()
+        f"ip6tables-nft -t nat -A PREROUTING -i eth0 -p udp -j DNAT --to-destination {SROS_MGMT_V6_ADDR}".split()
     )
     # masquerading the incoming traffic so SR OS is able to reply back
     vrnetlab.run_command(
-        "iptables -t nat -A POSTROUTING -o br-mgmt -j MASQUERADE".split()
+        "iptables-nft -t nat -A POSTROUTING -o br-mgmt -j MASQUERADE".split()
     )
     vrnetlab.run_command(
-        "ip6tables -t nat -A POSTROUTING -o br-mgmt -j MASQUERADE".split()
+        "ip6tables-nft -t nat -A POSTROUTING -o br-mgmt -j MASQUERADE".split()
     )
     # allow sros breakout to management network by NATing via eth0
-    vrnetlab.run_command("iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE".split())
     vrnetlab.run_command(
-        "ip6tables -t nat -A POSTROUTING -o eth0 -j MASQUERADE".split()
+        "iptables-nft -t nat -A POSTROUTING -o eth0 -j MASQUERADE".split()
+    )
+    vrnetlab.run_command(
+        "ip6tables-nft -t nat -A POSTROUTING -o eth0 -j MASQUERADE".split()
     )
 
     logger.debug(

--- a/veos/docker/Dockerfile
+++ b/veos/docker/Dockerfile
@@ -4,22 +4,23 @@ LABEL maintainer="Roman Dodin <dodin.roman@gmail.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    tftpd-hpa \
-    ssh \
-    inetutils-ping \
-    dnsutils \
-    openvswitch-switch \
-    iptables \
-    telnet \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   tftpd-hpa \
+   ssh \
+   inetutils-ping \
+   dnsutils \
+   openvswitch-switch \
+   iptables \
+   nftables \
+   telnet \
+   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/vmx/docker/Dockerfile
+++ b/vmx/docker/Dockerfile
@@ -1,20 +1,20 @@
 FROM ubuntu:20.04
-MAINTAINER Kristian Larsson <kristian@spritelink.net>
+LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    procps \
-    openvswitch-switch \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   procps \
+   openvswitch-switch \
+   && rm -rf /var/lib/apt/lists/*
 
 COPY vmx /vmx
 COPY *.py /

--- a/vsrx/docker/Dockerfile
+++ b/vsrx/docker/Dockerfile
@@ -1,17 +1,17 @@
 FROM debian:stable
-MAINTAINER Kristian Larsson <kristian@spritelink.net>
+LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/vsrx/docker/Dockerfile
+++ b/vsrx/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:bullseye
 LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -10,7 +10,8 @@ RUN apt-get update -qy \
    iproute2 \
    python3-ipy \
    socat \
-   qemu-kvm \
+   qemu-system-x86=1:5.2+dfsg-11+deb11u2 \
+   qemu-utils=1:5.2+dfsg-11+deb11u2 \
    && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE

--- a/xrv/docker/Dockerfile
+++ b/xrv/docker/Dockerfile
@@ -1,20 +1,20 @@
 FROM ubuntu:20.04
-MAINTAINER Kristian Larsson <kristian@spritelink.net>
+LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    procps \
-    openvswitch-switch \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   procps \
+   openvswitch-switch \
+   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/xrv9k/docker/Dockerfile
+++ b/xrv9k/docker/Dockerfile
@@ -1,24 +1,23 @@
 FROM ubuntu:20.04
-MAINTAINER Kristian Larsson <kristian@spritelink.net>
-MAINTAINER Roman Dodin <dodin.roman@gmail.com>
+LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    ssh \
-    telnet \
-    inetutils-ping \
-    dnsutils \
-    openvswitch-switch \
- && rm -rf /var/lib/apt/lists/*
+   && apt-get upgrade -qy \
+   && apt-get install -y \
+   bridge-utils \
+   iproute2 \
+   python3-ipy \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   ssh \
+   telnet \
+   inetutils-ping \
+   dnsutils \
+   openvswitch-switch \
+   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /


### PR DESCRIPTION
iptables backend is sunsetting in major for major OS release (Debian and RHEL derivatives are the user base for containerlab). This causes issues for OSes that don't have iptables kernel support, e.g. Rocky9. This results in errors to create iptables rules - see [chat](https://discord.com/channels/860500297297821756/865574858385784842/1123162654949769287).

This PR adds nftables package to ubuntu base so that iptables-nft CLI can be used as a drop-in replacement for iptables manipulation.

As a consequent change, the iptables command is switched to iptables-nft in the launch scripts for nodes which tune iptables rules.