### PR TITLE
When required, use a static MAC address for the VM management NIC

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -436,7 +436,8 @@ class VM:
         res = []
         # mgmt interface is special - we use qemu user mode network
         res.append("-device")
-        res.append(self.nic_type + f",netdev=p00,mac={gen_mac(0)}")
+        mac = 'c0:00:01:00:ca:fe' if getattr(self,'_static_mgmt_mac',False) else gen_mac(0)
+        res.append(self.nic_type + f",netdev=p00,mac={mac}")
         res.append("-netdev")
         res.append(
             "user,id=p00,net=10.0.0.0/24,"

--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -50,6 +50,7 @@ class CSR_vm(vrnetlab.VM):
                 os.rename("/" + e, "/tftpboot/license.lic")
 
         self.license = False
+        self._static_mgmt_mac = True
         if os.path.isfile("/tftpboot/license.lic"):
             logger.info("License found")
             self.license = True


### PR DESCRIPTION
The Cisco CSR 1000v build process includes updating the QCOW VM image (good) which results in the management MAC address being stored "somewhere". The build process tries to cope with that, but the current workaround no longer works with release 17.03.04a. Once the container is started, the VM consistently boots with the first interface being GigabitEthernet2 (not GigabitEthernet1) and then everything goes down the drain.

The fix is simple: make the MAC address of the management interface constant (not random). It shouldn't matter as the management MAC address is not visible outside of the container.

However, to be on the safe side, the static MAC address is used only when the child class requests it via the _static_mgmt_mac object property.