### PR TITLE
adding support for vJunos-switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGES_DIR=
-VRS = vr-xcon vr-bgp csr nxos routeros sros veos vmx vsr1000 vqfx vrp xrv xrv9k vsrx
+VRS = vr-xcon vr-bgp csr nxos routeros sros veos vjunosswitch vmx vsr1000 vqfx vrp xrv xrv9k vsrx
 VRS_PUSH = $(VRS:=-push)
 
 .PHONY: all $(VRS) $(VRS_PUSH)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Since the changes we made in this fork are VM specific, we added a few popular r
 * Cisco XRv
 * Juniper vMX
 * Juniper vSRX
+* Juniper vJunos-switch
 * Nokia SR OS
 
 The rest are left untouched and can be contributed back by the community.

--- a/config-engine-lite/configengine
+++ b/config-engine-lite/configengine
@@ -43,6 +43,8 @@ class Router:
             driver = napalm.get_network_driver("junos")
         elif self.type == "vsrx":
             driver = napalm.get_network_driver("junos")
+        elif self.type == "vjunosswitch":
+            driver = napalm.get_network_driver("junos")
         elif self.type == "csr":
             driver = napalm.get_network_driver("ios")
         else:
@@ -159,6 +161,9 @@ class ConfigBootstrap:
                 router.template = junos
 
             if router.type == "vsrx":
+                router.template = junos
+
+            if router.type == "vjunosswitch":
                 router.template = junos
 
             if router.type == "csr":
@@ -287,7 +292,7 @@ if __name__ == '__main__':
         if not args.config or not os.path.isfile(args.config):
             print("Configuration template doesn't exist")
             sys.exit(1)
-        if args.type not in [ "vmx", "csr", "xrv", "vsrx"]:
+        if args.type not in [ "vmx", "csr", "xrv", "vsrx", "vjunosswitch"]:
             print("Invalid router type {}".format(args.type))
             sys.exit(1)
 

--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -22,7 +22,7 @@ class VrTopo:
         for r, val in self.routers.items():
             if 'type' not in val:
                 raise ValueError("'type' is not defined for router %s" % r)
-            if val['type'] not in ('dummy', 'xcon', 'bgp', 'xrv', 'xrv9k', 'vmx', 'sros', 'csr', 'vqfx', 'vrp', 'vsrx'):
+            if val['type'] not in ('dummy', 'xcon', 'bgp', 'xrv', 'xrv9k', 'vmx', 'sros', 'csr', 'vjunosswitch', 'vqfx', 'vrp', 'vsrx'):
                 raise ValueError("Unknown type %s for router %s" % (val['type'], r))
 
         # expand p2p links
@@ -138,7 +138,9 @@ class VrTopo:
             return "GigabitEthernet4/0/%d" % (interface)
         elif r['type'] == 'vsrx':
             return "ge-0/0/%d" % (interface-1)
- 
+        elif r['type'] == 'vjunosswitch':
+            return "ge-0/0/%d" % (interface-1)
+
         return None
 
 

--- a/vjunosswitch/Makefile
+++ b/vjunosswitch/Makefile
@@ -1,0 +1,15 @@
+VENDOR=Juniper
+NAME=vJunos-switch
+IMAGE_FORMAT=qcow
+IMAGE_GLOB=*.qcow2
+
+# match versions like:
+# vJunos-switch-23.1R1.8.qcow2
+# vJunos-switch-22.1R2.2.qcow2
+# vJunos-switch-21.2R4.3.qcow2
+# ...
+
+VERSION=$(shell echo $(IMAGE) | sed -e 's/vJunos-switch-//' | sed -e 's/.qcow2//')
+
+-include ../makefile-sanity.include
+-include ../makefile.include

--- a/vjunosswitch/README.md
+++ b/vjunosswitch/README.md
@@ -1,0 +1,15 @@
+# vrnetlab / Juniper vJunos-switch
+
+This is the vrnetlab docker image for Juniper's vJunos-switch. 
+
+> Available with [containerlab](https://containerlab.srlinux.dev) as vr-vjunosswitch.
+
+## Building the docker image
+Download the vJunos-switch .qcow2 image from  https://www.juniper.net/us/en/dm/vjunos-labs.html
+and place it in this directory. After typing `make`, a new image will  appear called `vrnetlab/vjunos-switch`. 
+Run `docker images` to confirm this. 
+
+## System requirements
+CPU: 4 cores
+RAM: 5GB
+DISK: ~4.5GB

--- a/vjunosswitch/README.md
+++ b/vjunosswitch/README.md
@@ -1,15 +1,17 @@
 # vrnetlab / Juniper vJunos-switch
 
-This is the vrnetlab docker image for Juniper's vJunos-switch. 
+This is the vrnetlab docker image for Juniper's vJunos-switch.
 
 > Available with [containerlab](https://containerlab.dev) as vr-vjunosswitch.
 
 ## Building the docker image
-Download the vJunos-switch .qcow2 image from  https://www.juniper.net/us/en/dm/vjunos-labs.html
-and place it in this directory. After typing `make`, a new image will appear called `vrnetlab/vjunos-switch`. 
-Run `docker images` to confirm this. 
+
+Download the vJunos-switch .qcow2 image from  <https://www.juniper.net/us/en/dm/vjunos-labs.html>
+and place it in this directory. After typing `make`, a new image will appear called `vrnetlab/vjunos-switch`.
+Run `docker images` to confirm this.
 
 ## System requirements
+
 CPU: 4 cores
 RAM: 5GB
 DISK: ~4.5GB

--- a/vjunosswitch/README.md
+++ b/vjunosswitch/README.md
@@ -2,11 +2,11 @@
 
 This is the vrnetlab docker image for Juniper's vJunos-switch. 
 
-> Available with [containerlab](https://containerlab.srlinux.dev) as vr-vjunosswitch.
+> Available with [containerlab](https://containerlab.dev) as vr-vjunosswitch.
 
 ## Building the docker image
 Download the vJunos-switch .qcow2 image from  https://www.juniper.net/us/en/dm/vjunos-labs.html
-and place it in this directory. After typing `make`, a new image will  appear called `vrnetlab/vjunos-switch`. 
+and place it in this directory. After typing `make`, a new image will appear called `vrnetlab/vjunos-switch`. 
 Run `docker images` to confirm this. 
 
 ## System requirements

--- a/vjunosswitch/docker/Dockerfile
+++ b/vjunosswitch/docker/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get upgrade -qy \
+ && apt-get install -y \
+    dosfstools \
+    bridge-utils \
+    iproute2 \
+    python3-ipy \
+    socat \
+    qemu-kvm \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY $IMAGE* /
+# copy conf file
+COPY *.conf /
+# copy config shell script
+COPY *.sh /
+COPY *.py /
+
+EXPOSE 22 161/udp 830 5000 10000-10099 57400
+HEALTHCHECK CMD ["/healthcheck.py"]
+ENTRYPOINT ["/launch.py"]

--- a/vjunosswitch/docker/juniper.conf
+++ b/vjunosswitch/docker/juniper.conf
@@ -1,0 +1,31 @@
+system {
+    host-name HOST;
+    root-authentication {
+        plain-text-password-value "admin@123";
+    }
+    login {
+        user admin {
+            class super-user;
+            authentication {
+                plain-text-password-value "admin@123";
+            }
+        }
+    }
+    services {
+        ssh {
+            root-login allow;
+        }
+        netconf {
+            ssh;                        
+        }
+    }
+}
+interfaces {
+    fxp0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.15/24;
+            }
+        }
+    }
+}

--- a/vjunosswitch/docker/juniper.conf
+++ b/vjunosswitch/docker/juniper.conf
@@ -1,5 +1,5 @@
 system {
-    host-name HOST;
+    host-name vJunos-switch;
     root-authentication {
         plain-text-password-value "admin@123";
     }

--- a/vjunosswitch/docker/juniper.conf
+++ b/vjunosswitch/docker/juniper.conf
@@ -1,5 +1,5 @@
 system {
-    host-name vJunos-switch;
+    host-name {HOSTNAME};
     root-authentication {
         plain-text-password-value "admin@123";
     }

--- a/vjunosswitch/docker/juniper.conf
+++ b/vjunosswitch/docker/juniper.conf
@@ -16,7 +16,7 @@ system {
             root-login allow;
         }
         netconf {
-            ssh;                        
+            ssh;
         }
     }
 }

--- a/vjunosswitch/docker/launch.py
+++ b/vjunosswitch/docker/launch.py
@@ -12,11 +12,14 @@ import vrnetlab
 # loadable startup config
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
 
+
 def handle_SIGCHLD(signal, frame):
     os.waitpid(-1, os.WNOHANG)
 
+
 def handle_SIGTERM(signal, frame):
     sys.exit(0)
+
 
 signal.signal(signal.SIGINT, handle_SIGTERM)
 signal.signal(signal.SIGTERM, handle_SIGTERM)
@@ -25,31 +28,38 @@ signal.signal(signal.SIGCHLD, handle_SIGCHLD)
 TRACE_LEVEL_NUM = 9
 logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
 
+
 def trace(self, message, *args, **kws):
     # Yes, logger takes its '*args' as 'args'.
     if self.isEnabledFor(TRACE_LEVEL_NUM):
         self._log(TRACE_LEVEL_NUM, message, args, **kws)
+
+
 logging.Logger.trace = trace
+
 
 class VJUNOSSWITCH_vm(vrnetlab.VM):
     def __init__(self, hostname, username, password, conn_mode):
         for e in os.listdir("/"):
             if re.search(".qcow2$", e):
                 disk_image = "/" + e
-        super(VJUNOSSWITCH_vm, self).__init__(username, password, disk_image=disk_image, ram=5120)
+        super(VJUNOSSWITCH_vm, self).__init__(
+            username, password, disk_image=disk_image, ram=5120
+        )
         # device hostname
         self.hostname = hostname
-        
+
         # read juniper.conf configuration file
-        with open('juniper.conf', 'r') as file:
-            info = file.read()
+        # to replace hostname placehodler with given hostname
+        with open("juniper.conf", "r") as file:
+            cfg = file.read()
 
         # replace HOSTNAME file var with nodes given hostname
-        new_info = info.replace('{HOSTNAME}', hostname)
+        new_cfg = cfg.replace("{HOSTNAME}", hostname)
 
         # write changed to juniper.conf file
-        with open('juniper.conf', 'w') as file:
-            file.write(new_info)
+        with open("juniper.conf", "w") as file:
+            file.write(new_cfg)
 
         # generate mountable config disk based on juniper.conf file with base vrnetlab configs
         subprocess.run(["./make-config.sh", "juniper.conf", "config.img"], check=True)
@@ -57,24 +67,38 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
         # these QEMU cmd line args are translated from the shipped libvirt XML file
         self.qemu_args.extend(["-smp", "4,sockets=1,cores=4,threads=1"])
         # Additional CPU info
-        self.qemu_args.extend([
-            "-cpu", "IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=off"
-            ])
-        # mount config disk with juniper.conf base configs 
-        self.qemu_args.extend(["-drive", "if=none,id=config_disk,file=/config.img,format=raw",
-                               "-device", "virtio-blk-pci,drive=config_disk"])
+        self.qemu_args.extend(
+            [
+                "-cpu",
+                "IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=off",
+            ]
+        )
+        # mount config disk with juniper.conf base configs
+        self.qemu_args.extend(
+            [
+                "-drive",
+                "if=none,id=config_disk,file=/config.img,format=raw",
+                "-device",
+                "virtio-blk-pci,drive=config_disk",
+            ]
+        )
         self.qemu_args.extend(["-overcommit", "mem-lock=off"])
-        self.qemu_args.extend(["-display", "none", "-no-user-config", "-nodefaults", "-boot", "strict=on"])
+        self.qemu_args.extend(
+            ["-display", "none", "-no-user-config", "-nodefaults", "-boot", "strict=on"]
+        )
         self.nic_type = "virtio-net-pci"
         self.num_nics = 11
         self.smbios = ["type=1,product=VM-VEX"]
-        self.qemu_args.extend(["-machine", "pc-i440fx-focal,usb=off,dump-guest-core=off,accel=kvm"])
-        self.qemu_args.extend(["-device", "piix3-usb-uhci,id=usb,bus=pci.0,addr=0x1.0x2"])
+        self.qemu_args.extend(
+            ["-machine", "pc-i440fx-focal,usb=off,dump-guest-core=off,accel=kvm"]
+        )
+        self.qemu_args.extend(
+            ["-device", "piix3-usb-uhci,id=usb,bus=pci.0,addr=0x1.0x2"]
+        )
         self.conn_mode = conn_mode
 
     def bootstrap_spin(self):
-        """ This function should be called periodically to do work.
-        """
+        """This function should be called periodically to do work."""
         if self.spins > 300:
             # too many spins with no result ->  give up
             self.stop()
@@ -84,15 +108,15 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
         # lets wait for the OS/platform log to determine if VM is booted,
         # login prompt can get lost in boot logs
         (ridx, match, res) = self.tn.expect([b"FreeBSD/amd64"], 1)
-        if match: # got a match!
-            if ridx == 0: # login
+        if match:  # got a match!
+            if ridx == 0:  # login
                 self.logger.info("VM started")
 
                 # Login
                 self.wait_write("\r", None)
                 self.wait_write("admin", wait="login:")
                 self.wait_write(self.password, wait="Password:")
-                self.wait_write("\r", wait= f"{self.hostname}>")
+                self.wait_write("\r", wait=f"{self.hostname}>")
                 self.logger.info("Login completed")
 
                 # run startup config
@@ -108,7 +132,7 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
 
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time
-        if res != b'':
+        if res != b"":
             self.logger.trace("OUTPUT: %s" % res.decode())
             # reset spins if we saw some output
             self.spins = 0
@@ -141,21 +165,29 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
         self.wait_write("commit")
         self.wait_write("exit")
 
+
 class VJUNOSSWITCH(vrnetlab.VR):
     def __init__(self, hostname, username, password, conn_mode):
         super(VJUNOSSWITCH, self).__init__(username, password)
-        self.vms = [ VJUNOSSWITCH_vm(hostname, username, password, conn_mode) ]
+        self.vms = [VJUNOSSWITCH_vm(hostname, username, password, conn_mode)]
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser(description="")
-    parser.add_argument("--trace", action="store_true", help="enable trace level logging")
-    parser.add_argument("--hostname", default="vr-vjunosswitch", help="vJunos-switch hostname")
+    parser.add_argument(
+        "--trace", action="store_true", help="enable trace level logging"
+    )
+    parser.add_argument(
+        "--hostname", default="vr-vjunosswitch", help="vJunos-switch hostname"
+    )
     parser.add_argument("--username", default="vrnetlab", help="Username")
     parser.add_argument("--password", default="VR-netlab9", help="Password")
-    parser.add_argument("--connection-mode", default="tc", help="Connection mode to use in the datapath")
+    parser.add_argument(
+        "--connection-mode", default="tc", help="Connection mode to use in the datapath"
+    )
     args = parser.parse_args()
-
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
     logging.basicConfig(format=LOG_FORMAT)
@@ -165,7 +197,8 @@ if __name__ == '__main__':
     if args.trace:
         logger.setLevel(1)
 
-    vr = VJUNOSSWITCH(args.hostname,
+    vr = VJUNOSSWITCH(
+        args.hostname,
         args.username,
         args.password,
         conn_mode=args.connection_mode,

--- a/vjunosswitch/docker/launch.py
+++ b/vjunosswitch/docker/launch.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+import datetime
+import logging
+import os
+import re
+import signal
+import sys
+
+import vrnetlab
+
+# loadable startup config
+STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
+
+# generate mountable config disk based on juniper.conf file with base vrnetlab configs
+os.system("./make-config.sh juniper.conf config.img")
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+logging.Logger.trace = trace
+
+class VJUNOSSWITCH_vm(vrnetlab.VM):
+    def __init__(self, hostname, username, password, conn_mode):
+        for e in os.listdir("/"):
+            if re.search(".qcow2$", e):
+                disk_image = "/" + e
+        super(VJUNOSSWITCH_vm, self).__init__(username, password, disk_image=disk_image, ram=5120)
+
+        # these QEMU cmd line args are translated from the shipped libvirt XML file
+        self.qemu_args.extend(["-smp", "4,sockets=1,cores=4,threads=1"])
+        # Additional CPU info
+        self.qemu_args.extend([
+            "-cpu", "IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=off"
+            ])
+        # mount config disk with juniper.conf base configs 
+        self.qemu_args.extend(["-drive", "if=none,id=config_disk,file=/config.img,format=raw",
+                               "-device", "virtio-blk-pci,drive=config_disk"])
+        self.qemu_args.extend(["-overcommit", "mem-lock=off"])
+        self.qemu_args.extend(["-display", "none", "-no-user-config", "-nodefaults", "-boot", "strict=on"])
+        self.nic_type = "virtio-net-pci"
+        self.num_nics = 11
+        self.hostname = hostname
+        self.smbios = ["type=1,product=VM-VEX"]
+        self.qemu_args.extend(["-machine", "pc-i440fx-focal,usb=off,dump-guest-core=off,accel=kvm"])
+        self.qemu_args.extend(["-device", "piix3-usb-uhci,id=usb,bus=pci.0,addr=0x1.0x2"])
+        self.conn_mode = conn_mode
+
+    def bootstrap_spin(self):
+        """ This function should be called periodically to do work.
+        """
+
+        if self.spins > 300:
+            # too many spins with no result ->  give up
+            self.stop()
+            self.start()
+            return
+
+        # lets wait for the OS/platform log to determine if VM is booted 
+        (ridx, match, res) = self.tn.expect([b"FreeBSD/amd64"], 1)
+        if match: # got a match!
+            if ridx == 0: # login
+                self.logger.info("VM started")
+
+                # Login
+                self.wait_write("\r", None)
+                self.wait_write("admin", wait="login:")
+                self.wait_write(self.password, wait="Password:")
+                self.wait_write("", wait="admin@HOST>")
+                self.logger.info("Login completed")
+
+                # run startup config
+                self.startup_config()
+                # close telnet connection
+                self.tn.close()
+                # startup time?
+                startup_time = datetime.datetime.now() - self.start_time
+                self.logger.info("Startup complete in: %s" % startup_time)
+                # mark as running
+                self.running = True
+                return
+
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        if res != b'':
+            self.logger.trace("OUTPUT: %s" % res.decode())
+            # reset spins if we saw some output
+            self.spins = 0
+
+        self.spins += 1
+
+        return
+
+    def startup_config(self):
+        """Load additional config provided by user."""
+
+        if not os.path.exists(STARTUP_CONFIG_FILE):
+            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} is not found")
+            return
+
+        self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} exists")
+        with open(STARTUP_CONFIG_FILE) as file:
+            config_lines = file.readlines()
+            config_lines = [line.rstrip() for line in config_lines]
+            self.logger.trace(f"Parsed startup config file {STARTUP_CONFIG_FILE}")
+
+        self.logger.info(f"Writing lines from {STARTUP_CONFIG_FILE}")
+
+        self.wait_write("cli", "#")
+        self.wait_write("configure", ">")
+        # Apply lines from file
+        for line in config_lines:
+            self.wait_write(line)
+
+        self.wait_write("commit")
+        self.wait_write("exit")
+
+class VJUNOSSWITCH(vrnetlab.VR):
+    def __init__(self, hostname, username, password, conn_mode):
+        super(VJUNOSSWITCH, self).__init__(username, password)
+        self.vms = [ VJUNOSSWITCH_vm(hostname, username, password, conn_mode) ]
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument("--trace", action="store_true", help="enable trace level logging")
+    parser.add_argument("--hostname", default="vr-vjunosswitch", help="vJunos-switch hostname")
+    parser.add_argument("--username", default="vrnetlab", help="Username")
+    parser.add_argument("--password", default="VR-netlab9", help="Password")
+    parser.add_argument("--connection-mode", default="tc", help="Connection mode to use in the datapath")
+    args = parser.parse_args()
+
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    vr = VJUNOSSWITCH(args.hostname,
+        args.username,
+        args.password,
+        conn_mode=args.connection_mode,
+    )
+    vr.start()

--- a/vjunosswitch/docker/launch.py
+++ b/vjunosswitch/docker/launch.py
@@ -79,7 +79,7 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
                 self.wait_write("\r", None)
                 self.wait_write("admin", wait="login:")
                 self.wait_write(self.password, wait="Password:")
-                self.wait_write("", wait="admin@HOST>")
+                self.wait_write("\r", wait="admin@vJunos-switch>")
                 self.logger.info("Login completed")
 
                 # run startup config

--- a/vjunosswitch/docker/make-config.sh
+++ b/vjunosswitch/docker/make-config.sh
@@ -40,7 +40,7 @@ if [ $? != 0 ]; then
 fi
 mount -t vfat $LOOPDEV $MNTDIR
 if [ $? != 0 ]; then
-        echo "Failed to mount metadisk $LOOPDEV; exiting"
+		echo "Failed to mount metadisk $LOOPDEV; exiting"
 	cleanup_failed;
 
 fi

--- a/vjunosswitch/docker/make-config.sh
+++ b/vjunosswitch/docker/make-config.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Create a config metadisk from a supplied juniper.conf to attach
+# to a vJunos VM instance
+usage() {
+	echo "Usage :  make-config.sh <juniper-config> <config-disk>"
+	exit 0;
+}
+cleanup () {
+	echo "Cleaning up..."
+	umount -f -q $MNTDIR
+	losetup -d $LOOPDEV
+	rm -rfv $STAGING
+	rm -rfv $MNTDIR
+}
+
+cleanup_failed () {
+	cleanup;
+	rm -rfv $2
+	exit 1
+}
+
+if [ $# != 2 ]; then
+	usage;
+fi
+
+
+STAGING=`mktemp -d -p /var/tmp`
+MNTDIR=`mktemp -d -p /var/tmp`
+mkdir $STAGING/config
+cp -v $1 $STAGING/config
+qemu-img create -f qcow2 $2 1M
+LOOPDEV=`losetup --show -f $2`
+if [ $? != 0 ]; then
+	cleanup_failed;
+fi
+mkfs.vfat  -v -n "vmm-data" $LOOPDEV
+if [ $? != 0 ]; then
+	echo "Failed to format disk $LOOPDEV; exiting"
+	cleanup_failed;
+fi
+mount -t vfat $LOOPDEV $MNTDIR
+if [ $? != 0 ]; then
+        echo "Failed to mount metadisk $LOOPDEV; exiting"
+	cleanup_failed;
+
+fi
+echo "Copying file(s) to config disk $2"
+(cd $STAGING; tar cvzf $MNTDIR/vmm-config.tgz .)
+cleanup
+echo "Config disk $2 created"
+exit 0


### PR DESCRIPTION
This is a PR to add support for Juniper's vJunos-switch image that emulates an EX2914. vJunos Labs is a recent initiative that features lab images vJunos-switch and vJunosEvolved, the latter I am working out some kinks and will add this in a later PR. I used the below topology file with containerlab for testing. Once this is verified and upstream for vrnetlab I will make the PR for containerlab as well.

```yaml
name: demo

topology:
  nodes:
    n1:
      kind: srl
      image: ghcr.io/nokia/srlinux
      startup-config: srl.cfg

    vswitch0:
      kind: vr-vjunosswitch
      image: vrnetlab/vr-vjunosswitch:23.2R1.14
      startup-config: vjunos.cfg

  links:
    - endpoints: ["n1:e1-1", "vswitch0:eth1"]
```

The existing Juniper nodes (vSRX, vMX, vQFX) feature some send/wait type logic on the Junos CLI to configure the nodes with their bare minimum configs enforced by vrnetlab (such as user, password, various set commands, etc). Instead of using this logic, I used the shipped `make-config.sh` shell script featured in the support.juniper.net site that creates a disk image based on a juniper.conf file (this is where the various bare minimum configs lie) and then mounts this disk to the main vJunos-switch VM image. 
