### PR TITLE
From _latest_ qemu-utils binaries (which was qemu-img version 7.2.2 D…

### DIFF
--- a/vsrx/docker/Dockerfile
+++ b/vsrx/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -qy \
     iproute2 \
     python3-ipy \
     socat \
-    qemu-kvm \
+    qemu-system-x86=1:5.2+dfsg-11+deb11u2 \
     qemu-utils=1:5.2+dfsg-11+deb11u2 \
  && rm -rf /var/lib/apt/lists/*
 

--- a/vsrx/docker/Dockerfile
+++ b/vsrx/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -11,6 +11,7 @@ RUN apt-get update -qy \
     python3-ipy \
     socat \
     qemu-kvm \
+    qemu-utils=1:5.2+dfsg-11+deb11u2 \
  && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE


### PR DESCRIPTION
…ebian 1:7.2+dfsg-7) to pinned version qemu-img 5.2.0 (Debian 1:5.2+dfsg-11+deb11u2) from the Debian bullseye image.

Debian bullseye image is being used because the debian:stable image did not contain any other packages for qemu-utils.

Reference #127 @hellt 