### PR TITLE
Dell OS10: update for newer versions

### DIFF
--- a/ftosv/README.md
+++ b/ftosv/README.md
@@ -198,8 +198,9 @@ OS10 login: admin
 Password:      
 ```
 
-5. Once the image is built, you can shutdown the qemu-system host as the image has been built. With 10.5.2.4, it creates an image of approximately 7G.
-6. Next is to convert from vmdk to qcow2.
+5. After the login (username: *admin*, password: *admin*), once the system is ready and the prompt appears, you need to **stop ztd** with the command `ztd cancel`. Then, `write memory` and `reload`.
+6. Once the reload is completed, you can shutdown the qemu-system host as the image has been built. With 10.5.2.4, it creates an image of approximately 7G.
+7. Next is to convert from vmdk to qcow2.
 
 ```bash
 qemu-img convert -f vmdk -O qcow2 OS10-Disk-1.0.0.vmdk dellftos.{VERSION}.qcow2
@@ -231,5 +232,5 @@ NOTE:
 
 * CPU: 4 core
 * RAM: 4GB
-* Disk: <5GB
+* Disk: <10GB
 

--- a/ftosv/docker/launch.py
+++ b/ftosv/docker/launch.py
@@ -146,7 +146,7 @@ class FTOS_vm(vrnetlab.VM):
         self.logger.info("applying bootstrap configuration once system is ready")
         self.wait_write("", None)
 
-        self.wait_write("configure", wait="System is ready!!")
+        self.wait_write("configure", wait="OS10#")
         self.wait_write(f"hostname {self.hostname}")
         self.wait_write("service simple-password")
         self.wait_write(


### PR DESCRIPTION
Newer versions of Dell OS10 have a different *system ready* prompt.

Additionally, it is required to disable ZTD on first boot.
