### PR TITLE
Add FP5 SR-1 models

### DIFF
--- a/sros/README.md
+++ b/sros/README.md
@@ -42,6 +42,12 @@ By selecting a certain variant (referred by its `name`) the VSIM will start with
 |    ixr-e2c    | integrated  |       cpm-ixr-e2c        |  m12-sfp28+2-qsfp28   |    4     |    34    |
 |    ixr-r6    | integrated  |      cpiom-ixr-r6      |    m6-10g-sfp++1-100g-qsfp28     |    6     |    10    |
 |    ixr-s     | integrated  |       cpm-ixr-s        |        m48-sfp++6-qsfp28         |   3+4    |    54    |
+|    sr-1-46s  | distributed |       cpm-1x           | m40-200g-sfpdd+6-800g-qsfpdd-1   |    4     |    48    |
+|    sr-1-92s  | distributed |       cpm-1x           | m80-200g-sfpdd+12-400g-qsfpdd-1  |    4     |    48    |
+|    sr-1x-92s | distributed |       cpm-1x           | m80-200g-sfpdd+12-800g-qsfpdd-1x |    4     |    48    |
+|    sr-1-24d  | distributed |       cpm-1x           |        m24-800g-qsfpdd-1         |    4     |    48    |
+|    sr-1-48d  | distributed |       cpm-1x           |        m48-400g-qsfpdd-1         |    4     |    48    |
+|   sr-1x-48d  | distributed |       cpm-1x           |        m48-800g-qsfpdd-1x        |    4     |    48    |
 
 The variants are [defined in the code](https://github.com/hellt/vrnetlab/blob/bf70a9a9f2f060a68797a7ec29ce6aea96acb779/sros/docker/launch.py#L58) as a dictionary. If a variant you need is not in the table, use the `custom` variant and define the emulated platform yourself as described below.
 

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -492,7 +492,7 @@ SROS_VARIANTS = {
         "max_nics": 48,
         "cp": {
             "min_ram": 4,
-            "timos_line": "slot=A chassis=sr-1x-46s card=cpm-1x/i40-200g-sfpdd+6-800g-qsfpdd-1",  #CP Card must include CPM/IOM
+            "timos_line": "slot=A chassis=sr-1-46s card=cpm-1x/i40-200g-sfpdd+6-800g-qsfpdd-1",  #CP Card must include CPM/IOM
         },
         # line card (IOM/XCM)
         "lcs": [

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -484,20 +484,127 @@ SROS_VARIANTS = {
             },
         ],
     },
-    "sr-1x-48d": {
+### SR-1 FP5 models (six variants with sfp-dd or qsfpdd only): 
+    #SR-1 FP5 - CP Card must include CPM/IOM
+    "sr-1-46s": {
         "deployment_model": "distributed",
         # control plane (CPM)
         "max_nics": 48,
         "cp": {
             "min_ram": 4,
-            "timos_line": "slot=A chassis=sr-1x-48D card=cpm-1x",
+            "timos_line": "slot=A chassis=sr-1x-46s card=cpm-1x/i40-200g-sfpdd+6-800g-qsfpdd-1",  #CP Card must include CPM/IOM
         },
         # line card (IOM/XCM)
         "lcs": [
             {
                 "min_ram": 4,
                 **line_card_config(
-                    chassis="sr-1x-48D",
+                    chassis="sr-1-46s",
+                    card="i40-200g-sfpdd+6-800g-qsfpdd-1",
+                    mda="m40-200g-sfpdd+6-800g-qsfpdd-1",
+                ),
+            }
+        ],
+    },
+    #SR-1 FP5 - CP Card must include CPM/IOM
+    "sr-1-92s": {
+        "deployment_model": "distributed",
+        # control plane (CPM)
+        "max_nics": 48,
+        "cp": {
+            "min_ram": 4,
+            "timos_line": "slot=A chassis=sr-1-92s card=cpm-1x/i80-200g-sfpdd+12-400g-qsfpdd-1",   #CP Card must include CPM/IOM
+        },
+        # line card (IOM/XCM)
+        "lcs": [
+            {
+                "min_ram": 4,
+                **line_card_config(
+                    chassis="sr-1-92s",
+                    card="i80-200g-sfpdd+12-400g-qsfpdd-1",
+                    mda="m80-200g-sfpdd+12-400g-qsfpdd-1",
+                ),
+            }
+        ],
+    },
+    #SR-1 FP5 - CP Card must include CPM/IOM
+    "sr-1x-92s": {
+        "deployment_model": "distributed",
+        # control plane (CPM)
+        "max_nics": 48,
+        "cp": {
+            "min_ram": 4,
+            "timos_line": "slot=A chassis=sr-1x-92s card=cpm-1x/i80-200g-sfpdd+12-800g-qsfpdd-1x",   #CP Card must include CPM/IOM
+        },
+        # line card (IOM/XCM)
+        "lcs": [
+            {
+                "min_ram": 4,
+                **line_card_config(
+                    chassis="sr-1x-92s",
+                    card="i80-200g-sfpdd+12-800g-qsfpdd-1x",
+                    mda="m80-200g-sfpdd+12-800g-qsfpdd-1x",
+                ),
+            }
+        ],
+    },
+    #SR-1 FP5
+    "sr-1-24d": {
+        "deployment_model": "distributed",
+        # control plane (CPM)
+        "max_nics": 48,
+        "cp": {
+            "min_ram": 4,
+            "timos_line": "slot=A chassis=sr-1-24d card=cpm-1x",
+        },
+        # line card (IOM/XCM)
+        "lcs": [
+            {
+                "min_ram": 4,
+                **line_card_config(
+                    chassis="sr-1-24d",
+                    card="i24-800g-qsfpdd-1",
+                    mda="m24-800g-qsfpdd-1",
+                ),
+            }
+        ],
+    },
+    #SR-1 FP5
+    "sr-1-48d": {
+        "deployment_model": "distributed",
+        # control plane (CPM)
+        "max_nics": 48,
+        "cp": {
+            "min_ram": 4,
+            "timos_line": "slot=A chassis=sr-1-48D card=cpm-1x/i48-400g-qsfpdd-1",   #CP Card must include CPM/IOM
+        },
+        # line card (IOM/XCM)
+        "lcs": [
+            {
+                "min_ram": 4,
+                **line_card_config(
+                    chassis="sr-1-48D",
+                    card="i48-400g-qsfpdd-1",
+                    mda="m48-400g-qsfpdd-1",
+                ),
+            }
+        ],
+    },
+    #SR-1 FP5
+    "sr-1x-48d": {
+        "deployment_model": "distributed",
+        # control plane (CPM)
+        "max_nics": 48,
+        "cp": {
+            "min_ram": 4,
+            "timos_line": "slot=A chassis=sr-1x-48d card=cpm-1x",
+        },
+        # line card (IOM/XCM)
+        "lcs": [
+            {
+                "min_ram": 4,
+                **line_card_config(
+                    chassis="sr-1x-48d",
                     card="i48-800g-qsfpdd-1x",
                     mda="m48-800g-qsfpdd-1x",
                 ),


### PR DESCRIPTION
Add the SR-1 FP5 models:
•	SR-1-46S
•	SR-1-92S
•	SR-1x-92S
•	SR-1-24D
•	SR-1-48D
•	SR-1x-48D # => Already existing in vrnetlab

There are 6 versions of the SR-1 ranging in capacity from 2.4T FD to 4.8T FD using either one or two FP5 complexes
There are 3 versions of platform focussed on QSFP-DD 800 only (ends with D)
There are 3 versions of platform focussed on high-density 100G SFP-DD and QSFP-DD 800 (end with S)


