### PR TITLE
Make RouterOS more reliable with management IP config

### DIFF
--- a/routeros/docker/launch.py
+++ b/routeros/docker/launch.py
@@ -161,7 +161,10 @@ class ROS_vm(vrnetlab.VM):
         self.wait_write(f"/system identity set name={self.hostname}", wait="")
 
         self.wait_write(
-            f"/ip address add interface=ether1 address={ROS_MGMT_ADDR}/{PREFIX_LENGTH}",
+            # Some RouterOS versions didn't detect interfaces quick enough to reliably accept an IP being assigned to ether1.
+            # ROS 6.45.9 was particularly bad for this. So, tell the router to wait for the interface to appear before trying to add the IP.
+            "{ :local ether1count [/interface ethernet find where name=ether1]; :while ([:len $ether1count] < 1)  do={ :set ether1count [/interface ethernet find where name=ether1]; } };"
+            + f"/ip address add interface=ether1 address={ROS_MGMT_ADDR}/{PREFIX_LENGTH}",
             f"[admin@{self.hostname}] > ",
         )
         # Update admin account if username==admin and there is a password set


### PR DESCRIPTION
Some RouterOS versions didn't detect interfaces quick enough to reliably accept an IP being assigned to ether1. The would reject adding the IP to an interface that didn't yet exist and so would be unreachable via management IP. RouterOS 6.45.9 was particularly bad for this.

This change tells the router to wait for the interface to appear before trying to add the IP. It's probably not be the most elegant solution but it seems to work quite well. Hopefully it'll do until someone else comes up with a better idea.

Fixes #202

Tested on 3 different firmware versions and it appears to work well. See the last 3 rows of the table below.

# Lab Testing Results

31 nodes.

| Delay Time | Happy Nodes (got mgmt IP) | Sad Nodes (no mgmt IP) | Firmware Version | Test # | Max Workers |
| --- | --- | --- | --- | --- | --- |
| 0s | 12 | 19 | 6.45.8 | 2 | default |
| 5s | 8 | 23 | 6.45.9 | 1 | default |
| 10s | 29 | 2 | 6.45.9 | 3 | default |
| 15s | 30 (but 2 didn't import config) | 1 | 6.45.9 | 4 | default |
| 15s | 31 (but 5 didn't import config) | 0 | 6.45.9 | 5 | 4 |
| 0s | 31 (but 1 had a kernel failure and didn't import config) | 0 | 6.47.10 | 6 | default |
| 0s | 31 (but 1 had a kernel failure and didn't import config) | 0 | 6.47.10 | 7 | 4 |
| 0s | 31 | 0 | 6.49.10 | 8 | 4 |
| 0s | 31 | 0 | 6.49.10 | 9 | default |
| dynamic (this patch) | 31 (but 1 had a kernel failure and didn't import config) | 0 | 6.45.9 | 10 | default |
| dynamic (this patch) | 31 (but 4 didn't import config) | 0 | 6.38.5 | 11 | default |
| dynamic (this patch) | 31 | 0 | 7.12.2 | 12 | default |
