### PR TITLE
Adding support for IXR-e2c

### DIFF
--- a/sros/README.md
+++ b/sros/README.md
@@ -38,7 +38,8 @@ By selecting a certain variant (referred by its `name`) the VSIM will start with
 | ixr-e-small  | distributed | imm14-10g-sfp++4-1g-tx |       m14-10g-sfp++4-1g-tx       |   3+4    |    18    |
 |  ixr-e-big   | distributed |       cpm-ixr-e        |    m24-sfp++8-sfp28+2-qsfp28     |   3+4    |    34    |
 |    ixr-e2    | integrated  |       cpm-ixr-e2        |  m2-qsfpdd+2-qsfp28+24-sfp28   |    4     |    34    |
-|    ixr-ec    | integrated  |       cpm-ixr-e        |  m4-1g-tx+20-1g-sfp+6-10g-sfp+   |    4     |    34    |
+|    ixr-ec    | integrated  |       cpm-ixr-ec        |  m4-1g-tx+20-1g-sfp+6-10g-sfp+   |    4     |    34    |
+|    ixr-ec    | integrated  |       cpm-ixr-e        |  m12-sfp28+2-qsfp28   |    4     |    34    |
 |    ixr-r6    | integrated  |      cpiom-ixr-r6      |    m6-10g-sfp++1-100g-qsfp28     |    6     |    10    |
 |    ixr-s     | integrated  |       cpm-ixr-s        |        m48-sfp++6-qsfp28         |   3+4    |    54    |
 

--- a/sros/README.md
+++ b/sros/README.md
@@ -39,7 +39,7 @@ By selecting a certain variant (referred by its `name`) the VSIM will start with
 |  ixr-e-big   | distributed |       cpm-ixr-e        |    m24-sfp++8-sfp28+2-qsfp28     |   3+4    |    34    |
 |    ixr-e2    | integrated  |       cpm-ixr-e2        |  m2-qsfpdd+2-qsfp28+24-sfp28   |    4     |    34    |
 |    ixr-ec    | integrated  |       cpm-ixr-ec        |  m4-1g-tx+20-1g-sfp+6-10g-sfp+   |    4     |    34    |
-|    ixr-ec    | integrated  |       cpm-ixr-e        |  m12-sfp28+2-qsfp28   |    4     |    34    |
+|    ixr-e2c    | integrated  |       cpm-ixr-e2c        |  m12-sfp28+2-qsfp28   |    4     |    34    |
 |    ixr-r6    | integrated  |      cpiom-ixr-r6      |    m6-10g-sfp++1-100g-qsfp28     |    6     |    10    |
 |    ixr-s     | integrated  |       cpm-ixr-s        |        m48-sfp++6-qsfp28         |   3+4    |    54    |
 

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -181,6 +181,18 @@ SROS_VARIANTS = {
             integrated=True,
         ),
     },
+    "ixr-e2c": {
+        "deployment_model": "integrated",
+        "min_ram": 4,  # minimum RAM requirements
+        "max_nics": 30,
+        **line_card_config(
+            chassis="ixr-e2c",
+            card="cpm-ixr-e2c",
+            card_type="imm12-sfp28+2-qsfp28",
+            mda="m12-sfp28+2-qsfp28",
+            integrated=True,
+        ),
+    },
     "ixr-e2": {
         "deployment_model": "integrated",
         "min_ram": 4,  # minimum RAM requirements
@@ -926,10 +938,10 @@ class SROS_integrated(SROS_vm):
 
         if any(
             chassis in self.variant["timos_line"]
-            for chassis in ["chassis=ixr-r6", "chassis=ixr-ec", "chassis=ixr-e2"]
+            for chassis in ["chassis=ixr-r6", "chassis=ixr-ec", "chassis=ixr-e2", "chassis=ixr-e2c"]
         ):
             logger.debug(
-                "detected ixr-r6/ec/ixr-e2 chassis, creating a dummy network device for SFM connection"
+                "detected ixr-r6/ixr-ec/ixr-e2/ixr-e2c chassis, creating a dummy network device for SFM connection"
             )
             res.append(f"-device virtio-net-pci,netdev=dummy,mac={vrnetlab.gen_mac(0)}")
             res.append("-netdev tap,ifname=sfm-dummy,id=dummy,script=no,downscript=no")


### PR DESCRIPTION
Hi, new cool toy has arrived in 23.10.R3.

```
name: e2c
topology:
  nodes:

    ixr-e2c:
      kind: nokia_sros
      image: vrnetlab/vr-sros:23.10.R3
      type: ixr-e2c
      license: license.txt
```


```
A:admin@ixr-e2c# show system information

===============================================================================
System Information
===============================================================================
System Name            : ixr-e2c
System Type            : 7250 IXR-e2c
Chassis Topology       : Standalone
System Version         : B-23.10.R3
Crypto Module Version  : SRCM 4.2
System Contact         :
System Location        :
System Coordinates     :
System Up Time         : 0 days, 00:01:12.99 (hr:min:sec)
System Up Time (64-bit): 0 days, 00:01:12.99 (hr:min:sec)

Configuration Mode Cfg : model-driven
Configuration Mode Oper: model-driven
Last Mode Changed      : 2024/02/22 05:12:36 Duration: 0d 00:00:00

SNMP Port              : 161
SNMP Engine ID         : 0000197f00000c0009132500
SNMP Engine Boots      : 1
SNMP Max Message Size  : 9216
SNMP Max Bulk Duration : N/A
SNMP Admin State       : Enabled
SNMP Oper State        : Enabled
SNMP Index Boot Status : Persistent
SNMP Sync State        : N/A

Tel/Tel6/SSH/FTP Admin : Disabled/Disabled/Enabled/Disabled
Tel/Tel6/SSH/FTP Oper  : Down/Down/Up/Down

BOF Source             : cf3:
Image Source           : primary
Config Source          : primary
Last Booted Config File: tftp://172.31.255.29/config.txt
Last Boot Cfg Version  : 2024-02-21T08:28:49.3Z by admin from 172.31.255.29
Last Boot Config Header: # TiMOS-B-23.10.R3 both/x86_64 Nokia 7250 IXR
                         Copyright (c) 2000-2024 Nokia. # All rights reserved.
                          All use subject to applicable license agreements. #
                         Built on Thu Feb 15 16:43:14 UTC 2024 by builder in /
                         builds/2310B/R3/panos/main/sros # Configuration
                         format version 23.10 revision 0 # Generated 2024-02-
                         21T08:28:49.3Z by admin from 172.31.255.29
Last Boot Index Version: 2024-02-21T08:28:49.3Z by admin from 172.31.255.29
Last Boot Index Header : # TiMOS-B-23.10.R3 both/x86_64 Nokia 7250 IXR
                         Copyright (c) 2000-2024 Nokia. # All rights reserved.
                          All use subject to applicable license agreements. #
                         Built on Thu Feb 15 16:43:14 UTC 2024 by builder in /
                         builds/2310B/R3/panos/main/sros # Configuration
                         format version 23.10 revision 0 # Generated 2024-02-
                         21T08:28:49.3Z by admin from 172.31.255.29
Last Saved Config      : tftp://172.31.255.29/config.txt
Time Last Saved        : 2024/02/22 05:12:42
Changes Since Last Save: No
Max Cfg/BOF Backup Rev : 50
Cfg-OK Script          : N/A
Cfg-OK Script Status   : not used
Cfg-Fail Script        : N/A
Cfg-Fail Script Status : not used

IPv4 autoconfiguration : Disabled
IPv6 autoconfiguration : Disabled
Management IPv4 Addr   : 172.31.255.30/30
Management IPv6 Addr   : 200::1/127
Primary DNS Server     : N/A
Secondary DNS Server   : N/A
Tertiary DNS Server    : N/A
DNS Domain             : (Not Specified)
DNS Resolve Preference : ipv6-first
BOF Static Routes      :
  To                   Next Hop
  172.20.20.0/24       172.31.255.29

  2001:172:20:20::/64  200::


ICMP Vendor Enhancement: Disabled

Last Reboot Reason     : other
===============================================================================

[/]
A:admin@ixr-e2c#
```