### PR TITLE
SROS: added support for extra CF disks (custom variant). switched qemu drive if to virtio

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -67,7 +67,7 @@ class VM:
                 return image_info["format"]
         raise ValueError(f"Could not read image format for {self.image}")
 
-    def __init__(self, username, password, disk_image=None, num=0, ram=4096):
+    def __init__(self, username, password, disk_image=None, num=0, ram=4096, driveif='ide'):
         self.logger = logging.getLogger()
 
         # username / password to configure
@@ -135,7 +135,7 @@ class VM:
                 "-serial",
                 "telnet:0.0.0.0:50%02d,server,nowait" % self.num,
                 "-drive",
-                "if=ide,file=%s" % overlay_disk_image,
+                f"if={driveif},file={overlay_disk_image}",
             ]
         )
         # enable hardware assist if KVM is available

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -640,7 +640,7 @@ def gen_bof_config():
 
 class SROS_vm(vrnetlab.VM):
     def __init__(self, username, password, ram, conn_mode, cpu=2, num=0):
-        super().__init__(username, password, disk_image="/sros.qcow2", num=num, ram=ram)
+        super().__init__(username, password, disk_image="/sros.qcow2", num=num, ram=ram, driveif='virtio')
         self.nic_type = "virtio-net-pci"
         self.conn_mode = conn_mode
         self.uuid = "00000000-0000-0000-0000-000000000000"
@@ -675,7 +675,7 @@ class SROS_vm(vrnetlab.VM):
             diskidx=1
         elif cfname == 'cf2':
             diskidx=2
-        self.qemu_args.extend(["-drive",f"if=ide,index={diskidx},file={path}"])
+        self.qemu_args.extend(["-drive",f"if=virtio,index={diskidx},file={path}"])
 
     # override wait_write clean_buffer parameter default
     def wait_write(self, cmd, wait="__defaultpattern__", con=None, clean_buffer=True):


### PR DESCRIPTION
2 changes:
- Added support for extra CF disks on vr-sros (custom variant). 
- Switched qemu drive if from 'ide' to 'virtio' since this is the officially supported option and also faster.

Usage: add `cfX=SIZE` on cp: line., where 
X=the id of CF slot (1 or 2)
SIZE=the size of the disk to be created in case it doesn't exist. This is passed directly to qemu-img create if new disk needs to be created. Otherwise, an already existing disk is reused without modification.
The disks are located inside /tftpboot/, so they are easily accessible from the host and survive destroy operation.

node config sample:
```
r01:
      kind: vr-sros
      type: >- 
        cp: cpu=2 ram=4 cf1=1G cf2=2G chassis=SR-7 slot=A card=cpm5 ___
        lc: cpu=2 ram=4 max_nics=10 chassis=SR-7 slot=1 card=iom4-e-b mda/1=me10-10gb-sfp+

```
tftpboot directory
```
r01/
└── tftpboot
    ├── cf1_A.qcow2
    ├── cf2_A.qcow2
    ├── config.txt
    └── license.txt
```

Side note: when specifying only CF2 without any CF1, like this
`cp: cpu=2 ram=4 cf2=2G chassis=SR-7 slot=A card=cpm5 ___`
It will get relocated as CF1 on SROS CLI. I have tried creating vSIM using libvirt 'by the book' as described in documentation, and got same behavior.

Hope is useful!