### PR TITLE
Changed RouterOS nic driver from e1000 to virtio to fix RouterOS MTU bug

### DIFF
--- a/routeros/docker/launch.py
+++ b/routeros/docker/launch.py
@@ -56,6 +56,7 @@ class ROS_vm(vrnetlab.VM):
         self.qemu_args.extend(["-boot", "n"])
         self.hostname = hostname
         self.conn_mode = conn_mode
+        self.nic_type = "virtio-net" # "e1000" is default but breaks mtu > 1500 on vlan subinterfaces on RouterOS 6.x.x
         self.num_nics = 31
 
         # set up bridge for management interface to a localhost


### PR DESCRIPTION
On RouterOS 6.x.x with e1000 network driver vlan sub-interfaces with MTU > 1500 do not function properly (they have an MTU of 234 !). On RouterOs 7.x.x they function fine.

I tested with both virtio and vmxnet3 drivers.
* vmxnet3 drivers crashed qemu when the MTU was changed in RouterOS (resulting in a router reboot).
* virtio drivers worked and fixed the issue with MTU. Tested on RouterOS 6.45.9 and 7.12.2. Did not observe any issues while testing.

 Mikrotik recommend virtio driver for proxmox (also QEMU based) so it should be fairly safe: https://help.mikrotik.com/docs/display/ROS/CHR+ProxMox+installation