### PR TITLE
Allow a host with an AMD CPU to spin up vjunos-switch within a nested virtualisation setup

### DIFF
--- a/vjunosswitch/docker/launch.py
+++ b/vjunosswitch/docker/launch.py
@@ -70,7 +70,7 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
         self.qemu_args.extend(
             [
                 "-cpu",
-                "IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=off",
+                "IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=on",
             ]
         )
         # mount config disk with juniper.conf base configs


### PR DESCRIPTION
Allow a host with an AMD CPU to spin up vjunos-switch within a nested virtualisation setup.

Did originally try `host` however vjunos-switch instance wouldn't boot, it gets as far as "Creating initial configuration..."  before a qemu prompt is seen where it then loops waiting for the VM to boot.