### PR TITLE
Qemu-img command missing after pruning packages

### DIFF
--- a/sros/docker/Dockerfile
+++ b/sros/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -qy \
    python3 \
    socat \
    qemu-kvm \
+   qemu-utils \
    tcpdump \
    tftpd-hpa \
    ssh \


### PR DESCRIPTION
When deploying a lab with SR OS images built this way, shows 'ValueError: Could not read image format for /sros.qcow2'.