### PR TITLE
Add interface aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The documentation provided in this fork only explains the parts that have been c
 ## What is this fork about?
 At [containerlab](https://containerlab.srlinux.dev) we needed to have [a way to run virtual routers](https://containerlab.srlinux.dev/manual/vrnetlab/) alongside the containerized Network Operating Systems.
 
-Vrnetlab provides a perfect machinery to package most-common routing VMs in the container packaging. What upstream vrnetlab doesn't do, though, is creating datapath between the VMs in a "container-native" way.
+Vrnetlab provides a perfect machinery to package most-common routing VMs in the container packaging. What upstream vrnetlab doesn't do, though, is creating datapath between the VMs in a "container-native" way.  
 Vrnetlab relies on a separate VM (vr-xcon) to stich sockets exposed on each container and that doesn't play well with the regular ways of interconnecting container workloads.
 
 This fork adds additional option for `launch.py` script of the supported VMs called `connection-mode`. This option allows to choose the way vrnetlab will create datapath for the launched VMs.
@@ -19,7 +19,7 @@ Yes, the term is bloated, what it actually means is that with the changes we mad
 
 With this you can just add, say, veth pairs between the containers as you would do normally, and vrnetlab will make sure that these ports get mapped to your router' ports. In essence, that allows you to work with your vrnetlab containers like with a normal container and get the datapath working in the same "native" way.
 
-> Although the changes we made here are of a general purpose and you can run vrnetlab routers with docker CLI or any other container runtime, the purpose of this work was to couple vrnetlab with containerlab.
+> Although the changes we made here are of a general purpose and you can run vrnetlab routers with docker CLI or any other container runtime, the purpose of this work was to couple vrnetlab with containerlab.  
 > With this being said, we recommend the readers to start their journey from this [documentation entry](https://containerlab.srlinux.dev/manual/vrnetlab/) which will show you how easy it is to run routers in a containerized setting.
 
 ## Connection modes

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The documentation provided in this fork only explains the parts that have been c
 ## What is this fork about?
 At [containerlab](https://containerlab.srlinux.dev) we needed to have [a way to run virtual routers](https://containerlab.srlinux.dev/manual/vrnetlab/) alongside the containerized Network Operating Systems.
 
-Vrnetlab provides a perfect machinery to package most-common routing VMs in the container packaging. What upstream vrnetlab doesn't do, though, is creating datapath between the VMs in a "container-native" way.  
+Vrnetlab provides a perfect machinery to package most-common routing VMs in the container packaging. What upstream vrnetlab doesn't do, though, is creating datapath between the VMs in a "container-native" way.
 Vrnetlab relies on a separate VM (vr-xcon) to stich sockets exposed on each container and that doesn't play well with the regular ways of interconnecting container workloads.
 
 This fork adds additional option for `launch.py` script of the supported VMs called `connection-mode`. This option allows to choose the way vrnetlab will create datapath for the launched VMs.
@@ -19,13 +19,15 @@ Yes, the term is bloated, what it actually means is that with the changes we mad
 
 With this you can just add, say, veth pairs between the containers as you would do normally, and vrnetlab will make sure that these ports get mapped to your router' ports. In essence, that allows you to work with your vrnetlab containers like with a normal container and get the datapath working in the same "native" way.
 
-> Although the changes we made here are of a general purpose and you can run vrnetlab routers with docker CLI or any other container runtime, the purpose of this work was to couple vrnetlab with containerlab.  
+> Although the changes we made here are of a general purpose and you can run vrnetlab routers with docker CLI or any other container runtime, the purpose of this work was to couple vrnetlab with containerlab.
 > With this being said, we recommend the readers to start their journey from this [documentation entry](https://containerlab.srlinux.dev/manual/vrnetlab/) which will show you how easy it is to run routers in a containerized setting.
 
 ## Connection modes
 As mentioned above, the major change this fork brings is the ability to run vrnetlab containers without requiring vr-xcon and by using container-native networking.
 
 The default option that we use in containerlab for this setting is `connection-mode=tc`. With this particular mode we use tc-mirred redirects to stitch container's interfaces `eth1+` with the ports of the qemu VM running inside.
+
+vrnetlab also recognizes interface aliases, which, to the limitations of the Linux kernel and the definition found in each supported virtual appliance's definition, allows for the usage of matching interface names on the container side. One important limitation is the inability to use forward slash `/` (substituted with `-`) and whitespace (omitted) characters in container interface names (e.g. `GigabitEthernet 0/1` becomes `GigabitEthernet0-1`). For ease of use, interface aliases are handled case-insensitive by vrnetlab.
 
 ![tc](https://gitlab.com/rdodin/pics/-/wikis/uploads/4d31c06e6258e70edc887b17e0e758e0/image.png)
 

--- a/aoscx/README.md
+++ b/aoscx/README.md
@@ -13,6 +13,8 @@ The image will be tagged with the timestamp present in the vmdk file. Optionally
 docker tag vrnetlab/vr-aoscx:20210610000730 vrnetlab/vr-aoscx:10.07.0010
 ```
 
+The interface alias format supported on this image is `1-1-X`, where X is the port number.
+
 Tested booting and responding to SSH:
 
 * `ArubaOS-CX_10_12_0006.ova` (`arubaoscx-disk-image-genericx86-p4-20230531220439.vmdk`)

--- a/aoscx/docker/launch.py
+++ b/aoscx/docker/launch.py
@@ -51,8 +51,12 @@ class AOSCX_vm(vrnetlab.VM):
         )
         self.hostname = hostname
         self.conn_mode = conn_mode
+
         self.num_nics = 20
         self.nic_type = "virtio-net-pci"
+        self.interface_alias_regexp = r"1-1-(?P<port>\d+)"
+        # Data numbering starts at port 1 (1-1-1)
+        self.interface_alias_offset = 1
 
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""

--- a/asav/README.md
+++ b/asav/README.md
@@ -41,6 +41,8 @@ Management0/0 is always configured as a management interface.
 | GigabitEthernet0/6  | 7       |
 | GigabitEthernet0/7  | 8       |
 
+The interface alias format supported on this image is `GigabitEthernet0-X`, where X is the port number. `GigabitEthernet` can also be shortened to `Gi`.
+
 System requirements
 -------------------
 CPU: 1 core
@@ -52,4 +54,4 @@ Disk: <500MB
 FUAQ - Frequently or Unfrequently Asked Questions
 -------------------------------------------------
 ##### Q: Has this been extensively tested?
-A: Nope. 
+A: Nope.

--- a/asav/docker/launch.py
+++ b/asav/docker/launch.py
@@ -46,8 +46,12 @@ class ASAv_vm(vrnetlab.VM):
             username, password, disk_image=disk_image, ram=2048
         )
         self.nic_type = "e1000"
-        self.install_mode = install_mode
         self.num_nics = 8
+        self.interface_alias_regexp = r"(?:Gi|GigabitEthernet)0-(?P<port>\d+)"
+        # Data interface numbering starts at port 0 (Gi0-0)
+        self.interface_alias_offset = 0
+
+        self.install_mode = install_mode
 
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""

--- a/c8000v/README.md
+++ b/c8000v/README.md
@@ -78,6 +78,8 @@ The following images have been verified to NOT exhibit this behavior
 |   Gi10    |    8    |
 |   Gi11    |    9    |
 
+The interface alias format supported on this image is `GigabitEthernetX`, where X is the port number, and `X = 1` is reserved for the management interface. `GigabitEthernet` can also be shortened to `Gi`.
+
 ## System requirements
 
 CPU: 1 core

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -56,8 +56,12 @@ class C8000v_vm(vrnetlab.VM):
         self.install_mode = install_mode
         self.hostname = hostname
         self.conn_mode = conn_mode
+
         self.num_nics = 9
         self.nic_type = "virtio-net-pci"
+        self.interface_alias_regexp = r"(?:Gi|GigabitEthernet)(?P<port>\d+)"
+        # Data interface numbering starts at port 2 (Gi2)
+        self.interface_alias_offset = 2
 
         if self.install_mode:
             self.logger.trace("install mode")

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -49,7 +49,7 @@ class C8000v_vm(vrnetlab.VM):
 
         self.license = False
         if os.path.isfile("/tftpboot/license.lic"):
-            logger.info("License found")
+            self.logger.info("License found")
             self.license = True
 
         super().__init__(username, password, disk_image=disk_image, ram=4096)
@@ -60,7 +60,7 @@ class C8000v_vm(vrnetlab.VM):
         self.nic_type = "virtio-net-pci"
 
         if self.install_mode:
-            logger.trace("install mode")
+            self.logger.trace("install mode")
             self.image_name = "config.iso"
             self.create_boot_image()
 
@@ -134,7 +134,7 @@ class C8000v_vm(vrnetlab.VM):
                     self.running = True
                     return
                 else:
-                    self.log.warning("Unexpected reload while running")
+                    self.logger.warning("Unexpected reload while running")
 
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 import telnetlib
 import time
-from pathlib import Path
 
 MAX_RETRIES = 60
 

--- a/csr/README.md
+++ b/csr/README.md
@@ -25,7 +25,7 @@ Put the .qcow2 file in this directory and run `make docker-image` and
 you should be good to go. The resulting image is called `vrnetlab\vr-csr`. You can tag
 it with something else if you want, like `my-repo.example.com/vr-csr` and then
 push it to your repo. The tag is the same as the version of the CSR image, so
-if you have `csr1000v-universalk9.17.04.03-serial.qcow2` your final docker image will be
+if you have `csr1000v-universalk9.17.04.03-serial.qcow2` your final docker image will be 
 called `vrnetlab\vr-csr:17.07.03`
 
 Please note that you will always need to specify version when starting your
@@ -77,4 +77,4 @@ with a fairly large configuration.
 FUAQ - Frequently or Unfrequently Asked Questions
 -------------------------------------------------
 ##### Q: Has this been extensively tested?
-A: Nope.
+A: Nope. 

--- a/csr/README.md
+++ b/csr/README.md
@@ -25,7 +25,7 @@ Put the .qcow2 file in this directory and run `make docker-image` and
 you should be good to go. The resulting image is called `vrnetlab\vr-csr`. You can tag
 it with something else if you want, like `my-repo.example.com/vr-csr` and then
 push it to your repo. The tag is the same as the version of the CSR image, so
-if you have `csr1000v-universalk9.17.04.03-serial.qcow2` your final docker image will be 
+if you have `csr1000v-universalk9.17.04.03-serial.qcow2` your final docker image will be
 called `vrnetlab\vr-csr:17.07.03`
 
 Please note that you will always need to specify version when starting your
@@ -45,7 +45,9 @@ docker run -d --privileged --name my-csr-router vrnetlab/vr-csr
 Interface mapping
 -----------------
 IOS XE 17.03.02 supports a maximum of 26 interfaces, GigabitEthernet1 is always configured
-as a management interface leaving upto 25 interfaces for traffic. 
+as a management interface leaving upto 25 interfaces for traffic.
+
+The interface alias format supported on this image is `GigabitEthernetX`, where X is the port number, and `X = 1` is reserved for the management interface. `GigabitEthernet` can also be shortened to `Gi`.
 
 System requirements
 -------------------
@@ -75,4 +77,4 @@ with a fairly large configuration.
 FUAQ - Frequently or Unfrequently Asked Questions
 -------------------------------------------------
 ##### Q: Has this been extensively tested?
-A: Nope. 
+A: Nope.

--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -51,7 +51,7 @@ class CSR_vm(vrnetlab.VM):
 
         self.license = False
         if os.path.isfile("/tftpboot/license.lic"):
-            logger.info("License found")
+            self.logger.info("License found")
             self.license = True
 
         super(CSR_vm, self).__init__(username, password, disk_image=disk_image)
@@ -63,7 +63,7 @@ class CSR_vm(vrnetlab.VM):
         self.nic_type = "virtio-net-pci"
 
         if self.install_mode:
-            logger.trace("install mode")
+            self.logger.trace("install mode")
             self.image_name = "config.iso"
             self.create_boot_image()
 

--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -57,10 +57,14 @@ class CSR_vm(vrnetlab.VM):
         super(CSR_vm, self).__init__(username, password, disk_image=disk_image)
 
         self.install_mode = install_mode
-        self.num_nics = nics
         self.hostname = hostname
         self.conn_mode = conn_mode
+
+        self.num_nics = nics
         self.nic_type = "virtio-net-pci"
+        self.interface_alias_regexp = r"(?:Gi|GigabitEthernet)(?P<port>\d+)"
+        # Data interface numbering starts at port 2 (Gi2)
+        self.interface_alias_offset = 2
 
         if self.install_mode:
             self.logger.trace("install mode")

--- a/fortigate/README.md
+++ b/fortigate/README.md
@@ -9,6 +9,8 @@ Naming format: fortios-vX.Y.Z.qcow2
 
 `make`
 
+The interface alias format supported on this image is `portX`, where X is the port number, and `X = 1` is reserved for the management interface.
+
 ## Running the docker image manually
 
 If you need to run the image without using containerlab:

--- a/fortigate/docker/launch.py
+++ b/fortigate/docker/launch.py
@@ -52,12 +52,18 @@ class FortiOS_vm(vrnetlab.VM):
         )
         self.conn_mode = conn_mode
         self.hostname = hostname
+
         self.num_nics = 12
         self.nic_type = "virtio-net-pci"
         self.highest_port = 0
+        self.interface_alias_regexp = r"port(?P<port>\d+)"
+        # Data interface numbering starts at port 2 (port2)
+        self.interface_alias_offset = 2
+
         self.qemu_args.extend(["-uuid", str(uuid.uuid4())])
         self.spins = 0
         self.running = None
+
 
         # set up the extra empty disk image
         # for fortigate logs

--- a/freebsd/README.md
+++ b/freebsd/README.md
@@ -43,10 +43,12 @@ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' <con
 
 ## Interface mapping
 
-Interface `vtnet0` is always configured as a management interface. Interfaces `vtnet1` to `vio16` can be used for data plane.
+Interface `vtnet0` is always configured as a management interface. Interfaces `vtnet1` to `vtnet16` can be used for data plane.
+
+The interface alias format supported on this image is `vtnetX`, where X is the port number, and `X = 0` is reserved for the management interface.
 
 ## System requirements
 
-CPU: 1 core  
-RAM: 512MB  
+CPU: 1 core
+RAM: 512MB
 DISK: 4.0GB

--- a/freebsd/docker/launch.py
+++ b/freebsd/docker/launch.py
@@ -57,9 +57,13 @@ class FreeBSD_vm(vrnetlab.VM):
         )
 
         self.num_nics = nics
+        self.nic_type = "virtio-net-pci"
+        self.interface_alias_regexp = r"vtnet(?P<port>\d+)"
+        # Data interface numbering starts at port 1 (vtnet1)
+        self.interface_alias_offset = 1
+
         self.hostname = hostname
         self.conn_mode = conn_mode
-        self.nic_type = "virtio-net-pci"
 
         self.image_name = "cloud_init.iso"
         self.create_boot_image()

--- a/ftdv/README.md
+++ b/ftdv/README.md
@@ -13,6 +13,8 @@ with the following images:
 
 * Cisco_Secure_Firewall_Threat_Defense_Virtual-7.2.5-208.qcow2
 
+The interface alias format supported on this image is `GigabitEthernet0-X`, where X is the port number. `GigabitEthernet` can also be shortened to `Gi`.
+
 ## Usage
 
 ```
@@ -41,6 +43,6 @@ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' <con
 
 ## System requirements
 
-CPU: 4 core  
-RAM: 8GB  
-Disk: 4.6GB (Thin Provision disk size is 48.24GB)  
+CPU: 4 core
+RAM: 8GB
+Disk: 4.6GB (Thin Provision disk size is 48.24GB)

--- a/ftdv/docker/launch.py
+++ b/ftdv/docker/launch.py
@@ -73,7 +73,7 @@ class FTDV_vm(vrnetlab.VM):
             ]
         )
         if self.install_mode:
-            logger.trace("install mode")
+            self.logger.trace("install mode")
             self.image_name = "day0.iso"
             self.create_boot_image()
             # mount config disk with day0-config base config

--- a/ftdv/docker/launch.py
+++ b/ftdv/docker/launch.py
@@ -38,7 +38,6 @@ logging.Logger.trace = trace
 
 
 class FTDV_vm(vrnetlab.VM):
-    
     # FIPS check fails without exposing cpu (ERROR: FIPS Self-Test failure,  fipsPostGFSboxKat)
     def __init__(
         self, hostname, username, password, nics, conn_mode, install_mode=False, smp="4,sockets=1,cores=4,threads=1"
@@ -54,10 +53,14 @@ class FTDV_vm(vrnetlab.VM):
         )
 
         self.install_mode = install_mode
-        self.num_nics = nics
         self.hostname = hostname
         self.conn_mode = conn_mode
+
+        self.num_nics = nics
         self.nic_type = "virtio-net-pci"
+        self.interface_alias_regexp = r"(?:Gi|GigabitEthernet)0-(?P<port>\d+)"
+        # Data interface numbering starts at port0 (GigabitEthernet0-0), no offset needed
+
         overlay_disk_image = re.sub(r"(\.[^.]+$)", r"-overlay\1", disk_image)
         # boot harddrive first
         self.qemu_args.extend(["-boot", "order=c"])

--- a/ftosv/docker/launch.py
+++ b/ftosv/docker/launch.py
@@ -52,11 +52,13 @@ class FTOS_vm(vrnetlab.VM):
         self.credentials = [["admin", "admin"]]
         self.hostname = hostname
         self.conn_mode = conn_mode
+
         # mgmt + 56 (S5248 platform) that show up in the vm, may as well populate them all in vrnetlab right away
         # max interface numbers depend on the qemu disk image of platform used.
         # available OS10 virtualization platform options: S4000,S4128,S5212,S5224,S5248,S6000,S6010
         self.num_nics = 56
         self.nic_type = "e1000"
+        # TODO: Interface aliases
 
         overlay_disk_image = re.sub(r"(\.[^.]+$)", r"-overlay\1", disk_image)
         # boot harddrive first

--- a/n9kv/README.md
+++ b/n9kv/README.md
@@ -5,11 +5,12 @@ This is the vrnetlab docker image for Cisco Nexus 9000v virtual switch.
 
 ## Building the docker image
 
-Put the .qcow2 file in this directory and run make docker-image and you should be good to go. The resulting image is 
-called vr-n9kv. You can tag it with something else if you want, like my-repo.example.com/vr-n9kv and then push it to 
-your repo. The tag is the same as the version of the NXOS image, so if you have nxosv.9.2.4.qcow2 your final docker 
+Put the .qcow2 file in this directory and run make docker-image and you should be good to go. The resulting image is
+called vr-n9kv. You can tag it with something else if you want, like my-repo.example.com/vr-n9kv and then push it to
+your repo. The tag is the same as the version of the NXOS image, so if you have nxosv.9.2.4.qcow2 your final docker
 image will be called vr-n9kv:9.2.4
 
+The interface alias format supported on this image is `Ethernet1-X`, where X is the port number. `Ethernet` can also be shortened to `Et`.
 
 ## System requirements
 

--- a/n9kv/README.md
+++ b/n9kv/README.md
@@ -5,9 +5,9 @@ This is the vrnetlab docker image for Cisco Nexus 9000v virtual switch.
 
 ## Building the docker image
 
-Put the .qcow2 file in this directory and run make docker-image and you should be good to go. The resulting image is
-called vr-n9kv. You can tag it with something else if you want, like my-repo.example.com/vr-n9kv and then push it to
-your repo. The tag is the same as the version of the NXOS image, so if you have nxosv.9.2.4.qcow2 your final docker
+Put the .qcow2 file in this directory and run make docker-image and you should be good to go. The resulting image is 
+called vr-n9kv. You can tag it with something else if you want, like my-repo.example.com/vr-n9kv and then push it to 
+your repo. The tag is the same as the version of the NXOS image, so if you have nxosv.9.2.4.qcow2 your final docker 
 image will be called vr-n9kv:9.2.4
 
 The interface alias format supported on this image is `Ethernet1-X`, where X is the port number. `Ethernet` can also be shortened to `Et`.

--- a/n9kv/docker/launch.py
+++ b/n9kv/docker/launch.py
@@ -52,9 +52,13 @@ class N9KV_vm(vrnetlab.VM):
         )
         self.hostname = hostname
         self.conn_mode = conn_mode
+
         # mgmt + 128 that show up in the vm, may as well populate them all in vrnetlab right away
         self.num_nics = 129
         self.nic_type = "e1000"
+        self.interface_alias_regexp = r"(?:Et|Ethernet)1-(?P<port>\d+)"
+        # Data interface numbering starts at port 1 (Ethernet1-1)
+        self.interface_alias_offset = 1
 
         # bios for n9kv
         self.qemu_args.extend(["-bios", "/OVMF.fd"])

--- a/nxos/README.md
+++ b/nxos/README.md
@@ -15,6 +15,8 @@ push it to your repo. The tag is the same as the version of the NXOS image, so
 if you have nxosv-7.2.0.D1.1.qcow2 your final docker image will be called
 vr-nxos:7.2.0.D1.1
 
+The interface alias format supported on this image is `Ethernet1-X`, where X is the port number. `Ethernet` can also be shortened to `Et`.
+
 Usage
 -----
 ```

--- a/nxos/docker/launch.py
+++ b/nxos/docker/launch.py
@@ -50,6 +50,10 @@ class NXOS_vm(vrnetlab.VM):
         self.hostname = hostname
         self.conn_mode = conn_mode
 
+        self.interface_alias_regexp = r"(?:Et|Ethernet)1-(?P<port>\d+)"
+        # Data interface numbering starts at port 1 (Ethernet1-1)
+        self.interface_alias_offset = 1
+
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""
 

--- a/ocnos/docker/launch.py
+++ b/ocnos/docker/launch.py
@@ -51,9 +51,10 @@ class OCNOS_vm(vrnetlab.VM):
         )
         self.hostname = hostname
         self.conn_mode = conn_mode
+
         self.num_nics = 8
         self.nic_type = "virtio-net-pci"
-
+        # TODO: Interface aliases
 
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""

--- a/openbsd/README.md
+++ b/openbsd/README.md
@@ -49,6 +49,6 @@ The interface alias format supported on this image is `vioX`, where X is the por
 
 ## System requirements
 
-CPU: 1 core
-RAM: 512MB
+CPU: 1 core  
+RAM: 512MB  
 DISK: 4.0GB

--- a/openbsd/README.md
+++ b/openbsd/README.md
@@ -45,8 +45,10 @@ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' <con
 
 Interface `vio0` is always configured as a management interface. Interfaces `vio1` to `vio17` can be used for data plane.
 
+The interface alias format supported on this image is `vioX`, where X is the port number, and `X = 0` is reserved for the management interface.
+
 ## System requirements
 
-CPU: 1 core  
-RAM: 512MB  
+CPU: 1 core
+RAM: 512MB
 DISK: 4.0GB

--- a/openbsd/docker/launch.py
+++ b/openbsd/docker/launch.py
@@ -56,10 +56,14 @@ class OpenBSD_vm(vrnetlab.VM):
             username, password, disk_image=disk_image, ram=512
         )
 
-        self.num_nics = nics
         self.hostname = hostname
         self.conn_mode = conn_mode
+
+        self.num_nics = nics
         self.nic_type = "virtio-net-pci"
+        self.interface_alias_regexp = r"vio(?P<port>\d+)"
+        # Data interface numbering starts at port 1 (vio1)
+        self.interface_alias_offset = 1
 
         self.image_name = "cloud_init.iso"
         self.create_boot_image()

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -25,6 +25,8 @@ your final docker image will be called vr-openwrt:15.05.
 As per OpenWRT defaults, `br-lan`(`eth0`) is the LAN interface and `eth1` the
 WAN interface.
 
+The interface alias format supported on this image is `wan`.
+
 Tested booting and responding to SSH:
 * openwrt-23.05.3-x86-64-generic-ext4-combined.img 818f6ba04103915ad53f2d003c42aa84
 * openwrt-15.05.1-x86-64-combined-ext4.img   MD5:307d8cdb11faeb1b5e27fe55078bd152

--- a/openwrt/docker/launch.py
+++ b/openwrt/docker/launch.py
@@ -34,12 +34,19 @@ class OpenWRT_vm(vrnetlab.VM):
             if re.search(".img$", e):
                 disk_image = "/" + e
         super(OpenWRT_vm, self).__init__(username, password, disk_image=disk_image, ram=128)
-        self.nic_type = "virtio-net-pci"
-        self.num_nics = 1
         self.conn_mode=conn_mode
         self.hostname=hostname
         self.lan_ip=lan_ip
         self.lan_netmask=lan_netmask
+
+        self.nic_type = "virtio-net-pci"
+        self.num_nics = 1
+        self.interface_alias_regexp = r"wan"
+        # Data interface numbering offset does not apply
+
+    def calculate_interface_offset(self, intf):
+        """ Always return 1, since only a single wan interface is provisioned. """
+        return 1
 
     def bootstrap_spin(self):
         """ This function should be called periodically to do work.
@@ -126,7 +133,7 @@ def args(tracing,username,password,connection_mode,hostname,lan_ip,lan_netmask):
         logger.setLevel(logging.DEBUG)
         if tracing:
             logger.setLevel(1)
-        
+
         vr = OpenWRT(username, password, connection_mode, hostname, lan_ip, lan_netmask)
         vr.start()
 
@@ -143,10 +150,3 @@ if __name__ == '__main__':
     #     help="Connection mode to use in the datapath",
     # )
     # args = parser.parse_args()
-    
-
-
-    
-
-    
-

--- a/pan/README.md
+++ b/pan/README.md
@@ -8,7 +8,7 @@ This is the vrnetlab docker image for Palo Alto PA-VM firewalls.
 Download PA-VM in KVM/qcow2 format from the Palo Alto website (you will need a login/access).
 Place the .qcow2 file in this directory and run make. The resulting images is called `vrnetlab/vr-pan:VERSION`. You can
 tag it with something else if you want, like `my-repo.example.com/vr-pan` and
-then push it to your repo.
+then push it to your repo. 
 
 It's been tested to boot, respond to SSH and have correct interface mapping
 with the following images:

--- a/pan/README.md
+++ b/pan/README.md
@@ -8,7 +8,7 @@ This is the vrnetlab docker image for Palo Alto PA-VM firewalls.
 Download PA-VM in KVM/qcow2 format from the Palo Alto website (you will need a login/access).
 Place the .qcow2 file in this directory and run make. The resulting images is called `vrnetlab/vr-pan:VERSION`. You can
 tag it with something else if you want, like `my-repo.example.com/vr-pan` and
-then push it to your repo. 
+then push it to your repo.
 
 It's been tested to boot, respond to SSH and have correct interface mapping
 with the following images:
@@ -17,6 +17,7 @@ with the following images:
  * PA-VNM-KVM-9.1.9.qcow2
  * PA-VNM-KVM-10.0.6.qcow2
 
+The interface alias format supported on this image is `Ethernet1-X`, where X is the port number.
 
 ## System requirements
 

--- a/pan/docker/launch.py
+++ b/pan/docker/launch.py
@@ -53,9 +53,14 @@ class PAN_vm(vrnetlab.VM):
         )
         self.hostname = hostname
         self.conn_mode = conn_mode
+
         # mgmt + 24 that show up in the vm, may as well populate them all in vrnetlab right away
         self.num_nics = 25
         self.nic_type = "virtio-net-pci"
+        self.interface_alias_regexp = r"Ethernet1-(?P<port>\d+)"
+        # Data interface numbering starts at port 1 (Ethernet1-1)
+        self.interface_alias_offset = 1
+
         # pan wants a uuid it seems (for licensing reasons?!)
         self.uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 

--- a/routeros/README.md
+++ b/routeros/README.md
@@ -11,6 +11,7 @@ Tested booting and responding to SSH:
  * chr-6.47.9.vmdk
  * chr-7.1beta5.vmdk
 
+The interface alias format supported on this image is `etherX`, where X is the port number, and `X = 1` is reserved for the management interface.
 
 ## System requirements
 CPU: 1 core

--- a/routeros/docker/launch.py
+++ b/routeros/docker/launch.py
@@ -56,7 +56,11 @@ class ROS_vm(vrnetlab.VM):
         self.qemu_args.extend(["-boot", "n"])
         self.hostname = hostname
         self.conn_mode = conn_mode
+
         self.num_nics = 31
+        self.interface_alias_regexp = r"ether(?P<port>\d+)"
+        # Data interface numbering starts at port 2 (ether2)
+        self.interface_alias_offset = 2
 
         # set up bridge for management interface to a localhost
         self.logger.info("Creating br-mgmt bridge for management interface")

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -919,7 +919,7 @@ class SROS_vm(vrnetlab.VM):
         self.uuid = "00000000-0000-0000-0000-000000000000"
         self.power = "dc"  # vSR emulates DC only
         self.read_license()
-        
+
         # override default wait pattern with hash followed by the space
         self.wait_pattern = "# "
 
@@ -1139,13 +1139,13 @@ class SROS_vm(vrnetlab.VM):
         """Ignore environment variables here, since getMem function is used"""
         return self._ram
 
-    
+
     @property
     def cpu(self):
         """Ignore environment variables here, since CPU environment variable is used for number of cpus in getCPU function"""
-    
+
         return str(self._cpu)
-    
+
     @property
     def smp(self):
         """Ignore environment variables here, since CPU environment variable is used for number of cpus in getCPU function"""
@@ -1173,7 +1173,10 @@ class SROS_integrated(SROS_vm):
         )
         self.mode = mode
         self.role = "integrated"
+
         self.num_nics = num_nics
+        # TODO: Interface aliases
+
         self.smbios = [
             f"type=1,product=TIMOS:address={SROS_MGMT_V4_ADDR}/{V4_PREFIX_LENGTH}@active "
             f"address={SROS_MGMT_V6_ADDR}/{V6_PREFIX_LENGTH}@active license-file=tftp://{BRIDGE_V4_ADDR}/"
@@ -1317,8 +1320,10 @@ class SROS_lc(SROS_vm):
 
         self.smbios = ["type=1,product=TIMOS:{}".format(lc_config["timos_line"])]
         self.slot = slot
+
         self.num_nics = num_nics
         self.start_nic_eth_idx = nic_eth_start
+        # TODO: Interface aliases
 
     def start(self):
         # use parent class start() function

--- a/veos/README.md
+++ b/veos/README.md
@@ -2,7 +2,7 @@
 
 This is the vrnetlab docker image for Arista vEOS.
 
-> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.
+> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.  
 
 ## Added in this fork
 
@@ -19,7 +19,7 @@ This is the vrnetlab docker image for Arista vEOS.
 Download vEOS in vmdk format from https://www.arista.com/en/support/software-download
 Place the .vmdk file in this directory and run make. The resulting images is called `vrnetlab/vr-veos`. You can
 tag it with something else if you want, like `my-repo.example.com/vr-veos` and
-then push it to your repo.
+then push it to your repo. 
 
 
 It's been tested to boot, respond to SSH and have correct interface mapping

--- a/veos/README.md
+++ b/veos/README.md
@@ -2,7 +2,7 @@
 
 This is the vrnetlab docker image for Arista vEOS.
 
-> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.  
+> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.
 
 ## Added in this fork
 
@@ -19,7 +19,7 @@ This is the vrnetlab docker image for Arista vEOS.
 Download vEOS in vmdk format from https://www.arista.com/en/support/software-download
 Place the .vmdk file in this directory and run make. The resulting images is called `vrnetlab/vr-veos`. You can
 tag it with something else if you want, like `my-repo.example.com/vr-veos` and
-then push it to your repo. 
+then push it to your repo.
 
 
 It's been tested to boot, respond to SSH and have correct interface mapping
@@ -27,6 +27,7 @@ with the following images:
 
  * vEOS64-lab-4.25.2F
 
+The interface alias format supported on this image is `Ethernet1-X`, where X is the port number. `Ethernet` can also be shortened to `Et`.
 
 ## System requirements
 

--- a/veos/docker/launch.py
+++ b/veos/docker/launch.py
@@ -51,7 +51,11 @@ class VEOS_vm(vrnetlab.VM):
         )
         self.hostname = hostname
         self.conn_mode = conn_mode
+
         self.num_nics = 20
+        self.interface_alias_regexp = r"(?:Et|Ethernet)1-(?P<port>\d+)"
+        # Data interface numbering starts at port 1 (Ethernet1-1)
+        self.interface_alias_offset = 1
 
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""

--- a/vjunosevolved/README.md
+++ b/vjunosevolved/README.md
@@ -10,6 +10,8 @@ Download the vJunosEvolved .qcow2 image from  <https://www.juniper.net/us/en/dm/
 and place it in this directory. After typing `make`, a new image will appear called `vrnetlab/vjunosevolved`.
 Run `docker images` to confirm this.
 
+The interface alias format supported on this image is `ge-0-0-X`, where X is the port number. The prefixes `et` and `te` can also be used interchangeably.
+
 ## System requirements
 
 CPU: 4 cores

--- a/vjunosevolved/docker/launch.py
+++ b/vjunosevolved/docker/launch.py
@@ -52,13 +52,13 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         # create SHA-512 hash of the password
         password_hash = crypt.crypt("admin@123", crypt.mksalt(crypt.METHOD_SHA512))
 
-        # read init.conf configuration file to replace hostname placehodler 
+        # read init.conf configuration file to replace hostname placehodler
         # with given hostname
         with open("init.conf", "r") as file:
             cfg = file.read()
 
         # replace HOSTNAME file var with nodes given hostname
-        # replace CRYPT_PSWD file var with nodes given password 
+        # replace CRYPT_PSWD file var with nodes given password
         # (Evo does not accept plaintext passwords in config)
         new_cfg = cfg.replace("{HOSTNAME}", hostname).replace("{CRYPT_PSWD}", password_hash)
 
@@ -86,15 +86,19 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         ])
 
         self.qemu_args.extend(["-no-user-config", "-nodefaults", "-boot", "strict=on"])
+
         self.nic_type = "virtio-net-pci"
         self.num_nics = 17
+        self.interface_alias_regexp = r"(?:ge|xe|et)-0-0-(?P<port>\d+)"
+        # Data interface numbering starts at port 0 (ge-0-0-0), no offset needed
+
         self.hostname = hostname
         self.smbios = [
             "type=0,vendor=Bochs,version=Bochs", "type=3,manufacturer=Bochs", "type=1,manufacturer=Bochs,product=Bochs,serial=chassis_no=0:slot=0:type=1:assembly_id=0x0D20:platform=251:master=0:channelized=no"            ]
         self.conn_mode = conn_mode
 
     def startup_config(self):
-        """Load additional config provided by user and append initial 
+        """Load additional config provided by user and append initial
         configurations set by vrnetlab."""
         # if startup cfg DNE
         if not os.path.exists(STARTUP_CONFIG_FILE):

--- a/vjunosrouter/README.md
+++ b/vjunosrouter/README.md
@@ -8,6 +8,8 @@ Download the vJunos-router .qcow2 image from  <https://support.juniper.net/suppo
 and place it in this directory. After typing `make`, a new image will appear called `vrnetlab/vjunosrouter`.
 Run `docker images` to confirm this.
 
+The interface alias format supported on this image is `ge-0-0-X`, where X is the port number. The prefixes `et` and `te` can also be used interchangeably.
+
 ## System requirements
 
 CPU: 4 cores

--- a/vjunosrouter/docker/launch.py
+++ b/vjunosrouter/docker/launch.py
@@ -86,8 +86,12 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
         self.qemu_args.extend(
             ["-display", "none", "-no-user-config", "-nodefaults", "-boot", "strict=on"]
         )
+
         self.nic_type = "virtio-net-pci"
         self.num_nics = 11
+        self.interface_alias_regexp = r"(?:ge|xe|et)-0-0-(?P<port>\d+)"
+        # Data interface numbering starts at port 0 (ge-0-0-0), no offset needed
+
         self.smbios = ["type=1,product=VM-VMX,family=lab"]
         self.qemu_args.extend(["-machine", "pc,usb=off,dump-guest-core=off,accel=kvm"])
         self.qemu_args.extend(

--- a/vjunosswitch/README.md
+++ b/vjunosswitch/README.md
@@ -10,6 +10,8 @@ Download the vJunos-switch .qcow2 image from  <https://www.juniper.net/us/en/dm/
 and place it in this directory. After typing `make`, a new image will appear called `vrnetlab/vjunosswitch`.
 Run `docker images` to confirm this.
 
+The interface alias format supported on this image is `ge-0-0-X`, where X is the port number. The prefixes `et` and `te` can also be used interchangeably.
+
 ## System requirements
 
 CPU: 4 cores

--- a/vjunosswitch/docker/launch.py
+++ b/vjunosswitch/docker/launch.py
@@ -67,7 +67,7 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
         self.startup_config()
 
         # these QEMU cmd line args are translated from the shipped libvirt XML file
-        
+
         # mount config disk with juniper.conf base configs
         self.qemu_args.extend(
             [
@@ -81,8 +81,12 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
         self.qemu_args.extend(
             ["-display", "none", "-no-user-config", "-nodefaults", "-boot", "strict=on"]
         )
+
         self.nic_type = "virtio-net-pci"
         self.num_nics = 11
+        self.interface_alias_regexp = r"(?:ge|xe|et)-0-0-(?P<port>\d+)"
+        # Data interface numbering starts at port 0 (ge-0-0-0), no offset needed
+
         self.smbios = ["type=1,product=VM-VEX"]
         self.qemu_args.extend(["-machine", "pc,usb=off,dump-guest-core=off,accel=kvm"])
         self.qemu_args.extend(

--- a/vmx/README.md
+++ b/vmx/README.md
@@ -2,7 +2,7 @@
 
 This is the vrnetlab docker image for Juniper vMX.
 
-> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.
+> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.  
 
 ## Added in this fork
 

--- a/vmx/README.md
+++ b/vmx/README.md
@@ -2,7 +2,7 @@
 
 This is the vrnetlab docker image for Juniper vMX.
 
-> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.  
+> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.
 
 ## Added in this fork
 
@@ -34,6 +34,7 @@ with the following images:
 
 * vmx-bundle-20.2R1.10.tgz
 
+The interface alias format supported on this image is `ge-0-0-X`, where X is the port number. The prefixes `et` and `te` can also be used interchangeably.
 
 ## System requirements
 

--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -257,9 +257,12 @@ class VMX_vfpc(vrnetlab.VM):
     def __init__(self, version, conn_mode):
         super(VMX_vfpc, self).__init__(None, None, disk_image="/vmx/vfpc.img", num=1, cpu="SandyBridge", smp="3")
         self.junos_version = version
-        self.num_nics = 96
 
+        self.num_nics = 96
         self.nic_type = "virtio-net-pci"
+        self.interface_alias_regexp = r"(?:ge|xe|et)-0-0-(?P<port>\d+)"
+        # Data interface numbering starts at port 0 (ge-0-0-0), no offset needed
+
         self.qemu_args.extend(["-M", "pc"])
         # add metadata image if it exists
         if os.path.exists("/vmx/metadata-usb-fpc0.img"):

--- a/vqfx/README.md
+++ b/vqfx/README.md
@@ -2,5 +2,7 @@
 =======================
 Experimental support for Juniper vQFX v18+ launched by containerlab.
 
+The interface alias format supported on this image is `ge-0-0-X`, where X is the port number. The prefixes `et` and `te` can also be used interchangeably.
+
 ## Building the docker image
 To be added.

--- a/vqfx/docker/launch.py
+++ b/vqfx/docker/launch.py
@@ -42,7 +42,11 @@ class VQFX_vcp(vrnetlab.VM):
         super(VQFX_vcp, self).__init__(
             username, password, disk_image=disk_image, ram=2048
         )
+
         self.num_nics = 12
+        self.interface_alias_regexp = r"(?:ge|xe|et)-0-0-(?P<port>\d+)"
+        # Data interface numbering starts at port 0 (ge-0-0-0), no offset needed
+
         self.conn_mode = conn_mode
         self.hostname = hostname
         # _version is a custom version dict that has major and minor version components

--- a/vrp/docker/launch.py
+++ b/vrp/docker/launch.py
@@ -39,10 +39,11 @@ class simulator_VM(vrnetlab.VM):
         self.vcpu = 6
         self.disk_size = '40G'
         super(simulator_VM, self).__init__(username, password, disk_image=disk_image, ram=self.ram, smp=f"{self.vcpu}")
+        self.wait_time = 30
 
         self.num_nics = 14
-        self.wait_time = 30
         self.nic_type = 'virtio-net-pci'
+        # TODO: Interface aliases
 
         vrnetlab.run_command(["qemu-img", "create", "-f", "qcow2", "DataDisk.qcow2", self.disk_size])
 

--- a/vsr1000/docker/launch.py
+++ b/vsr1000/docker/launch.py
@@ -38,6 +38,7 @@ class VSR_vm(vrnetlab.VM):
 
         # The VSR supports up to 15 user nics
         self.num_nics = 7
+        # TODO: Interface aliases
 
     def bootstrap_spin(self):
         """ This function should be called periodically to do work.

--- a/vsrx/docker/launch.py
+++ b/vsrx/docker/launch.py
@@ -34,9 +34,13 @@ class VSRX_vm(vrnetlab.VM):
             if re.search(".qcow2$", e):
                 disk_image = "/" + e
         super(VSRX_vm, self).__init__(username, password, disk_image=disk_image, ram=4096, smp="2")
+
         self.nic_type = "virtio-net-pci"
-        self.conn_mode = conn_mode
         self.num_nics = 10
+        self.interface_alias_regexp = r"(?:ge|xe|et)-0-0-(?P<port>\d+)"
+        # Data interface numbering starts at port 0 (ge-0-0-0), no offset needed
+
+        self.conn_mode = conn_mode
         self.hostname = hostname
 
     def bootstrap_spin(self):
@@ -118,7 +122,7 @@ class VSRX_vm(vrnetlab.VM):
                 #Check to see if the user startup config file starts with a set command or not.
                 if first_line.startswith('set'):
                     self.logger.trace("User startup-config file %s is in Junos set commands" % STARTUP_CONFIG_FILE)
-                    #Write the first line then read the remainder of the file. 
+                    #Write the first line then read the remainder of the file.
                     self.wait_write(first_line, "#")
                     config_lines = file.readlines()
                     config_lines = [line.rstrip() for line in config_lines]

--- a/xrv/README.md
+++ b/xrv/README.md
@@ -2,7 +2,7 @@
 
 This is the vrnetlab docker image for Cisco IOS XRv.
 
-> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.  
+> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.
 
 There are two flavours of virtual XR routers, XRv and XRv9000 where the latter
 has a much more complete forwarding plane. This is for XRv, if you have the
@@ -27,3 +27,5 @@ Obtain XRv vmkd image and put the .vmdk file in this directory and run `make doc
 push it to your repo. The tag is the same as the version of the XRv image, so if you have iosxrv-k9-demo.vmdk-5.3.3 your final docker image will be called `vrnetlab/vr-xrv:5.3.3`
 
  * 6.1.2
+
+The interface alias format supported on this image is `GigabitEthernet0-0-0-X`, where X is the port number. `GigabitEthernet` can also be shortened to `Gi`.

--- a/xrv/README.md
+++ b/xrv/README.md
@@ -2,7 +2,7 @@
 
 This is the vrnetlab docker image for Cisco IOS XRv.
 
-> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.
+> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.  
 
 There are two flavours of virtual XR routers, XRv and XRv9000 where the latter
 has a much more complete forwarding plane. This is for XRv, if you have the

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -50,8 +50,12 @@ class XRV_vm(vrnetlab.VM):
         )
         self.hostname = hostname
         self.conn_mode = conn_mode
-        self.num_nics = 128
         self.credentials = [["admin", "admin"]]
+
+        self.num_nics = 128
+        self.interface_alias_regexp = r"(?:Gi|GigabitEthernet)0-0-0-(?P<port>\d+)"
+        # Data interface numbering starts at port 0 (Gi0-0-0-0)
+        self.interface_alias_offset = 0
 
         self.xr_ready = False
 

--- a/xrv9k/README.md
+++ b/xrv9k/README.md
@@ -1,7 +1,7 @@
 # vrnetlab / Cisco IOS XRv9k
 This is the vrnetlab docker image for Cisco IOS XRv9k.
 
-> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.  
+> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.
 
 There are two flavours of virtual XR routers, XRv and XRv9k where the latter
 has a much more complete forwarding plane. This is for XRv9k if you have the
@@ -30,9 +30,16 @@ Put the .qcow2 file in this directory and run `make docker-image` and you
 should be good to go. The resulting image is called `vrnetlab/vr-xrv9k`. You can tag it
 with something else if you want, like `my-repo.example.com/vr-xrv` and then
 push it to your repo. The tag is the same as the version of the XRv9k image,
-so if you have xrv9k-fullk9-x.vrr-6.2.1.qcow2 your final docker image will be 
+so if you have xrv9k-fullk9-x.vrr-6.2.1.qcow2 your final docker image will be
 called vr-xrv9k:6.2.1
 
 It's been tested to boot and respond to SSH with:
 
  * xrv9k-fullk9-x-7.2.1.qcow2
+
+The interface alias format supported on this image is `[InterfaceType]0-0-0-X`, where X is the port number. `InterfaceType` can be one of the following:
+
+ * `GigabitEthernet`
+    - Can be shortened to `Gi`
+ * `TenGigabitEthernet`
+    - Can be shortened to `TenGigE` or `Te`

--- a/xrv9k/README.md
+++ b/xrv9k/README.md
@@ -1,7 +1,7 @@
 # vrnetlab / Cisco IOS XRv9k
 This is the vrnetlab docker image for Cisco IOS XRv9k.
 
-> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.
+> Originally developed by Kristian Larsson (@plajjan), adapted by @hellt to be integrated with [containerlab](https://containerlab.srlinux.dev) networking.  
 
 There are two flavours of virtual XR routers, XRv and XRv9k where the latter
 has a much more complete forwarding plane. This is for XRv9k if you have the
@@ -30,7 +30,7 @@ Put the .qcow2 file in this directory and run `make docker-image` and you
 should be good to go. The resulting image is called `vrnetlab/vr-xrv9k`. You can tag it
 with something else if you want, like `my-repo.example.com/vr-xrv` and then
 push it to your repo. The tag is the same as the version of the XRv9k image,
-so if you have xrv9k-fullk9-x.vrr-6.2.1.qcow2 your final docker image will be
+so if you have xrv9k-fullk9-x.vrr-6.2.1.qcow2 your final docker image will be 
 called vr-xrv9k:6.2.1
 
 It's been tested to boot and respond to SSH with:

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -48,7 +48,12 @@ class XRV_vm(vrnetlab.VM):
         super(XRV_vm, self).__init__(username, password, disk_image=disk_image, ram=ram, smp=f"cores={vcpu},threads=1,sockets=1")
         self.hostname = hostname
         self.conn_mode = conn_mode
+
         self.num_nics = nics
+        self.interface_alias_regexp = r"(?:Gi|GigabitEthernet|Te|TenGigE|TenGigabitEthernet)0-0-0-(?P<port>\d+)"
+        # Data interface numbering starts at port 0 (Gi0-0-0-0)
+        self.interface_alias_offset = 0
+
         self.qemu_args.extend(
             [
                 "-machine",


### PR DESCRIPTION
Interface aliases allow for the use of container interface names similar or matching those used by virtual appliances encapsulated in vrnetlab. This allows containerlab and any other projects that might use vrnetlab to better represent the internal network interface names of NOSes, and also allows for easier labbing and automatable lab generation based on existing topologies.

`ethX` based naming still works the same by design.

This PR adds interface aliases for most VM types, except for the following:
* Dell FTOSv (lack of information about interface mapping)
* Huawei VRP/eNSP (lack of information about interface mapping)
* Nokia SR OS (complex, LC-based interface naming rules, not an expert on things Nokia)
* IP Infusion ocNOS (lack of information about interface mapping)
* HPE VSR1000 (lack of information about interface mapping)

## How does this work?

Containerlab creates interfaces within the container based on the Containerlab topology definition. vrnetlab expects these interfaces to be called `ethX`, corresponding to VM NIC interface X. `eth0` is reserved for management purposes, and `eth1` and up are data plane interfaces.

An important aspect of adding this feature is that backwards-compatibility needs to be preserved for vrnetlab naming rules (and by extension, for existing Containerlab topologies).

The implementation is based on the Linux Netlink feature called "altnames". When an interface has an altname set on it, Netlink-based tooling can transparently refer to this interface via its altname. Altnames were introduced in Linux kernel 5.5 and is a fairly mature feature.

The underlying vrnetlab interface handling logic, including the `tc` and `vr-xcon` connection modes, continues to rely on and use `ethX`-based interface naming. By adding appropriate `ethX` altnames to the container interfaces, virtual appliance-specific interface names can be used in topologies, while preserving correct container-to-VM interface naming.

## Adding interface aliases to VM types

Developers working on existing or new VM types can add interface aliases by defining two new attributes on the VM class:

* `interface_alias_regexp`: The regular expression that matches on the interface aliases. The default interface offset calculator function assumes that a named group "port" capturing the effective interface index is present in the regexp. 
* `interface_alias_offset`: A numeric offset representing the offset between 0 and the captured interface index for the first available data interface on the virtual appliance. For example, in case of `abc1-(?P<port>\d+)` and first available data interface `abc1-3` (`abc1-1` and `abc1-2` being reserved for some other use), this offset would be `3`. 

Additionally, the function for calculating aliased interface index offsets, `calculate_interface_offset`, can also be redefined inside the specific VM model. This is particularly useful for complex, LC-based virtual appliances, where additional calculation and information might be needed to correctly find the interface offset.

> [!CAUTION]
> It's important that container interface names must NOT contain two characters that NOSes like to use: `/` and ` ` (whitespace). I would propose substituting the former with a `-` and just removing the latter as a "good-enough" solution.
>
> It is also important to note that Linux interface names must be at most 15 bytes long (16 bytes including null termination) -- some NOS's long interface names don't fit this limitation! These interface names need to be truncated or shortened by applications using vrnetlab containers.

## Example usage

Say, we want to spin up a topology with the following kind of nodes:

* vSRX
* vEOS
* CSR1000v

and then connect them like so:

* vSRX ge-0/0/2 <-> Ethernet1/2 vEOS
* CSR1000v Gi5 <-> ge-0/0/5 vSRX
* vEOS Ethernet1/3 <-> Gi3 CSR1000v

Using the `ethX` node names, one would have to create the following container interfaces and connect them up in the following manner (in this case, using the topology definition of Containerlab):

 ```
   links:
     - endpoints: ["vSRX:eth3", "vEOS:eth2"]
     - endpoints: ["CSR1000v:eth4", "vSRX:eth6"]
     - endpoints: ["vEOS:eth3", "CSR1000v:eth2"]
 ```

Note the three different kinds of offset used here on the three different types of VM images!

Using aliased interface names, the topology definition becomes more straightforward:

```
  links:
    - endpoints: ["vSRX:ge-0-0-2", "vEOS:Ethernet1-2"]
    - endpoints: ["CSR1000v:Gi5", "vSRX:ge-0-0-5"]
    - endpoints: ["vEOS:Ethernet1-3", "CSR1000v:Gi3"]
```

> [!NOTE]
> Inside the vrnetlab containers, the following interfaces and altnames get created. This is done transparently to the user and to the application using vrnetlab.
> The calculations show the parsed port index, the alias offset and the starting `ethX` data interface index (currently supported aliases only derive this from the base VM subclass, where it's set to 1) respectively.
> 
> * vSRX
>   - ge-0-0-2 -> eth3 (2 - 0 + 1)
>   - ge-0-0-5 -> eth6 (5 - 0 + 1)
> * vEOS
>   - Ethernet1-2 -> eth2 (2 - 1 + 1)
>   - Ethernet1-3 -> eth3 (3 - 1 + 1)
> * CSR1000v
>   - Gi3 -> eth2 (2 - 2 + 1)
>   - Gi5 -> eth4 (5 - 2 + 1)

## What's next?

Testing for more "harder to acquire" VM types would be very welcome!
Additional contributions for interface aliases, especially for SR OS, would be superb. 

So far, these have been tested working with interface aliases, including discontinuous interface indexes in use, as well as legacy `ethX`-based interface naming:

* vSRX
* all vJunos types
* vEOS

After this PR is merged to vrnetlab, additional work is needed to add NOS-specific interface naming to Containerlab before this feature can be leveraged. This should be fairly straightforward by defining appropriate `CheckInterfaceName` functions for vrnetlab-based Kinds -- this function is already used to check NOS-specific interface names in containerised NOSes.