### PR TITLE
vJunos/vSRX: Slim Dockerfiles, use virtio for boot disk mounting, standardise across Juniper models

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -77,7 +77,7 @@ class VM:
         driveif="ide",
         provision_pci_bus=True,
         cpu="host",
-        smp=1,
+        smp="1",
     ):
         self.logger = logging.getLogger()
 
@@ -436,7 +436,11 @@ class VM:
         res = []
         # mgmt interface is special - we use qemu user mode network
         res.append("-device")
-        mac = 'c0:00:01:00:ca:fe' if getattr(self,'_static_mgmt_mac',False) else gen_mac(0)
+        mac = (
+            "c0:00:01:00:ca:fe"
+            if getattr(self, "_static_mgmt_mac", False)
+            else gen_mac(0)
+        )
         res.append(self.nic_type + f",netdev=p00,mac={mac}")
         res.append("-netdev")
         res.append(

--- a/vjunosevolved/docker/Dockerfile
+++ b/vjunosevolved/docker/Dockerfile
@@ -1,15 +1,18 @@
-FROM debian:bookworm-slim
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
+LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
- && apt-get install -y \
+ && apt-get install --no-install-recommends -y \
     dosfstools \
     bridge-utils \
     iproute2 \
+    python3-ipy \
     socat \
     ssh \
     qemu-kvm \
+    qemu-utils \
     inetutils-ping \
     dnsutils \
     telnet \

--- a/vjunosevolved/docker/Dockerfile
+++ b/vjunosevolved/docker/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update -qy \
     dosfstools \
     bridge-utils \
     iproute2 \
-    python3-ipy \
+    python3 \
+    python3-passlib \
     socat \
     ssh \
     qemu-kvm \

--- a/vjunosevolved/docker/launch.py
+++ b/vjunosevolved/docker/launch.py
@@ -1,25 +1,28 @@
 #!/usr/bin/env python3
 
+import crypt
 import datetime
 import logging
 import os
-import subprocess
 import re
 import signal
+import subprocess
 import sys
 import uuid
-import crypt
 
 import vrnetlab
 
 # loadable startup config
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
 
+
 def handle_SIGCHLD(signal, frame):
     os.waitpid(-1, os.WNOHANG)
 
+
 def handle_SIGTERM(signal, frame):
     sys.exit(0)
+
 
 signal.signal(signal.SIGINT, handle_SIGTERM)
 signal.signal(signal.SIGTERM, handle_SIGTERM)
@@ -27,11 +30,16 @@ signal.signal(signal.SIGCHLD, handle_SIGCHLD)
 
 TRACE_LEVEL_NUM = 9
 logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+
+
 def trace(self, message, *args, **kws):
     # Yes, logger takes its '*args' as 'args'.
     if self.isEnabledFor(TRACE_LEVEL_NUM):
         self._log(TRACE_LEVEL_NUM, message, args, **kws)
+
+
 logging.Logger.trace = trace
+
 
 class VJUNOSEVOLVED_vm(vrnetlab.VM):
     def __init__(self, hostname, username, password, conn_mode):
@@ -45,7 +53,7 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
             ram=8192,
             driveif="virtio",
             cpu="IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=off",
-            smp="4,sockets=1,cores=4,threads=1"
+            smp="4,sockets=1,cores=4,threads=1",
         )
 
         # device hostname
@@ -53,15 +61,17 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         # create SHA-512 hash of the password
         password_hash = crypt.crypt("admin@123", crypt.mksalt(crypt.METHOD_SHA512))
 
-        # read init.conf configuration file to replace hostname placehodler 
+        # read init.conf configuration file to replace hostname placehodler
         # with given hostname
         with open("init.conf", "r") as file:
             cfg = file.read()
 
         # replace HOSTNAME file var with nodes given hostname
-        # replace CRYPT_PSWD file var with nodes given password 
+        # replace CRYPT_PSWD file var with nodes given password
         # (Evo does not accept plaintext passwords in config)
-        new_cfg = cfg.replace("{HOSTNAME}", hostname).replace("{CRYPT_PSWD}", password_hash)
+        new_cfg = cfg.replace("{HOSTNAME}", hostname).replace(
+            "{CRYPT_PSWD}", password_hash
+        )
 
         # write changes to init.conf file
         with open("init.conf", "w") as file:
@@ -79,12 +89,14 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         self.qemu_args.extend(["-device", "qemu-xhci,id=usb,bus=pci.0,addr=0x1.0x2"])
 
         # mount config disk with juniper.conf base configs
-        self.qemu_args.extend([
-            "-drive",
-            "file=/config.img,format=raw,if=none,id=config_disk",
-            "-device",
-            "usb-storage,bus=usb.0,port=1,drive=config_disk,id=usb-disk0,removable=off,write-cache=on",
-        ])
+        self.qemu_args.extend(
+            [
+                "-drive",
+                "file=/config.img,format=raw,if=none,id=config_disk",
+                "-device",
+                "usb-storage,bus=usb.0,port=1,drive=config_disk,id=usb-disk0,removable=off,write-cache=on",
+            ]
+        )
 
         self.qemu_args.extend(["-no-user-config", "-nodefaults", "-boot", "strict=on"])
         self.nic_type = "virtio-net-pci"
@@ -93,24 +105,26 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         self.smbios = [
             "type=0,vendor=Bochs,version=Bochs",
             "type=3,manufacturer=Bochs",
-            "type=1,manufacturer=Bochs,product=Bochs,serial=chassis_no=0:slot=0:type=1:assembly_id=0x0D20:platform=251:master=0:channelized=no"
+            "type=1,manufacturer=Bochs,product=Bochs,serial=chassis_no=0:slot=0:type=1:assembly_id=0x0D20:platform=251:master=0:channelized=no",
         ]
         self.conn_mode = conn_mode
 
     def startup_config(self):
-        """Load additional config provided by user and append initial 
+        """Load additional config provided by user and append initial
         configurations set by vrnetlab."""
         # if startup cfg DNE
         if not os.path.exists(STARTUP_CONFIG_FILE):
             self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} is not found")
             # rename init.conf to juniper.conf, this is our startup config
-            os.rename('init.conf', 'juniper.conf')
+            os.rename("init.conf", "juniper.conf")
 
         # if startup cfg file is found
         else:
-            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} found, appending initial configuration")
+            self.logger.trace(
+                f"Startup config file {STARTUP_CONFIG_FILE} found, appending initial configuration"
+            )
             # append startup cfg to inital configuration
-            append_cfg = f'cat init.conf {STARTUP_CONFIG_FILE} >> juniper.conf'
+            append_cfg = f"cat init.conf {STARTUP_CONFIG_FILE} >> juniper.conf"
             subprocess.run(append_cfg, shell=True)
 
         # generate mountable config disk based on juniper.conf file with base vrnetlab configs
@@ -162,18 +176,25 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
 class VJUNOSEVOLVED(vrnetlab.VR):
     def __init__(self, hostname, username, password, conn_mode):
         super(VJUNOSEVOLVED, self).__init__(username, password)
-        self.vms = [ VJUNOSEVOLVED_vm(hostname, username, password, conn_mode) ]
+        self.vms = [VJUNOSEVOLVED_vm(hostname, username, password, conn_mode)]
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser(description="")
-    parser.add_argument("--trace", action="store_true", help="enable trace level logging")
-    parser.add_argument("--hostname", default="vr-vjunosevolved", help="vJunosEvolved hostname")
+    parser.add_argument(
+        "--trace", action="store_true", help="enable trace level logging"
+    )
+    parser.add_argument(
+        "--hostname", default="vr-vjunosevolved", help="vJunosEvolved hostname"
+    )
     parser.add_argument("--username", default="vrnetlab", help="Username")
     parser.add_argument("--password", default="VR-netlab9", help="Password")
-    parser.add_argument("--connection-mode", default="tc", help="Connection mode to use in the datapath")
+    parser.add_argument(
+        "--connection-mode", default="tc", help="Connection mode to use in the datapath"
+    )
     args = parser.parse_args()
-
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
     logging.basicConfig(format=LOG_FORMAT)
@@ -183,7 +204,8 @@ if __name__ == '__main__':
     if args.trace:
         logger.setLevel(1)
 
-    vr = VJUNOSEVOLVED(args.hostname,
+    vr = VJUNOSEVOLVED(
+        args.hostname,
         args.username,
         args.password,
         conn_mode=args.connection_mode,

--- a/vjunosevolved/docker/launch.py
+++ b/vjunosevolved/docker/launch.py
@@ -75,7 +75,7 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         # generate UUID to attach
         self.qemu_args.extend(["-uuid", str(uuid.uuid4())])
 
-        # extend QEMU args with device USB details, xchi is the most virtualisation-friendly
+        # extend QEMU args with device USB details, xhci is the most virtualisation-friendly
         self.qemu_args.extend(["-device", "qemu-xhci,id=usb,bus=pci.0,addr=0x1.0x2"])
 
         # mount config disk with juniper.conf base configs

--- a/vjunosevolved/docker/launch.py
+++ b/vjunosevolved/docker/launch.py
@@ -43,6 +43,7 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
             password,
             disk_image=disk_image,
             ram=8192,
+            driveif="virtio",
             cpu="IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=off",
             smp="4,sockets=1,cores=4,threads=1"
         )
@@ -74,8 +75,8 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         # generate UUID to attach
         self.qemu_args.extend(["-uuid", str(uuid.uuid4())])
 
-        # extend QEMU args with device USB details
-        self.qemu_args.extend(["-device", "piix3-usb-uhci,id=usb,bus=pci.0,addr=0x1.0x2"])
+        # extend QEMU args with device USB details, xchi is the most virtualisation-friendly
+        self.qemu_args.extend(["-device", "qemu-xhci,id=usb,bus=pci.0,addr=0x1.0x2"])
 
         # mount config disk with juniper.conf base configs
         self.qemu_args.extend([
@@ -90,7 +91,10 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         self.num_nics = 17
         self.hostname = hostname
         self.smbios = [
-            "type=0,vendor=Bochs,version=Bochs", "type=3,manufacturer=Bochs", "type=1,manufacturer=Bochs,product=Bochs,serial=chassis_no=0:slot=0:type=1:assembly_id=0x0D20:platform=251:master=0:channelized=no"            ]
+            "type=0,vendor=Bochs,version=Bochs",
+            "type=3,manufacturer=Bochs",
+            "type=1,manufacturer=Bochs,product=Bochs,serial=chassis_no=0:slot=0:type=1:assembly_id=0x0D20:platform=251:master=0:channelized=no"
+        ]
         self.conn_mode = conn_mode
 
     def startup_config(self):

--- a/vjunosevolved/docker/launch.py
+++ b/vjunosevolved/docker/launch.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import crypt
 import datetime
 import logging
 import os
@@ -9,6 +8,8 @@ import signal
 import subprocess
 import sys
 import uuid
+
+from passlib.hash import sha512_crypt
 
 import vrnetlab
 
@@ -59,7 +60,7 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         # device hostname
         self.hostname = hostname
         # create SHA-512 hash of the password
-        password_hash = crypt.crypt("admin@123", crypt.mksalt(crypt.METHOD_SHA512))
+        password_hash = sha512_crypt.hash("admin@123")
 
         # read init.conf configuration file to replace hostname placehodler
         # with given hostname

--- a/vjunosevolved/docker/make-config.sh
+++ b/vjunosevolved/docker/make-config.sh
@@ -28,11 +28,18 @@ STAGING=`mktemp -d -p /var/tmp`
 MNTDIR=`mktemp -d -p /var/tmp`
 mkdir $STAGING/config
 cp -v $1 $STAGING/config
-qemu-img create -f raw $2 1M
-LOOPDEV=`losetup --show -f $2`
-if [ $? != 0 ]; then
-	cleanup_failed;
-fi
+qemu-img create -f raw $2 32M
+LOOP_EXITCODE=1
+while [ $LOOP_EXITCODE != 0 ]; do
+	LOOPDEV=`losetup -f`
+	if [ ! -b ${LOOPDEV} ]; then
+		echo "Free loop device ${LOOPDEV} does not exist, manually creating loop device node"
+		LOOPINDEX=`echo ${LOOPDEV} | grep -Po "\d+"`
+		mknod ${LOOPDEV} b 7 ${LOOPINDEX}
+	fi
+	losetup ${LOOPDEV} $2
+	LOOP_EXITCODE=$?
+done
 mkfs.vfat  -v -n "vmm-data" $LOOPDEV
 if [ $? != 0 ]; then
 	echo "Failed to format disk $LOOPDEV; exiting"
@@ -40,7 +47,7 @@ if [ $? != 0 ]; then
 fi
 mount -t vfat $LOOPDEV $MNTDIR
 if [ $? != 0 ]; then
-		echo "Failed to mount metadisk $LOOPDEV; exiting"
+	echo "Failed to mount metadisk $LOOPDEV; exiting"
 	cleanup_failed;
 
 fi

--- a/vjunosrouter/docker/Dockerfile
+++ b/vjunosrouter/docker/Dockerfile
@@ -1,15 +1,18 @@
 FROM public.ecr.aws/docker/library/debian:bookworm-slim
+LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
- && apt-get install -y \
+ && apt-get install --no-install-recommends -y \
     dosfstools \
     bridge-utils \
     iproute2 \
+    python3-ipy \
     socat \
     ssh \
     qemu-kvm \
+    qemu-utils \
     inetutils-ping \
     dnsutils \
     telnet \

--- a/vjunosrouter/docker/Dockerfile
+++ b/vjunosrouter/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -qy \
     dosfstools \
     bridge-utils \
     iproute2 \
-    python3-ipy \
+    python3 \
     socat \
     ssh \
     qemu-kvm \

--- a/vjunosrouter/docker/launch.py
+++ b/vjunosrouter/docker/launch.py
@@ -51,7 +51,7 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
             ram=5120,
             driveif="virtio",
             cpu="IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=on",
-            smp="4,sockets=1,cores=4,threads=1"
+            smp="4,sockets=1,cores=4,threads=1",
         )
         # device hostname
         self.hostname = hostname
@@ -80,12 +80,14 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
         self.qemu_args.extend(["-device", "qemu-xhci,id=usb,bus=pci.0,addr=0x1.0x2"])
 
         # mount config disk with juniper.conf base configs
-        self.qemu_args.extend([
-            "-drive",
-            "file=/config.img,format=raw,if=none,id=config_disk",
-            "-device",
-            "usb-storage,drive=config_disk,id=usb-disk0,removable=off,write-cache=on",
-        ])
+        self.qemu_args.extend(
+            [
+                "-drive",
+                "file=/config.img,format=raw,if=none,id=config_disk",
+                "-device",
+                "usb-storage,drive=config_disk,id=usb-disk0,removable=off,write-cache=on",
+            ]
+        )
 
         self.qemu_args.extend(["-no-user-config", "-nodefaults", "-boot", "strict=on"])
         self.nic_type = "virtio-net-pci"

--- a/vjunosrouter/docker/launch.py
+++ b/vjunosrouter/docker/launch.py
@@ -6,6 +6,7 @@ import re
 import signal
 import subprocess
 import sys
+import uuid
 
 import vrnetlab
 
@@ -44,7 +45,13 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
             if re.search(".qcow2$", e):
                 disk_image = "/" + e
         super(VJUNOSROUTER_vm, self).__init__(
-            username, password, disk_image=disk_image, ram=5120
+            username,
+            password,
+            disk_image=disk_image,
+            ram=5120,
+            driveif="virtio",
+            cpu="IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=on",
+            smp="4,sockets=1,cores=4,threads=1"
         )
         # device hostname
         self.hostname = hostname
@@ -65,34 +72,25 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
         self.startup_config()
 
         # these QEMU cmd line args are translated from the shipped libvirt XML file
-        self.qemu_args.extend(["-smp", "4,sockets=1,cores=4,threads=1"])
-        # Additional CPU info
-        self.qemu_args.extend(
-            [
-                "-cpu",
-                "IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=on",
-            ]
-        )
-        # mount config disk with juniper.conf base configs
-        self.qemu_args.extend(
-            [
-                "-drive",
-                "if=none,id=config_disk,file=/config.img,format=raw",
-                "-device",
-                "virtio-blk-pci,drive=config_disk",
-            ]
-        )
         self.qemu_args.extend(["-overcommit", "mem-lock=off"])
-        self.qemu_args.extend(
-            ["-display", "none", "-no-user-config", "-nodefaults", "-boot", "strict=on"]
-        )
+        # generate UUID to attach
+        self.qemu_args.extend(["-uuid", str(uuid.uuid4())])
+
+        # extend QEMU args with device USB details, xhci is the most virtualisation-friendly
+        self.qemu_args.extend(["-device", "qemu-xhci,id=usb,bus=pci.0,addr=0x1.0x2"])
+
+        # mount config disk with juniper.conf base configs
+        self.qemu_args.extend([
+            "-drive",
+            "file=/config.img,format=raw,if=none,id=config_disk",
+            "-device",
+            "usb-storage,drive=config_disk,id=usb-disk0,removable=off,write-cache=on",
+        ])
+
+        self.qemu_args.extend(["-no-user-config", "-nodefaults", "-boot", "strict=on"])
         self.nic_type = "virtio-net-pci"
         self.num_nics = 11
         self.smbios = ["type=1,product=VM-VMX,family=lab"]
-        self.qemu_args.extend(["-machine", "pc,usb=off,dump-guest-core=off,accel=kvm"])
-        self.qemu_args.extend(
-            ["-device", "piix3-usb-uhci,id=usb,bus=pci.0,addr=0x1.0x2"]
-        )
         self.conn_mode = conn_mode
 
     def startup_config(self):

--- a/vjunosrouter/docker/make-config.sh
+++ b/vjunosrouter/docker/make-config.sh
@@ -28,11 +28,18 @@ STAGING=`mktemp -d -p /var/tmp`
 MNTDIR=`mktemp -d -p /var/tmp`
 mkdir $STAGING/config
 cp -v $1 $STAGING/config
-qemu-img create -f raw $2 1M
-LOOPDEV=`losetup --show -f $2`
-if [ $? != 0 ]; then
-	cleanup_failed;
-fi
+qemu-img create -f raw $2 32M
+LOOP_EXITCODE=1
+while [ $LOOP_EXITCODE != 0 ]; do
+	LOOPDEV=`losetup -f`
+	if [ ! -b ${LOOPDEV} ]; then
+		echo "Free loop device ${LOOPDEV} does not exist, manually creating loop device node"
+		LOOPINDEX=`echo ${LOOPDEV} | grep -Po "\d+"`
+		mknod ${LOOPDEV} b 7 ${LOOPINDEX}
+	fi
+	losetup ${LOOPDEV} $2
+	LOOP_EXITCODE=$?
+done
 mkfs.vfat  -v -n "vmm-data" $LOOPDEV
 if [ $? != 0 ]; then
 	echo "Failed to format disk $LOOPDEV; exiting"
@@ -40,7 +47,7 @@ if [ $? != 0 ]; then
 fi
 mount -t vfat $LOOPDEV $MNTDIR
 if [ $? != 0 ]; then
-		echo "Failed to mount metadisk $LOOPDEV; exiting"
+	echo "Failed to mount metadisk $LOOPDEV; exiting"
 	cleanup_failed;
 
 fi

--- a/vjunosrouter/docker/make-config.sh
+++ b/vjunosrouter/docker/make-config.sh
@@ -28,7 +28,7 @@ STAGING=`mktemp -d -p /var/tmp`
 MNTDIR=`mktemp -d -p /var/tmp`
 mkdir $STAGING/config
 cp -v $1 $STAGING/config
-qemu-img create -f qcow2 $2 1M
+qemu-img create -f raw $2 1M
 LOOPDEV=`losetup --show -f $2`
 if [ $? != 0 ]; then
 	cleanup_failed;

--- a/vjunosswitch/docker/Dockerfile
+++ b/vjunosswitch/docker/Dockerfile
@@ -1,15 +1,18 @@
-FROM debian:bookworm-slim
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
+LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
- && apt-get install -y \
+ && apt-get install --no-install-recommends -y \
     dosfstools \
     bridge-utils \
     iproute2 \
+    python3-ipy \
     socat \
     ssh \
     qemu-kvm \
+    qemu-utils \
     inetutils-ping \
     dnsutils \
     telnet \

--- a/vjunosswitch/docker/Dockerfile
+++ b/vjunosswitch/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -qy \
     dosfstools \
     bridge-utils \
     iproute2 \
-    python3-ipy \
+    python3 \
     socat \
     ssh \
     qemu-kvm \

--- a/vjunosswitch/docker/launch.py
+++ b/vjunosswitch/docker/launch.py
@@ -51,7 +51,7 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
             ram=5120,
             driveif="virtio",
             cpu="IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=on",
-            smp="4,sockets=1,cores=4,threads=1"
+            smp="4,sockets=1,cores=4,threads=1",
         )
         # device hostname
         self.hostname = hostname
@@ -80,12 +80,14 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
         self.qemu_args.extend(["-device", "qemu-xhci,id=usb,bus=pci.0,addr=0x1.0x2"])
 
         # mount config disk with juniper.conf base configs
-        self.qemu_args.extend([
-            "-drive",
-            "file=/config.img,format=raw,if=none,id=config_disk",
-            "-device",
-            "usb-storage,drive=config_disk,id=usb-disk0,removable=off,write-cache=on",
-        ])
+        self.qemu_args.extend(
+            [
+                "-drive",
+                "file=/config.img,format=raw,if=none,id=config_disk",
+                "-device",
+                "usb-storage,drive=config_disk,id=usb-disk0,removable=off,write-cache=on",
+            ]
+        )
 
         self.qemu_args.extend(["-no-user-config", "-nodefaults", "-boot", "strict=on"])
         self.nic_type = "virtio-net-pci"

--- a/vjunosswitch/docker/launch.py
+++ b/vjunosswitch/docker/launch.py
@@ -6,6 +6,7 @@ import re
 import signal
 import subprocess
 import sys
+import uuid
 
 import vrnetlab
 
@@ -44,7 +45,11 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
             if re.search(".qcow2$", e):
                 disk_image = "/" + e
         super(VJUNOSSWITCH_vm, self).__init__(
-            username, password, disk_image=disk_image, ram=5120,
+            username,
+            password,
+            disk_image=disk_image,
+            ram=5120,
+            driveif="virtio",
             cpu="IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=on",
             smp="4,sockets=1,cores=4,threads=1"
         )
@@ -67,27 +72,25 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
         self.startup_config()
 
         # these QEMU cmd line args are translated from the shipped libvirt XML file
-        
-        # mount config disk with juniper.conf base configs
-        self.qemu_args.extend(
-            [
-                "-drive",
-                "if=none,id=config_disk,file=/config.img,format=raw",
-                "-device",
-                "virtio-blk-pci,drive=config_disk",
-            ]
-        )
         self.qemu_args.extend(["-overcommit", "mem-lock=off"])
-        self.qemu_args.extend(
-            ["-display", "none", "-no-user-config", "-nodefaults", "-boot", "strict=on"]
-        )
+        # generate UUID to attach
+        self.qemu_args.extend(["-uuid", str(uuid.uuid4())])
+
+        # extend QEMU args with device USB details, xhci is most virtualization-friendly
+        self.qemu_args.extend(["-device", "qemu-xhci,id=usb,bus=pci.0,addr=0x1.0x2"])
+
+        # mount config disk with juniper.conf base configs
+        self.qemu_args.extend([
+            "-drive",
+            "file=/config.img,format=raw,if=none,id=config_disk",
+            "-device",
+            "usb-storage,drive=config_disk,id=usb-disk0,removable=off,write-cache=on",
+        ])
+
+        self.qemu_args.extend(["-no-user-config", "-nodefaults", "-boot", "strict=on"])
         self.nic_type = "virtio-net-pci"
         self.num_nics = 11
         self.smbios = ["type=1,product=VM-VEX"]
-        self.qemu_args.extend(["-machine", "pc,usb=off,dump-guest-core=off,accel=kvm"])
-        self.qemu_args.extend(
-            ["-device", "piix3-usb-uhci,id=usb,bus=pci.0,addr=0x1.0x2"]
-        )
         self.conn_mode = conn_mode
 
     def startup_config(self):

--- a/vjunosswitch/docker/make-config.sh
+++ b/vjunosswitch/docker/make-config.sh
@@ -28,11 +28,18 @@ STAGING=`mktemp -d -p /var/tmp`
 MNTDIR=`mktemp -d -p /var/tmp`
 mkdir $STAGING/config
 cp -v $1 $STAGING/config
-qemu-img create -f raw $2 1M
-LOOPDEV=`losetup --show -f $2`
-if [ $? != 0 ]; then
-	cleanup_failed;
-fi
+qemu-img create -f raw $2 32M
+LOOP_EXITCODE=1
+while [ $LOOP_EXITCODE != 0 ]; do
+	LOOPDEV=`losetup -f`
+	if [ ! -b ${LOOPDEV} ]; then
+		echo "Free loop device ${LOOPDEV} does not exist, manually creating loop device node"
+		LOOPINDEX=`echo ${LOOPDEV} | grep -Po "\d+"`
+		mknod ${LOOPDEV} b 7 ${LOOPINDEX}
+	fi
+	losetup ${LOOPDEV} $2
+	LOOP_EXITCODE=$?
+done
 mkfs.vfat  -v -n "vmm-data" $LOOPDEV
 if [ $? != 0 ]; then
 	echo "Failed to format disk $LOOPDEV; exiting"
@@ -40,7 +47,7 @@ if [ $? != 0 ]; then
 fi
 mount -t vfat $LOOPDEV $MNTDIR
 if [ $? != 0 ]; then
-		echo "Failed to mount metadisk $LOOPDEV; exiting"
+	echo "Failed to mount metadisk $LOOPDEV; exiting"
 	cleanup_failed;
 
 fi

--- a/vjunosswitch/docker/make-config.sh
+++ b/vjunosswitch/docker/make-config.sh
@@ -28,7 +28,7 @@ STAGING=`mktemp -d -p /var/tmp`
 MNTDIR=`mktemp -d -p /var/tmp`
 mkdir $STAGING/config
 cp -v $1 $STAGING/config
-qemu-img create -f qcow2 $2 1M
+qemu-img create -f raw $2 1M
 LOOPDEV=`losetup --show -f $2`
 if [ $? != 0 ]; then
 	cleanup_failed;

--- a/vsrx/docker/Dockerfile
+++ b/vsrx/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -qy \
    && apt-get install --no-install-recommends -y \
    bridge-utils \
    iproute2 \
-   python3-ipy \
+   python3 \
    socat \
    qemu-kvm \
    qemu-utils \

--- a/vsrx/docker/launch.py
+++ b/vsrx/docker/launch.py
@@ -44,7 +44,13 @@ class VSRX_vm(vrnetlab.VM):
             if re.search(".qcow2$", e):
                 disk_image = "/" + e
         super(VSRX_vm, self).__init__(
-            username, password, disk_image=disk_image, ram=4096, smp="2"
+            username,
+            password,
+            disk_image=disk_image,
+            ram=4096,
+            driveif="virtio",
+            cpu="SandyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=on,aes=on",
+            smp="2,sockets=1,cores=2,threads=1"
         )
         self.nic_type = "virtio-net-pci"
         self.conn_mode = conn_mode

--- a/vsrx/docker/launch.py
+++ b/vsrx/docker/launch.py
@@ -50,7 +50,7 @@ class VSRX_vm(vrnetlab.VM):
             ram=4096,
             driveif="virtio",
             cpu="SandyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=on,aes=on",
-            smp="2,sockets=1,cores=2,threads=1"
+            smp="2,sockets=1,cores=2,threads=1",
         )
         self.nic_type = "virtio-net-pci"
         self.conn_mode = conn_mode


### PR DESCRIPTION
This PR contains "slim" Dockerfiles, `virtio` disks for all non-EOL Juniper models, and XHCI-based config disks for vJunos models.

## Slim Dockerfiles

All vJunos-based models now have the same Dockerfile, which now contains the `--no-install-recommends` option for apt. This reduces the container image sizes by ~650 MB for every vJunos image.

## `virtio` disks

All non-EOL Juniper devices now run off of virtio-mounted disks, which both increases boot speed and performance, and decreases virtualisation overhead.

I ran a benchmark launching all 4 VM models at the same time, and got the following results:

| Type          | IDE boot time  | `virtio` boot time | Improvement |
|---------------|----------------|--------------------|-------------|
| vSRX 3.0      | 04:24 |     02:34 |         42% |
| vJunosEvolved | 01:39 |     01:08 |         32% |
| vJunos-router | 02:22 |     01:57 |         18% |
| vJunos-switch | 02:30 |     02:04 |         18% |

## XHCI-based boot disks
All vJunos-based vrnet node types now use the same mechanism for loading a startup configuration, USB storage mounted through an XHCI controller. XHCI has lower virtualisation overhead[1] compared to EHCI/UHCI, and is supported by all vJunos models, it's an easy win for standardisation.

All changes have been tested with:
 - vSRX 2.0 17.3R1.10
 - vSRX 3.0 23.2R2.21
 - vJunos-switch 23.2R1.14
 - vJunos-router 23.2R1.15
 - vJunosEvolved 23.2R2.21-EVO
 
 [1] https://qemu-project.gitlab.io/qemu/system/devices/usb.html#xhci-controller-support