### PR TITLE
run SR OS tftp server as a root user 

### DIFF
--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1539,7 +1539,7 @@ if __name__ == "__main__":
             "in.tftpd",
             "--listen",
             "--user",
-            "tftp",
+            "root",
             "-a",
             "0.0.0.0:69",
             "-s",


### PR DESCRIPTION
A dirty workaround for potential permissions issue rooted in the fact that originally tftp server that hosts the SR OS config was run by the `tftp` user wity uid/gid = 103/106.

This caused access issues on _some_ installations where SR OS was not able to save the config due to permissions error -- more in this [discord thread](https://discord.com/channels/860500297297821756/1228455734585589892).
It appears to be that the issue is amplifed by the File ACLs added in containerlab some time ago. 

The file ACLs for the tftboot dir are as follows:

```
root@sros:/# getfacl /tftpboot/
getfacl: Removing leading '/' from absolute path names
# file: tftpboot/
# owner: root
# group: root
user::rwx
user:1000:rwx
group::r-x
group:1000:r-x
mask::rwx
other::rwx
default:user::rwx
default:user:1000:rwx
default:group::r-x
default:group:1000:r-x
default:mask::rwx
default:other::r-x
```

It is not clear why these facls were a problem for some deployments, as I couldn't reproduce it on my VMs.

As a quick workaround the user has been changed from the `tftp` to `root` in the tftp server launch command, this should prevent potential access issues.