### PR TITLE
Patch for version bug in VMX_vfpc outlined in https://github.com/hellt/vrnetlab/issues/192

### DIFF
--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -256,7 +256,7 @@ class VMX_vcp(vrnetlab.VM):
 class VMX_vfpc(vrnetlab.VM):
     def __init__(self, version, conn_mode):
         super(VMX_vfpc, self).__init__(None, None, disk_image="/vmx/vfpc.img", num=1)
-        self.version = version
+        self.junos_version = version
         self.num_nics = 96
 
         self.nic_type = "virtio-net-pci"
@@ -289,7 +289,7 @@ class VMX_vfpc(vrnetlab.VM):
             ["-netdev", "tap,ifname=vfpc-int,id=vfpc-int,script=no,downscript=no"]
         )
 
-        if self.version not in ("vmx-14.1R6.4"):
+        if self.junos_version not in ("vmx-14.1R6.4"):
             # dummy interface for some vMX versions - not sure why vFPC wants
             # it but without it we get a misalignment
             res.extend(


### PR DESCRIPTION
Issue outlined in: https://github.com/hellt/vrnetlab/issues/192

I have tested this on new vMX images, and it works.

I am opting to re-name the `version` variable in the `VMX_vfpc` class to `junos_version`, which will fix the bug of unintentionally trying to set the getter property in the `vrnetlab.VM` superclass, while maintaining backwards compatibility with the if clause for 14.1R6.4.

We cannot simply use the getter property, as the environment variable is not set by default, causing an exception. I also am not 100% sure whether that is meant to be the same value as the image running, or a different version value.