### PR TITLE
Initial ASAv support

### DIFF
--- a/asav/Makefile
+++ b/asav/Makefile
@@ -1,0 +1,12 @@
+VENDOR=Cisco
+NAME=ASAv
+IMAGE_FORMAT=qcow2
+IMAGE_GLOB=*.qcow2
+
+# match versions like:
+# asav9-18-2.qcow2
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\-[0-9]\+\-[0-9]\+[a-z]\?\)\([^0-9].*\|$$\)/\1/')
+
+-include ../makefile-sanity.include
+-include ../makefile.include
+-include ../makefile-install.include

--- a/asav/README.md
+++ b/asav/README.md
@@ -1,0 +1,55 @@
+vrnetlab / Cisco ASAv
+===========================
+This is the vrnetlab docker image for Cisco ASAv.
+
+Building the docker image
+-------------------------
+Put the .qcow2 file in this directory and run `make docker-image` and
+you should be good to go. The resulting image is called `vr-asav`. You can tag
+it with something else if you want, like `my-repo.example.com/vr-asav` and then
+push it to your repo. The tag is the same as the version of the ASAv image, so
+if you have asav9-18-2.qcow2 your final docker image will be called
+vr-asav:9-18-2
+
+Please note that you will always need to specify version when starting your
+router as the "latest" tag is not added to any images since it has no meaning
+in this context.
+
+It's been tested to boot and respond to SSH with:
+
+ * 9.18.2 (asav9-18-2.qcow2)
+
+Usage
+-----
+```
+docker run -d --privileged --name my-asav-firewall vr-asav
+```
+
+Interface mapping
+-----------------
+Management0/0 is always configured as a management interface.
+
+| vr-asav             | vr-xcon |
+| :---:               |  :---:  |
+| Management0/0       | 0       |
+| GigabitEthernet0/0  | 1       |
+| GigabitEthernet0/1  | 2       |
+| GigabitEthernet0/2  | 3       |
+| GigabitEthernet0/3  | 4       |
+| GigabitEthernet0/4  | 5       |
+| GigabitEthernet0/5  | 6       |
+| GigabitEthernet0/6  | 7       |
+| GigabitEthernet0/7  | 8       |
+
+System requirements
+-------------------
+CPU: 1 core
+
+RAM: 2GB
+
+Disk: <500MB
+
+FUAQ - Frequently or Unfrequently Asked Questions
+-------------------------------------------------
+##### Q: Has this been extensively tested?
+A: Nope. 

--- a/asav/docker/Dockerfile
+++ b/asav/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:bullseye
+MAINTAINER Kristian Larsson <kristian@spritelink.net>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get upgrade -qy \
+ && apt-get install -y \
+    bridge-utils \
+    iproute2 \
+    python3-ipy \
+    socat \
+    qemu-kvm \
+    genisoimage \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION
+ENV VERSION=${VERSION}
+ARG IMAGE
+COPY $IMAGE* /
+COPY *.py /
+
+EXPOSE 22 161/udp 830 5000 10000-10099
+HEALTHCHECK CMD ["/healthcheck.py"]
+ENTRYPOINT ["/launch.py"]

--- a/asav/docker/Dockerfile
+++ b/asav/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM ubuntu:20.04 
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -11,6 +11,11 @@ RUN apt-get update -qy \
     python3-ipy \
     socat \
     qemu-kvm \
+    tcpdump \
+    ssh \ 
+    inetutils-ping \
+    dnsutils \
+    telnet \
     genisoimage \
  && rm -rf /var/lib/apt/lists/*
 

--- a/asav/docker/launch.py
+++ b/asav/docker/launch.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+
+import datetime
+import logging
+import os
+import re
+import signal
+import subprocess
+import sys
+import telnetlib
+import time
+
+import vrnetlab
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+logging.Logger.trace = trace
+
+
+class ASAv_vm(vrnetlab.VM):
+    def __init__(self, username, password, install_mode=False):
+        for e in os.listdir("/"):
+            if re.search(".qcow2$", e):
+                disk_image = "/" + e
+
+        super(ASAv_vm, self).__init__(username, password, disk_image=disk_image, ram=2048)
+        self.nic_type = "e1000"
+        self.install_mode = install_mode
+        self.num_nics = 8
+
+
+    def bootstrap_spin(self):
+        """ This function should be called periodically to do work.
+        """
+
+        if self.spins > 300:
+            # too many spins with no result ->  give up
+            self.stop()
+            self.start()
+            return
+
+        (ridx, match, res) = self.tn.expect([b"ciscoasa>"], 1)
+        if match: # got a match!
+            if ridx == 0: # login
+                if self.install_mode:
+                    self.logger.debug("matched, ciscoasa>")
+                    self.wait_write("", wait=None)
+                    self.wait_write("", None)
+                    self.wait_write("", wait="ciscoasa>")
+                    self.running = True
+                    return
+
+                self.logger.debug("matched, ciscoasa>")
+                self.wait_write("", wait=None)
+
+                # run main config!
+                self.bootstrap_config()
+                # close telnet connection
+                self.tn.close()
+                # startup time?
+                startup_time = datetime.datetime.now() - self.start_time
+                self.logger.info("Startup complete in: %s" % startup_time)
+                # mark as running
+                self.running = True
+                return
+
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        if res != b'':
+            self.logger.trace("OUTPUT: %s" % res.decode())
+            # reset spins if we saw some output
+            self.spins = 0
+
+        self.spins += 1
+
+        return
+
+
+    def bootstrap_config(self):
+        """ Do the actual bootstrap config
+        """
+        self.logger.info("applying bootstrap configuration")
+        self.wait_write("", None)
+        self.wait_write("enable", wait="ciscoasa>")
+        self.wait_write("VR-netlab9", wait="Enter  Password:")
+        self.wait_write("VR-netlab9", wait="Repeat Password:")
+        self.wait_write("", wait="ciscoasa#")
+        self.wait_write("configure terminal", wait="#")
+        self.wait_write("N", wait="[Y]es, [N]o, [A]sk later:")
+        self.wait_write("", wait="(config)#")
+        self.wait_write("aaa authentication ssh console LOCAL")
+        self.wait_write("aaa authentication enable console LOCAL")
+        self.wait_write("username %s password %s privilege 15" % (self.username, self.password))
+        self.wait_write("interface Management0/0")
+        self.wait_write("nameif management")
+        self.wait_write("ip address 10.0.0.15 255.255.255.0")
+        self.wait_write("no shutdown")
+        self.wait_write("ssh 0.0.0.0 0.0.0.0 management")
+        self.wait_write("ssh version 2")
+        self.wait_write("ssh key-exchange group dh-group14-sha256")
+        self.wait_write("crypto key generate ecdsa")        
+        self.wait_write("write")
+        self.wait_write("end")
+        self.wait_write("\r", None)
+
+
+class ASAv(vrnetlab.VR):
+    def __init__(self, username, password):
+        super(ASAv, self).__init__(username, password)
+        self.vms = [ ASAv_vm(username, password) ]
+
+
+class ASAv_installer(ASAv):
+    """ ASAv installer
+    """
+    def __init__(self, username, password):
+        super(ASAv, self).__init__(username, password)
+        self.vms = [ ASAv_vm(username, password, install_mode=True)  ]
+
+    def install(self):
+        self.logger.info("Installing ASAv")
+        asav = self.vms[0]
+        while not asav.running:
+            asav.work()
+        time.sleep(30)
+        asav.stop()
+        self.logger.info("Installation complete")
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default='vrnetlab', help='Username')
+    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    parser.add_argument('--install', action='store_true', help='Install ASAv')
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    if args.install:
+        vr = ASAv_installer(args.username, args.password)
+        vr.install()
+    else:
+        vr = ASAv(args.username, args.password)
+        vr.start()


### PR DESCRIPTION
Hi all,

This PR is to add support for Cisco ASAv, I've build and tested this with the asav9-18-2.qcow2 image that is available from Cisco CML / VIRL.

I'd like to add it to this project so it hopefully can also be supported in https://github.com/srl-labs/containerlab

Terminal output where you can see the build:
```
root@containerlab:/home/stimmerman/vrnetlab/asav# make docker-image
../makefile-install.include:32: warning: overriding recipe for target 'docker-pre-build'
../makefile.include:18: warning: ignoring old recipe for target 'docker-pre-build'
for IMAGE in asav9-18-2.qcow2; do \
        echo "Making $IMAGE"; \
        make IMAGE=$IMAGE docker-build; \
done
Making asav9-18-2.qcow2
make[1]: Entering directory '/home/stimmerman/vrnetlab/asav'
../makefile-install.include:32: warning: overriding recipe for target 'docker-pre-build'
../makefile.include:18: warning: ignoring old recipe for target 'docker-pre-build'
rm -f docker/*.qcow2* docker/*.tgz* docker/*.vmdk* docker/*.iso
cat cidfile | xargs --no-run-if-empty docker rm -f
Error response from daemon: No such container: 9883b1915fd6c5c922e613750041ec3e289f9fcd56a6e288a49ea811755f2938
rm cidfile
docker tag vr-asav:9-18-2 vr-asav:9-18-2-previous-build
Building docker image using asav9-18-2.qcow2 as vr-asav:9-18-2
cp ../common/* docker/
make IMAGE=$IMAGE docker-build-image-copy
make[2]: Entering directory '/home/stimmerman/vrnetlab/asav'
../makefile-install.include:32: warning: overriding recipe for target 'docker-pre-build'
../makefile.include:18: warning: ignoring old recipe for target 'docker-pre-build'
cp asav9-18-2.qcow2* docker/
make[2]: Leaving directory '/home/stimmerman/vrnetlab/asav'
(cd docker; docker build --build-arg http_proxy= --build-arg https_proxy= --build-arg IMAGE=asav9-18-2.qcow2 --build-arg VERSION=9-18-2 -t vr-asav:9-18-2 .)
[+] Building 4.4s (9/9) FINISHED                                                                                                                                                                                                                                              docker:default
 => [internal] load .dockerignore                                                                                                                                                                                                                                                       0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                         0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                    0.0s
 => => transferring dockerfile: 531B                                                                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye                                                                                                                                                                                                                      2.6s
 => [1/4] FROM docker.io/library/debian:bullseye@sha256:1beb7cf458bdfe71b5220cb2069eb45e3fc7eb77a1ccfb169eaebf5f6c4809ab                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                                                                       1.5s
 => => transferring context: 340.35MB                                                                                                                                                                                                                                                   1.5s
 => CACHED [2/4] RUN apt-get update -qy  && apt-get upgrade -qy  && apt-get install -y     bridge-utils     iproute2     python3-ipy     socat     qemu-kvm     genisoimage  && rm -rf /var/lib/apt/lists/*                                                                             0.0s
 => CACHED [3/4] COPY asav9-18-2.qcow2* /                                                                                                                                                                                                                                               0.0s
 => [4/4] COPY *.py /                                                                                                                                                                                                                                                                   0.3s
 => exporting to image                                                                                                                                                                                                                                                                  0.0s
 => => exporting layers                                                                                                                                                                                                                                                                 0.0s
 => => writing image sha256:6f777c6a2b81046b3cbca83a5b2c2ff437621e0b81f5d7baa129cc9045de9240                                                                                                                                                                                            0.0s
 => => naming to docker.io/library/vr-asav:9-18-2                                                                                                                                                                                                                                       0.0s
docker inspect --format '{{.RootFS.Layers}}' vr-asav:9-18-2-previous-build | tr -d '][' | awk '{ $(NF)=""; print }' > built-image-sha-previous
docker inspect --format '{{.RootFS.Layers}}' vr-asav:9-18-2 | tr -d '][' > built-image-sha-current
if [ "$(cat built-image-sha-previous | sed -e 's/[[:space:]]*$//')" = "$(cat built-image-sha-current)" ]; then echo "Previous image is the same as current, retagging!"; \
docker tag vr-asav:9-18-2-previous-build vr-asav:9-18-2 || true; \
else \
echo "Current build differ from previous, running install!"; \
docker run --cidfile cidfile --privileged vr-asav:9-18-2 --trace --install ; \
docker commit --change='ENTRYPOINT ["/launch.py"]' $(cat cidfile) vr-asav:9-18-2; \
docker rm -f $(cat cidfile); \
fi
Current build differ from previous, running install!
2023-08-31 11:56:02,108: vrnetlab   DEBUG    Creating overlay disk image /asav9-18-2-0-overlay.qcow2 for /asav9-18-2.qcow2
2023-08-31 11:56:02,118: vrnetlab   DEBUG    (b"Formatting '/asav9-18-2-0-overlay.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=9126805504 backing_file=/asav9-18-2.qcow2 backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16\n", None)
2023-08-31 11:56:02,118: launch     INFO     Installing ASAv
2023-08-31 11:56:02,118: vrnetlab   DEBUG    VM not started; starting!
2023-08-31 11:56:02,118: vrnetlab   INFO     Starting ASAv_vm[0]
2023-08-31 11:56:02,118: vrnetlab   DEBUG    ['qemu-system-x86_64', '-enable-kvm', '-display', 'none', '-machine', 'pc', '-monitor', 'tcp:0.0.0.0:4000,server,nowait', '-m', '2048', '-serial', 'telnet:0.0.0.0:5000,server,nowait', '-drive', 'if=ide,file=/asav9-18-2-0-overlay.qcow2', '-device', 'pci-bridge,chassis_nr=1,id=pci.1', '-device', 'e1000,netdev=p00,mac=52:54:00:59:b4:00', '-netdev', 'user,id=p00,net=10.0.0.0/24,tftp=/tftpboot,hostfwd=udp::2161-10.0.0.15:161,hostfwd=tcp::2830-10.0.0.15:830,hostfwd=tcp::2080-10.0.0.15:80,hostfwd=tcp::2443-10.0.0.15:443,hostfwd=tcp::2022-10.0.0.15:22', '-device', 'e1000,netdev=p01,mac=52:54:00:51:38:01,bus=pci.1,addr=0x2', '-netdev', 'socket,id=p01,listen=:10001', '-device', 'e1000,netdev=p02,mac=52:54:00:83:ba:02,bus=pci.1,addr=0x3', '-netdev', 'socket,id=p02,listen=:10002', '-device', 'e1000,netdev=p03,mac=52:54:00:88:95:03,bus=pci.1,addr=0x4', '-netdev', 'socket,id=p03,listen=:10003', '-device', 'e1000,netdev=p04,mac=52:54:00:4e:d1:04,bus=pci.1,addr=0x5', '-netdev', 'socket,id=p04,listen=:10004', '-device', 'e1000,netdev=p05,mac=52:54:00:85:f9:05,bus=pci.1,addr=0x6', '-netdev', 'socket,id=p05,listen=:10005', '-device', 'e1000,netdev=p06,mac=52:54:00:c3:03:06,bus=pci.1,addr=0x7', '-netdev', 'socket,id=p06,listen=:10006', '-device', 'e1000,netdev=p07,mac=52:54:00:47:94:07,bus=pci.1,addr=0x8', '-netdev', 'socket,id=p07,listen=:10007', '-device', 'e1000,netdev=p08,mac=52:54:00:a5:97:08,bus=pci.1,addr=0x9', '-netdev', 'socket,id=p08,listen=:10008']
2023-08-31 11:56:50,173: launch     TRACE    OUTPUT: loader: Platform type set to default
Platform ASAv
loader: Platform type set
2023-08-31 11:56:52,175: launch     TRACE    OUTPUT:  to default
IO memory blocks requested from bigphys 32bit: 196608
INFO: The system integrator has chosen not to place th
2023-08-31 11:56:54,176: launch     TRACE    OUTPUT: e requested string in the SMBIOS
DEBUG: Could not find string for SMBIOS type *** String ***INFO: SMBIOS indicates Nested 
2023-08-31 11:56:56,179: launch     TRACE    OUTPUT: KVM Environment
early console in extract_kernel
input_data: 0x00000000021c13b1
input_len: 0x0000000000567f93
output: 0x0000000001000000
output_len: 0x0000000001701e20
kernel_total_size: 0x00000000012e8000
trampoline_32bit: 0x000000000009d000
booted via startup_32()
Physical KASLR using RDTSC...
Virtual KASLR using RDTSC...

Decompressing Linux... Parsing ELF... Performing relocations... done.
Booting the kernel.
Memory KASLR using RDTSC...

INIT: version 2.88 bootingaunch     TRACE    OUTPUT: 
Starting udev

2023-08-31 11:57:00,184: launch     TRACE    OUTPUT: Configuring network interfaces... done.
Starting random number generator daemon.

2023-08-31 11:57:02,187: launch     TRACE    OUTPUT: warning: Device /dev/hda has no label.
fsck.fat 4.1 (2017-01-24)
Starting check/repair pass.
Starting verification pass.
/dev/hda1: 14 files, 41415/65246 clusters
dosfsck(/dev/hda1) returned 0
Mounting /dev/hda1
fsck.fat 4.1 (2017-01-24)
Starting check/repair pass.
Starting verification pass.
/dev/hda2: 2 files, 1/2092548 clusters
dosfsck(/dev/hda2) returned 0
Mounting /dev/hda2
warning: Device /dev/hdc has no label.
no cdrom devices found

2023-08-31 11:57:04,189: launch     TRACE    OUTPUT: CAT9k CFG directory mounting
mount: /mnt/cat9k-cfg: special device shared_mount does not exist.
shared_mount Failure
Removing cat9k_cfg

2023-08-31 11:57:06,191: launch     TRACE    OUTPUT: info: Running in kvm virtual environment.
Lina to use serial port /dev/ttyS0 for console IO
Configuring packages on first boot....
 (This may take several minutes. Please do not power off the machine.)
Running postinst /etc/rpm-postinsts/100-sysvinit-inittab...
Running postinst /etc/rpm-postinsts/101-dpdk...
update-rc.d: /etc/init.d/run-postinsts exists during rc.d purge (continuing)
 Removing any system startup links for run-postinsts ...
  /etc/rcS.d/S99run-postinsts


Loading...
The digital signature of the running image verified successfully
lina_init_env: memif is not enabled.
System Cores 1 Nodes 1 Max Cores 32

total_reserved_mem = 0 

total_heapcache_mem = 0 
total mem 2064969728 system 2098524160 kernel 12596633 image 0
new 1247066727 old 2064969728 reserve 0 priv new 1259663360 priv old 1259663360
Processor memory:   2147483648
M_MMAP_THRESHOLD 65536, M_MMAP_MAX 32768
POST started...
POST finished, result is 0 (hint: 1 means it failed)

Cisco Adaptive Security Appliance Software Version 9.18(2)

Compiled on Mon 08-Aug-22 15:58 GMT by builders
Failed to read security parameters - base 0xfff00000 offset 0x400 buf_size 20
secstore_buf_fill: Error reading secure store -  buffer 0x46294c40, size 0x14 tag 3 id 0
ASA: Platform type set to default. secstore rcode 1
Failed to read security parameters - base 0x0 offset 0x400 buf_size 20
secstore_buf_fill: Error reading secure store -  buffer 0x46294770, size 0x14 tag 4 id 0
CPU mode is not set and it may have impact on performance. Please check the ASAv installation document for appropriate cpu mode.

2023-08-31 11:57:16,202: launch     TRACE    OUTPUT: 
Total NICs found: 10
en_vtun rev00 Backplane Tap Interface     @ index 09 MAC: 0000.0100.0001
Counter ID 'TLS13_DOWNSTREAM_CLIENT_CERTIFICATE_VERIFY' is too long must be 40 characters or less
WARNING: Attribute already exists in the dictionary.

INFO: Unable to read firewall mode from flash
       Writing default firewall mode (single) to flash

INFO: Unable to read cluster interface-mode from flash
        Writing default mode "None" to flash
Error: Platform type has not been configured.
Use software crypto.

2023-08-31 11:57:18,204: launch     TRACE    OUTPUT: 
Cisco Adaptive Security Appliance Software Version 9.18(2) 

  ****************************** Warning *******************************
  This product contains cryptographic features and is
  subject to United States and local country laws
  governing, import, export, transfer, and use.
  Delivery of Cisco cryptographic products does not
  imply third-party authority to import, export,
  distribute, or use encryption. Importers, exporters,
  distributors and users are responsible for compliance
  with U.S. and local country laws. By using this
  product you agree to comply with applicable laws and
  regulations. If you are unable to comply with U.S.
  and local laws, return the enclosed items immediately.

  A summary of U.S. laws governing Cisco cryptographic
  products may be found at:
  http://www.cisco.com/wwl/export/crypto/tool/stqrg.html

  If you require further assistance please contact us by
  sending email to export@cisco.com.
  ******************************* Warning *******************************
Cisco Adaptive Security Appliance Software, version 9.18
Copyright (c) 1996-2022 by Cisco Systems, Inc.
For licenses and notices for open source software used in this product, please visit
http://www.cisco.com/go/asa-opensource

                Restricted Rights Legend
Use, duplication, or disclosure by the Government is
subject to restrictions as set forth in subparagraph
(c) of the Commercial Computer Software - Restricted
Rights clause at FAR sec. 52.227-19 and subparagraph
(c) (1) (ii) of the Rights in Technical Data and Computer
Software clause at DFARS sec. 252.227-7013.

                Cisco Systems, Inc.
                170 West Tasman Drive
                San Jose, California 95134-1706

Error: Platform type has not been configured.

 Successfully discovered platform.  Rebooting to apply the platform type.

2023-08-31 11:57:20,206: launch     TRACE    OUTPUT: Process shutdown finished

2023-08-31 11:57:22,209: launch     TRACE    OUTPUT: Rebooting... (status 0x9)

2023-08-31 11:57:30,219: launch     TRACE    OUTPUT: ..
INIT: Switching to runlevel: 6
INIT: Sending processes the TERM signal

2023-08-31 11:57:32,222: launch     TRACE    OUTPUT: Stopping OpenBSD Secure Shell server: sshd
no /usr/sbin/sshd found; none killed
Stopping Advanced Configuration and Power Interface daemon: no /usr/sbin/acpid found; none killed
acpid.
Stopping random number generator daemon.
Deconfiguring network interfaces... done.
Sending all processes the TERM signal...

2023-08-31 11:57:36,226: launch     TRACE    OUTPUT: Sending all processes the KILL signal...
Deactivating swap...
Unmounting local filesystems...
Rebooting... 
2023-08-31 11:58:28,280: launch     TRACE    OUTPUT: Platform ASAv
IO memor
2023-08-31 11:58:30,282: launch     TRACE    OUTPUT: y blocks requested from bigphys 32bit: 196608
INFO: The system integrator has chosen not to place the requested string in t
2023-08-31 11:58:32,283: launch     TRACE    OUTPUT: he SMBIOS
DEBUG: Could not find string for SMBIOS type *** String ***INFO: SMBIOS indicates Nested KVM Environment

2023-08-31 11:58:34,285: launch     TRACE    OUTPUT: early console in extract_kernel
input_data: 0x00000000021c13b1
input_len: 0x0000000000567f93
output: 0x0000000001000000
output_len: 0x0000000001701e20
kernel_total_size: 0x00000000012e8000
trampoline_32bit: 0x000000000009d000
booted via startup_32()
Physical KASLR using RDTSC...
Virtual KASLR using RDTSC...

Decompressing Linux... Parsing ELF... Performing relocations... done.
Booting the kernel.
Memory KASLR using RDTSC...

INIT: version 2.88 bootingaunch     TRACE    OUTPUT: 
Starting udev

2023-08-31 11:58:40,292: launch     TRACE    OUTPUT: Configuring network interfaces... done.
Starting random number generator daemon.
warning: Device /dev/hda has no label.
fsck.fat 4.1 (2017-01-24)

2023-08-31 11:58:42,294: launch     TRACE    OUTPUT: Starting check/repair pass.
Starting verification pass.
/dev/hda1: 14 files, 41415/65246 clusters
dosfsck(/dev/hda1) returned 0
Mounting /dev/hda1
fsck.fat 4.1 (2017-01-24)
Starting check/repair pass.
Starting verification pass.
/dev/hda2: 21 files, 57/2092548 clusters
dosfsck(/dev/hda2) returned 0
Mounting /dev/hda2
warning: Device /dev/hdc has no label.
no cdrom devices found

2023-08-31 11:58:50,302: launch     TRACE    OUTPUT: Info: Encrypted disk file system created & mounted successfully


2023-08-31 11:58:52,304: launch     TRACE    OUTPUT: CAT9k CFG directory mounting
mount: /mnt/cat9k-cfg: special device shared_mount does not exist.
shared_mount Failure
Removing cat9k_cfg

2023-08-31 11:58:54,307: launch     TRACE    OUTPUT: info: Running in kvm virtual environment.
Lina to use serial port /dev/ttyS0 for console IO
Configuring packages on first boot....
 (This may take several minutes. Please do not power off the machine.)
Running postinst /etc/rpm-postinsts/100-sysvinit-inittab...
Running postinst /etc/rpm-postinsts/101-dpdk...
update-rc.d: /etc/init.d/run-postinsts exists during rc.d purge (continuing)
 Removing any system startup links for run-postinsts ...
  /etc/rcS.d/S99run-postinsts


Loading...
The digital signature of the running image verified successfully
lina_init_env: memif is not enabled.
System Cores 1 Nodes 1 Max Cores 32

total_reserved_mem = 0 

total_heapcache_mem = 0 
total mem 2064969728 system 2098524160 kernel 12596633 image 0
new 1247066727 old 2064969728 reserve 0 priv new 1259663360 priv old 1259663360
Processor memory:   2147483648
M_MMAP_THRESHOLD 65536, M_MMAP_MAX 32768
POST started...
POST finished, result is 0 (hint: 1 means it failed)

Cisco Adaptive Security Appliance Software Version 9.18(2)

Compiled on Mon 08-Aug-22 15:58 GMT by builders
CPU mode is not set and it may have impact on performance. Please check the ASAv installation document for appropriate cpu mode.

2023-08-31 11:59:10,323: launch     TRACE    OUTPUT: 
Total NICs found: 10
en_vtun rev00 Backplane Tap Interface     @ index 09 MAC: 0000.0100.0001
Counter ID 'TLS13_DOWNSTREAM_CLIENT_CERTIFICATE_VERIFY' is too long must be 40 characters or less
WARNING: Attribute already exists in the dictionary.
Use software crypto.

Cisco Adaptive Security Appliance Software Version 9.18(2) 

  ****************************** Warning *******************************
  This product contains cryptographic features and is
  subject to United States and local country laws
  governing, import, export, transfer, and use.
  Delivery of Cisco cryptographic products does not
  imply third-party authority to import, export,
  distribute, or use encryption. Importers, exporters,
  distributors and users are responsible for compliance
  with U.S. and local country laws. By using this
  product you agree to comply with applicable laws and
  regulations. If you are unable to comply with U.S.
  and local laws, return the enclosed items immediately.

  A summary of U.S. laws governing Cisco cryptographic
  products may be found at:
  http://www.cisco.com/wwl/export/crypto/tool/stqrg.html

  If you require further assistance please contact us by
  sending email to export@cisco.com.
  ******************************* Warning *******************************
Cisco Adaptive Security Appliance Software, version 9.18
Copyright (c) 1996-2022 by Cisco Systems, Inc.
For licenses and notices for open source software used in this product, please visit
http://www.cisco.com/go/asa-opensource

                Restricted Rights Legend
Use, duplication, or disclosure by the Government is
subject to restrictions as set forth in subparagraph
(c) of the Commercial Computer Software - Restricted
Rights clause at FAR sec. 52.227-19 and subparagraph
(c) (1) (ii) of the Rights in Technical Data and Computer
Software clause at DFARS sec. 252.227-7013.

                Cisco Systems, Inc.
                170 West Tasman Drive
                San Jose, California 95134-1706


2023-08-31 11:59:40,335: launch     TRACE    OUTPUT: Keypair generation process begin. Please wait...

2023-08-31 11:59:42,336: launch     TRACE    OUTPUT: 
Cryptochecksum (changed): d41d8cd9 8f00b204 e9800998 ecf8427e 
INFO: converting 'fixup protocol dns maximum-length 512' to MPF commands
ERROR: Inspect configuration of this type exists, first remove 
that configuration and then add the new configuration
INFO: converting 'fixup protocol ftp 21' to MPF commands
INFO: converting 'fixup protocol h323_h225 1720' to MPF commands
INFO: converting 'fixup protocol h323_ras 1718-1719' to MPF commands
INFO: converting 'fixup protocol ip-options 1' to MPF commands
INFO: converting 'fixup protocol netbios 137-138' to MPF commands
INFO: converting 'fixup protocol rsh 514' to MPF commands
INFO: converting 'fixup protocol rtsp 554' to MPF commands
INFO: converting 'fixup protocol sip 5060' to MPF commands
INFO: converting 'fixup protocol skinny 2000' to MPF commands
INFO: converting 'fixup protocol smtp 25' to MPF commands
INFO: converting 'fixup protocol sqlnet 1521' to MPF commands
INFO: converting 'fixup protocol sunrpc 111' to MPF commands
INFO: converting 'fixup protocol sunrpc_udp 111' to MPF commands
INFO: converting 'fixup protocol tftp 69' to MPF commands
INFO: converting 'fixup protocol sip udp 5060' to MPF commands
INFO: File /mnt/disk0/.private/dynamic-config.json not opened; errno 2
INFO: Network Service reload not performed.

2023-08-31 11:59:44,337: launch     TRACE    OUTPUT: 
INFO: Power-On Self-Test in process.
.....................................
INFO: Power-On Self-Test complete.

INFO: Starting SW-DRBG health test...
INFO: SW-DRBG health test passed.
Creating trustpoint "_SmartCallHome_ServerCA" and installing certificate...

Trustpoint CA certificate accepted.
Creating trustpoint "_SmartCallHome_ServerCA2" and installing certificate...

Trustpoint CA certificate accepted.

2023-08-31 11:59:45,339: launch     DEBUG    matched, ciscoasa>
2023-08-31 11:59:45,339: vrnetlab   DEBUG    writing to serial console: 
2023-08-31 11:59:45,339: vrnetlab   DEBUG    writing to serial console: 
2023-08-31 11:59:45,339: vrnetlab   TRACE    waiting for 'ciscoasa>' on serial console
2023-08-31 11:59:45,352: vrnetlab   TRACE    read from serial console:  
ciscoasa>
2023-08-31 11:59:45,352: vrnetlab   DEBUG    writing to serial console: 
2023-08-31 12:00:15,560: launch     INFO     Installation complete
sha256:298e94eadaaa0a311e275fcfda0953584860a7c62a0caa09a075689565ad66e5
55672ed699cc4c60bcdbeb642ee5d50629914ffef6adf99da1c488150ab9d9eb
docker rmi -f vr-asav:9-18-2-previous-build || true
Untagged: vr-asav:9-18-2-previous-build
Deleted: sha256:74c887449cd5a78dd27c9be1750d4c72218a89c3a86fe5d60d0e4658eb1102b6
Deleted: sha256:7bd03182dac9ab208d7eff690f3cbf1232b207bee781fc4499dc83b4f6eb8b27
Deleted: sha256:182ddaa38380408f34345e9e9b6c24491616150250ee38fb6750fe3d476cabc0
rm built-image-sha*
make[1]: Leaving directory '/home/stimmerman/vrnetlab/asav'
root@containerlab:/home/stimmerman/vrnetlab/asav#
```

Terminal output from running the resulting container:
```
root@containerlab:/home/stimmerman/vrnetlab/asav# docker run --privileged --name my-asav vr-asav:9-18-2
2023-08-31 12:01:24,342: vrnetlab   DEBUG    Starting vrnetlab <__main__.ASAv object at 0x7fc6392deb80>
2023-08-31 12:01:24,342: vrnetlab   DEBUG    VMs: [<__main__.ASAv_vm object at 0x7fc6392deaf0>]
2023-08-31 12:01:24,346: vrnetlab   DEBUG    VM not started; starting!
2023-08-31 12:01:24,346: vrnetlab   INFO     Starting ASAv_vm[0]
2023-08-31 12:01:24,346: vrnetlab   DEBUG    ['qemu-system-x86_64', '-enable-kvm', '-display', 'none', '-machine', 'pc', '-monitor', 'tcp:0.0.0.0:4000,server,nowait', '-m', '2048', '-serial', 'telnet:0.0.0.0:5000,server,nowait', '-drive', 'if=ide,file=/asav9-18-2-0-overlay.qcow2', '-device', 'pci-bridge,chassis_nr=1,id=pci.1', '-device', 'e1000,netdev=p00,mac=52:54:00:11:56:00', '-netdev', 'user,id=p00,net=10.0.0.0/24,tftp=/tftpboot,hostfwd=tcp::2830-10.0.0.15:830,hostfwd=tcp::2080-10.0.0.15:80,hostfwd=tcp::2443-10.0.0.15:443,hostfwd=tcp::2022-10.0.0.15:22,hostfwd=udp::2161-10.0.0.15:161', '-device', 'e1000,netdev=p01,mac=52:54:00:dc:ee:01,bus=pci.1,addr=0x2', '-netdev', 'socket,id=p01,listen=:10001', '-device', 'e1000,netdev=p02,mac=52:54:00:8d:44:02,bus=pci.1,addr=0x3', '-netdev', 'socket,id=p02,listen=:10002', '-device', 'e1000,netdev=p03,mac=52:54:00:7e:00:03,bus=pci.1,addr=0x4', '-netdev', 'socket,id=p03,listen=:10003', '-device', 'e1000,netdev=p04,mac=52:54:00:89:5e:04,bus=pci.1,addr=0x5', '-netdev', 'socket,id=p04,listen=:10004', '-device', 'e1000,netdev=p05,mac=52:54:00:c7:43:05,bus=pci.1,addr=0x6', '-netdev', 'socket,id=p05,listen=:10005', '-device', 'e1000,netdev=p06,mac=52:54:00:6c:b1:06,bus=pci.1,addr=0x7', '-netdev', 'socket,id=p06,listen=:10006', '-device', 'e1000,netdev=p07,mac=52:54:00:9c:2d:07,bus=pci.1,addr=0x8', '-netdev', 'socket,id=p07,listen=:10007', '-device', 'e1000,netdev=p08,mac=52:54:00:3d:be:08,bus=pci.1,addr=0x9', '-netdev', 'socket,id=p08,listen=:10008']
2023-08-31 12:02:49,448: launch     DEBUG    matched, ciscoasa>
2023-08-31 12:02:49,448: vrnetlab   DEBUG    writing to serial console: 
2023-08-31 12:02:49,448: launch     INFO     applying bootstrap configuration
2023-08-31 12:02:49,449: vrnetlab   DEBUG    writing to serial console: 
2023-08-31 12:02:49,489: vrnetlab   DEBUG    writing to serial console: enable
2023-08-31 12:02:49,564: vrnetlab   DEBUG    writing to serial console: password
2023-08-31 12:02:49,607: vrnetlab   DEBUG    writing to serial console: password
2023-08-31 12:02:49,674: vrnetlab   DEBUG    writing to serial console: 
2023-08-31 12:02:49,729: vrnetlab   DEBUG    writing to serial console: configure terminal
2023-08-31 12:02:49,850: vrnetlab   DEBUG    writing to serial console: N
2023-08-31 12:02:49,947: vrnetlab   DEBUG    writing to serial console: 
2023-08-31 12:02:50,004: vrnetlab   DEBUG    writing to serial console: aaa authentication ssh console LOCAL
2023-08-31 12:02:50,047: vrnetlab   DEBUG    writing to serial console: aaa authentication enable console LOCAL
2023-08-31 12:02:50,135: vrnetlab   DEBUG    writing to serial console: username vrnetlab password VR-netlab9 privilege 15
2023-08-31 12:02:50,219: vrnetlab   DEBUG    writing to serial console: interface Management0/0
2023-08-31 12:02:50,295: vrnetlab   DEBUG    writing to serial console: nameif management
2023-08-31 12:02:50,359: vrnetlab   DEBUG    writing to serial console: ip address 10.0.0.15 255.255.255.0
2023-08-31 12:02:50,439: vrnetlab   DEBUG    writing to serial console: no shutdown
2023-08-31 12:02:50,503: vrnetlab   DEBUG    writing to serial console: ssh 0.0.0.0 0.0.0.0 management
2023-08-31 12:02:50,571: vrnetlab   DEBUG    writing to serial console: ssh version 2
2023-08-31 12:02:50,635: vrnetlab   DEBUG    writing to serial console: ssh key-exchange group dh-group14-sha256
2023-08-31 12:02:50,695: vrnetlab   DEBUG    writing to serial console: crypto key generate ecdsa
2023-08-31 12:02:50,760: vrnetlab   DEBUG    writing to serial console: write
2023-08-31 12:02:50,906: vrnetlab   DEBUG    writing to serial console: end
2023-08-31 12:02:50,906: vrnetlab   DEBUG    writing to serial console: 
2023-08-31 12:02:50,907: launch     INFO     Startup complete in: 0:01:26.564936
```