### PR TITLE
Remove change to skip empty commands

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -631,9 +631,6 @@ class VM:
         Defaults to using self.tn as connection but this can be overridden
         by passing a telnetlib.Telnet object in the con argument.
         """
-        if not cmd:  # skip empty commands
-            return
-
         con_name = "custom con"
         if con is None:
             con = self.tn


### PR DESCRIPTION
Revert change to skip empty commands, some platforms rely on this (one could argue they should use '\r' to send <enter>, but...)

Addresses https://github.com/hellt/vrnetlab/issues/130