### PR TITLE
Fix vQFX custom version handling

### DIFF
--- a/vqfx/docker/launch.py
+++ b/vqfx/docker/launch.py
@@ -3,9 +3,9 @@
 import datetime
 import logging
 import os
+import re
 import signal
 import sys
-import re
 
 import vrnetlab
 
@@ -45,7 +45,10 @@ class VQFX_vcp(vrnetlab.VM):
         self.num_nics = 12
         self.conn_mode = conn_mode
         self.hostname = hostname
-        self.version = version
+        # _version is a custom version dict that has major and minor version components
+        # while the self.version is a version @property of the common.VM class that reads
+        # the value from the env var.
+        self._version = version
 
     def start(self):
         # use parent class start() function
@@ -93,7 +96,7 @@ class VQFX_vcp(vrnetlab.VM):
         # logged_in_prompt prompt for v20+ versions
         logged_in_prompt = b"root@:RE:0%"
 
-        if self.version["major"] < 20:
+        if self._version["major"] < 20:
             logged_in_prompt = b"root@vqfx-re:RE:0%"
 
         (ridx, match, res) = self.tn.expect([b"login:", logged_in_prompt], 1)
@@ -103,7 +106,7 @@ class VQFX_vcp(vrnetlab.VM):
                 self.wait_write("root", wait=None)
 
                 # v19 has Juniper password for root login
-                if self.version["major"] < 20:
+                if self._version["major"] < 20:
                     self.wait_write("Juniper", wait="Password:")
             if ridx == 1:
                 # run main config!


### PR DESCRIPTION
The vqfx platform uses a custom version that messes up with the vrnetlab.VM property attribute which has a function getter.
To temporary resolve this clash a new var name is locally declared.

Similar to #193 