### PR TITLE
probably  a useless tinkering with the c8000v install process

### DIFF
--- a/c8000v/README.md
+++ b/c8000v/README.md
@@ -42,14 +42,11 @@ it to your repo. The tag is the same as the version of the Catalyst 8000v image,
 so if you have c8000v-universalk9.16.04.01.qcow2 your final docker image will be
 called `vr-c8000v:16.04.01`
 
-Please note that you will always need to specify version when starting your
-router as the "latest" tag is not added to any images since it has no meaning
-in this context.
-
 It's been tested to boot and respond to SSH with:
 
 - 16.03.01a (c8000v-universalk9.16.03.01a.qcow2)
 - 16.04.01 (c8000v-universalk9.16.04.01.qcow2)
+- 17.11.01a (c8000v-universalk9_16G_serial.17.11.01a.qcow2)
 
 ## Usage
 
@@ -104,3 +101,18 @@ only has an expiration date not a start date.
 
 The license unlocks feature and throughput. The default throughput for C8000v is
 20Mbit/s which is perfectly for basic management and testing.
+
+## Known issues
+
+If during the image boot process (not during the install process) you notice messages like:
+
+```
+% Failed to initialize nvram
+% Failed to initialize backup nvram
+```
+
+Then the image will boot, but SSH might not work. You still can use telnet to access the running VM. For instance:
+
+```bash
+telnet <container name> 5000
+```

--- a/c8000v/docker/Dockerfile
+++ b/c8000v/docker/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update -qy \
  && apt-get install -y \
     bridge-utils \
     iproute2 \
-    python3-ipy \
     socat \
     qemu-kvm \
     tcpdump \

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -52,12 +52,12 @@ class C8000v_vm(vrnetlab.VM):
             logger.info("License found")
             self.license = True
 
-        super(C8000v_vm, self).__init__(username, password, disk_image=disk_image)
-        self.nic_type = "vmxnet3"
+        super().__init__(username, password, disk_image=disk_image, ram=4096)
         self.install_mode = install_mode
         self.hostname = hostname
         self.conn_mode = conn_mode
         self.num_nics = 9
+        self.nic_type = "virtio-net-pci"
 
         if self.install_mode:
             logger.trace("install mode")


### PR DESCRIPTION
I have been battling with c8000v image being rendered running but with no ssh access, the ssh just got established, hanged until timeout and disconnected.

I noticied, that this happens when during the image start, the following messages appear on the console

```
% Failed to initialize nvram
% Failed to initialize backup nvram
```

They do always appear in the install phase, but they appear _sometimes_ during the image start (with containerlab) and when they do, I experience the SSH issues.
Not sure how this related, but I have been increasing cpu and ram, to no avail.

Lastly I got the most succesfull runs with setting the virtio net interface, but likely it has nothing to do with the original issue. Will merge this in, but I almost sure that during the autocon1 workshop the issue will reappear somehow to screw things up :D