### PR TITLE
Version specific config for SR OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ venv
 # Still allow for the common python scripts
 !common/healthcheck.py
 !common/vrnetlab.py
+
+.envrc

--- a/dev-notes.md
+++ b/dev-notes.md
@@ -1,0 +1,11 @@
+# Developer notes
+
+## vrnetlab module and vscode pylance
+
+since vrnetlab module is in the `common` dir the pylance extension in vscode will not be able to find the module reference in `launch.py` files. To fix this, add the following to the `settings.json` file in vscode:
+
+```json
+{
+    "python.analysis.extraPaths": ["common"]
+}
+```

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -632,7 +632,6 @@ SROS_CL_COMMON_CFG = """
 /configure system name {name}
 /configure system security profile \"administrative\" netconf base-op-authorization lock
 /configure system login-control ssh inbound-max-sessions 30
-/configure system management-interface yang-modules nokia-combined-modules
 /configure system management-interface yang-modules no base-r13-modules
 /configure system netconf auto-config-save
 /configure system netconf no shutdown
@@ -664,6 +663,7 @@ SROS_MD_COMMON_CFG = """
 /configure system grpc allow-unsecure-connection
 /configure system grpc gnmi auto-config-save true
 /configure system grpc rib-api admin-state enable
+/configure system management-interface netconf auto-config-save true
 /configure system management-interface snmp packet-size 9216
 /configure system management-interface snmp streaming admin-state enable
 /configure system security user-params local-user user "admin" access console true
@@ -682,20 +682,20 @@ def return_specific_cfg(release):
     if release <= 20:
         return """
 /configure system management-interface yang-modules no nokia-modules
+/configure system management-interface yang-modules nokia-combined-modules
 """
     elif release <= 22:
         return """
 /configure system management-interface yang-modules no nokia-submodules
+/configure system management-interface yang-modules nokia-combined-modules
 """
-    elif release > 22: 
+    elif release > 22 and release < 24:
         return """
 /configure system management-interface netconf admin-state enable
-/configure system management-interface netconf auto-config-save true
 """
     else:
         return """
-/configure system management-interface listen netconf admin-state enable
-/configure system management-interface listen netconf auto-config-save true
+/configure system management-interface netconf listen admin-state enable
 """
 
 # to allow writing config to tftp location we needed to spin up a normal

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -689,7 +689,7 @@ def return_specific_cfg(release):
 /configure system management-interface yang-modules no nokia-submodules
 /configure system management-interface yang-modules nokia-combined-modules
 """
-    elif release > 22 and release < 24:
+    elif 22 < release < 24:
         return """
 /configure system management-interface netconf admin-state enable
 """

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -8,7 +8,6 @@ import shutil
 import signal
 import sys
 from dataclasses import dataclass
-from collections import defaultdict
 from typing import Dict
 
 import vrnetlab

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -674,9 +674,10 @@ SROS_MD_COMMON_CFG = """
 /configure system security snmp community "public" version v2c
 """
 
-# in release 24 SR OS introduced an extra container "listen" in the netconf 
+
+# in release 24 SR OS introduced an extra container "listen" in the netconf
 # container. As both release 23 and 24 will continue to be fairly widely used
-# an adaptation has to be made to be able to generate both images along with the 
+# an adaptation has to be made to be able to generate both images along with the
 # appropriate configuration for netconf to be enabled
 def return_specific_cfg(release):
     if release <= 20:
@@ -697,6 +698,7 @@ def return_specific_cfg(release):
         return """
 /configure system management-interface netconf listen admin-state enable
 """
+
 
 # to allow writing config to tftp location we needed to spin up a normal
 # tftp server in container host system. To access the host from qemu VM
@@ -1497,7 +1499,6 @@ def getDefaultConfig() -> str:
     """
     if SROS_VERSION.major <= 22:
         return SROS_CL_COMMON_CFG + return_specific_cfg(SROS_VERSION.major)
-
 
     return SROS_MD_COMMON_CFG + return_specific_cfg(SROS_VERSION.major)
 

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -632,9 +632,10 @@ SROS_CL_COMMON_CFG = """
 /configure system name {name}
 /configure system security profile \"administrative\" netconf base-op-authorization lock
 /configure system login-control ssh inbound-max-sessions 30
-/configure system management-interface yang-modules no nokia-modules
 /configure system management-interface yang-modules nokia-combined-modules
 /configure system management-interface yang-modules no base-r13-modules
+/configure system netconf auto-config-save
+/configure system netconf no shutdown
 /configure system grpc allow-unsecure-connection
 /configure system grpc gnmi auto-config-save
 /configure system grpc gnmi no shutdown
@@ -678,10 +679,13 @@ SROS_MD_COMMON_CFG = """
 # an adaptation has to be made to be able to generate both images along with the 
 # appropriate configuration for netconf to be enabled
 def return_specific_cfg(release):
-    if release <= 22:
-        """
-/configure system netconf auto-config-save
-/configure system netconf no shutdown
+    if release <= 20:
+        return """
+/configure system management-interface yang-modules no nokia-modules
+"""
+    elif release <= 22:
+        return """
+/configure system management-interface yang-modules no nokia-submodules
 """
     elif release > 22: 
         return """


### PR DESCRIPTION
With release 24, a listen container is added to the netconf container under management-interface. To accommodate this and not break functionality with older releases, add some function that generates different base configurations depending on which release is being used.

Tested with SROS releases 20.10.R13, 21.10.R13, 22.7.R2, 23.7.R2 and 24.3.R1.


