### PR TITLE
sros: fix distributed model (getMem, getCpu)

### DIFF
--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1229,8 +1229,8 @@ class SROS_cp(SROS_vm):
         # cp - control plane. role is used to create a separate overlay image name
         self.role = "cp"
 
-        ram: int = vrnetlab.getMem(self.role, variant.get("cp").get("min_ram"))
-        cpu: int = vrnetlab.getCpu(self.role, variant.get("cp").get("cpu"))
+        ram: int = getMem(self.role, variant.get("cp").get("min_ram"))
+        cpu: int = getCpu(self.role, variant.get("cp").get("cpu"))
         slot: str = variant.get("cp").get("slot")
 
         super(SROS_cp, self).__init__(
@@ -1303,8 +1303,8 @@ class SROS_lc(SROS_vm):
         # role lc if for a line card. role is used to create a separate overlay image name
         self.role = "lc"
 
-        ram: int = vrnetlab.getMem(self.role, lc_config.get("min_ram"))
-        cpu: int = vrnetlab.getCpu(self.role, lc_config.get("cpu"))
+        ram: int = getMem(self.role, lc_config.get("min_ram"))
+        cpu: int = getCpu(self.role, lc_config.get("cpu"))
 
         super(SROS_lc, self).__init__(
             None,


### PR DESCRIPTION
Commit 249b3ca broken SROS distributed model deployment.
 
```
Traceback (most recent call last):
  File "/launch.py", line 1659, in <module>
    ia = SROS(
         ^^^^^
  File "/launch.py", line 1407, in __init__
    SROS_cp(
  File "/launch.py", line 1232, in __init__
    ram: int = vrnetlab.getMem(self.role, variant.get("cp").get("min_ram"))
```

There was a change related to getMem and getCpu functions, but only integrated model references were updated.
This updates remaining references for the distributed model case.