### PR TITLE
Add install feature based on vrnetlab/vrnetlab implementation.

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -855,3 +855,17 @@ def get_digits(input_str: str) -> int:
 
     non_string_chars = re.findall(r"\d", input_str)
     return int("".join(non_string_chars))
+
+class VR_Installer:
+    def __init__(self):
+        self.logger = logging.getLogger()
+        self.vm = None
+
+    def install(self):
+        vm = self.vm
+        while not vm.running:
+            self.logger.trace("%s working", self.__class__.__name__)
+            vm.work()
+        self.logger.debug("%s running, shutting down", self.__class__.__name__)
+        vm.stop()
+        self.logger.info("Installation complete")

--- a/xrv9k/Makefile
+++ b/xrv9k/Makefile
@@ -12,3 +12,4 @@ VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+\(
 
 -include ../makefile-sanity.include
 -include ../makefile.include
+-include ../makefile-install.include


### PR DESCRIPTION
Add the install feature that exists in vrnetlab/vrnetlab.

On first boot XRv9k takes around ~20 minutes to get to user creation/shell, this is due to a lengthy package installation process. Subsequent boots take much less time than this.

The install feature performs the first boot install when the image is built, this means when the image is used in clab topologies, the boot time is much less (~6 minutes in my testing).

The negative effects are the image is now larger (around 7gigs) and the build process takes the time of the first boot (~20 minutes).