### PR TITLE
Add support for Cisco Catalyst 9000v

### DIFF
--- a/cat9kv/Makefile
+++ b/cat9kv/Makefile
@@ -1,0 +1,20 @@
+VENDOR=Cisco
+NAME=cat9kv
+IMAGE_FORMAT=qcow2
+IMAGE_GLOB=*.qcow2
+asic=UADP
+
+# match versions like:
+# csr1000v-universalk9.16.03.01a.qcow2
+# csr1000v-universalk9.16.04.01.qcow2
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[a-z]\?\)\([^0-9].*\|$$\)/\1/')-$(asic)
+
+-include ../makefile-sanity.include
+-include ../makefile.include
+-include ../makefile-install.include
+
+
+docker-build: docker-build-common
+	docker run --cidfile cidfile --privileged $(REGISTRY)vr-$(VR_NAME):$(VERSION) --trace --install
+	docker commit --change='ENTRYPOINT ["/launch.py"]' $$(cat cidfile) $(REGISTRY)vr-$(VR_NAME):$(VERSION)
+	docker rm -f $$(cat cidfile)

--- a/cat9kv/README.md
+++ b/cat9kv/README.md
@@ -1,0 +1,84 @@
+# Cisco Catalyst 9000V
+
+This is the vrnetlab image for the Cisco Catalyst 9000v (cat9kv, c9000v).
+
+The Cat9kv emulates two types of ASICs that are found in the common Catalyst 9000 hardware platforms, either:
+
+- UADP (Cisco Unified Access Data Plane)
+- Cisco Silicon One Q200 (referred to as Q200 for short)
+
+The Q200 is a newer ASIC, however doen't support as many features as the UADP ASIC emulation.
+
+> Insufficient RAM will not allow the node to boot correctly.
+
+Eight interfaces will always appear regardless if you have defined any links in the `*.clab.yaml` topology file. The Cat9kv requires 8 interfaces at minimum to boot, so dummy interfaces are created if there are an insufficient amount of interfaces (links) defined.
+
+## Building the image
+
+Copy the Cat9kv .qcow2 file in this directory and you can perform `make docker-image`. On average the image takes approxmiately ~4 minutes to build as an initial install process occurs.
+
+The UADP and Q200 use the same .qcow2 image. The default image created is the UADP image.
+
+To configure the Q200 image or enable a higher throughput dataplane for UADP; you must supply the relevant `vswitch.xml` file. You can place that file in this directory and build the image.
+
+> You can obtain a `vswitch.xml` file from the relevant CML node definiton file.
+
+You can then perform the same process, you can supply the `asic` argument to tag the image with the relevant image. By default the image is tagged as UADP.
+
+```sh
+# This doesn't change the ASIC type, it only tags the image
+make docker-image asic=q200
+```
+
+Known working versions:
+- cat9kv-prd-17.12.01prd9.qcow2 (UADP & Q200)
+
+## Usage
+
+You can define the image easily and use it in a topolgy. As mentioned earlier no links are requried to be defined.
+
+```yaml
+# topology.clab.yaml
+name: mylab
+topology:
+  nodes:
+    cat9kv:
+      kind: cisco_cat9kv 
+      image: vrnetlab/vr-cat9kv:<tag>
+```
+### Interface naming
+
+Currently a maximum of 8 data-plane interfaces are supported. 9 interfaces total if including the management interface.
+
+- `eth0` - Node management interface
+- `eth1` - First dataplane interface (GigabitEthernet1/0/1).
+- `ethX` - Subsequent dataplane interfaces will count onwards from 1. For example, the third dataplane interface will be `eth3`
+
+### Environment Variables
+
+| Environment Variable  | Default       |
+| --------------------- | ------------- |
+| VCPU                  | 4             |
+| RAM                   | 18432         |
+
+### Example
+
+```yaml
+name: my-example-lab
+topology:
+  nodes:
+    my-cat9kv:
+      kind: cisco_cat9kv 
+      image: vrnetlab/vr-cat9kv:17.12.01p-q200
+    env:
+        VCPU: 6
+        RAM: 12288
+```
+
+## System requirements
+
+|           | UADP (Default)| Q200  |
+| --------- | ------------- | ----- |
+| vCPU      | 4             | 4     |
+| RAM (MB)  | 18432         | 12288 |
+| Disk (GB) | 4             | 4     |

--- a/cat9kv/docker/Dockerfile
+++ b/cat9kv/docker/Dockerfile
@@ -1,0 +1,29 @@
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get install -y \
+    bridge-utils \
+    iproute2 \
+    socat \
+    qemu-kvm \
+    tcpdump \
+    inetutils-ping \
+    ssh \
+    telnet \
+    procps \
+    genisoimage \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION
+ENV VERSION=${VERSION}
+ARG IMAGE
+COPY $IMAGE* /
+COPY *.py /
+# for vSwitch.xml file (specifies ASIC emulation parameters), won't throw error if vswitch.xml isn't present
+COPY vswitch.xm[l] /img_dir/conf/
+
+EXPOSE 22 161/udp 830 5000 10000-10099
+HEALTHCHECK CMD ["/healthcheck.py"]
+ENTRYPOINT ["/launch.py"]

--- a/cat9kv/docker/launch.py
+++ b/cat9kv/docker/launch.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+
+import datetime
+import logging
+import os
+import re
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+import vrnetlab
+
+STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
+
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+
+
+logging.Logger.trace = trace
+
+
+class cat9kv_vm(vrnetlab.VM):
+    def __init__(self, hostname, username, password, conn_mode,  vcpu, ram, install_mode=False):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".qcow2$", e):
+                disk_image = "/" + e
+            if re.search(r"\.license$", e):
+                os.rename("/" + e, "/tftpboot/license.lic")
+
+        self.license = False
+        if os.path.isfile("/tftpboot/license.lic"):
+            logger.info("License found")
+            self.license = True
+
+        super().__init__(username, password, disk_image=disk_image, smp=f"cores={vcpu},threads=1,sockets=1",ram=ram, min_dp_nics=8)
+        self.install_mode = install_mode
+        self.hostname = hostname
+        self.conn_mode = conn_mode
+        self.num_nics = 9
+        self.nic_type = "virtio-net-pci"
+        
+        self.image_name = "config.img"
+        
+        self.qemu_args.extend(
+            [
+                "-overcommit mem-lock=off", 
+                f"-boot order=cd -cdrom /{self.image_name}",
+            ]
+        )
+
+        if self.install_mode:
+            logger.trace("install mode")
+            self.create_boot_image()
+
+    def create_boot_image(self):
+        """Creates a iso image with a bootstrap configuration"""
+        try:
+            os.mkdir("/img_dir")
+        except:
+            self.logger.error("Unable to make '/img_dir'. Does the directory already exist?")
+
+        with open("/img_dir/iosxe_config.txt", "w") as cfg_file:
+            cfg_file.write("hostname my_hostname\r\n")
+            cfg_file.write("end\r\n")
+
+        genisoimage_args = [
+            "genisoimage",
+            "-l",
+            "-o",
+            "/" + self.image_name,
+            "/img_dir",
+        ]
+
+        subprocess.Popen(genisoimage_args)
+
+    def bootstrap_spin(self):
+        """This function should be called periodically to do work."""
+
+        if self.spins > 300:
+            # too many spins with no result ->  give up
+            self.stop()
+            self.start()
+            return
+
+        (ridx, match, res) = self.tn.expect(
+            [b"Press RETURN to get started!", b"IOSXEBOOT-4-FACTORY_RESET", b"Autoinstall.*"], 1
+        )
+        if match:  # got a match!
+            if ridx == 0:  # login
+                self.logger.debug("matched, Press RETURN to get started.")
+                if self.install_mode:
+                    self.logger.debug("Now we wait for the device to reload")
+                else:
+                    self.wait_write("", wait=None)
+
+                    # run main config!
+                    self.bootstrap_config()
+                    # add startup config if present
+                    self.startup_config()
+                    # close telnet connection
+                    self.tn.close()
+                    # startup time?
+                    startup_time = datetime.datetime.now() - self.start_time
+                    self.logger.info("Startup complete in: %s", startup_time)
+                    # mark as running
+                    self.running = True
+                    return
+            elif ridx == 1 or ridx == 2:  # IOSXEBOOT-4-FACTORY_RESET or regex match for 'Autoinstall'
+                if self.install_mode:
+                    install_time = datetime.datetime.now() - self.start_time
+                    self.logger.info("Install complete in: %s", install_time)
+                    self.running = True
+                    return
+                else:
+                    self.logger.warning("Unexpected reload while running")
+
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        if res != b"":
+            self.logger.trace("OUTPUT: %s", res.decode())
+            # reset spins if we saw some output
+            self.spins = 0
+
+        self.spins += 1
+
+        return
+
+    def bootstrap_config(self):
+        """Do the actual bootstrap config"""
+        self.logger.info("applying bootstrap configuration")
+
+        self.wait_write("", None)
+        self.wait_write("enable", wait=">")
+        self.wait_write("configure terminal", wait=">")
+
+        # self.wait_write(f"hostname {self.hostname}")
+        self.wait_write(
+            "username %s privilege 15 password %s" % (self.username, self.password)
+        )
+        if int(self.version.split(".")[0]) >= 16:
+            self.wait_write("ip domain name example.com")
+        else:
+            self.wait_write("ip domain-name example.com")
+        self.wait_write("crypto key generate rsa modulus 2048")
+
+        # self.wait_write("interface GigabitEthernet1")
+        # self.wait_write("ip address 10.0.0.15 255.255.255.0")
+        # self.wait_write("no shut")
+        # self.wait_write("exit")
+        self.wait_write("restconf")
+        self.wait_write("netconf-yang")
+        self.wait_write("netconf max-sessions 16")
+        # I did not find any documentation about this, but is seems like a good idea!?
+        self.wait_write("netconf detailed-error")
+        self.wait_write("ip ssh server algorithm mac hmac-sha2-512")
+        self.wait_write("ip ssh maxstartups 128")
+
+        self.wait_write("line vty 0 4")
+        self.wait_write("login local")
+        self.wait_write("transport input all")
+        self.wait_write("end")
+        self.wait_write("copy running-config startup-config")
+        self.wait_write("\r", "Destination")
+
+    def startup_config(self):
+        """Load additional config provided by user."""
+
+        if not os.path.exists(STARTUP_CONFIG_FILE):
+            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} is not found")
+            return
+
+        self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} exists")
+        with open(STARTUP_CONFIG_FILE) as file:
+            config_lines = file.readlines()
+            config_lines = [line.rstrip() for line in config_lines]
+            self.logger.trace(f"Parsed startup config file {STARTUP_CONFIG_FILE}")
+
+        self.logger.info(f"Writing lines from {STARTUP_CONFIG_FILE}")
+
+        self.wait_write("configure terminal")
+        # Apply lines from file
+        for line in config_lines:
+            self.wait_write(line)
+        # End and Save
+        self.wait_write("end")
+        self.wait_write("copy running-config startup-config")
+        self.wait_write("\r", "Destination")
+
+
+class cat9kv(vrnetlab.VR):
+    def __init__(self, hostname, username, password, conn_mode, vcpu, ram):
+        super(cat9kv, self).__init__(username, password)
+        self.vms = [cat9kv_vm(hostname, username, password, conn_mode, vcpu, ram)]
+
+
+class cat9kv_installer(cat9kv):
+    """cat9kv installer
+
+    Will start the cat9kv with a mounted iso to make sure that we get
+    console output on serial, not vga.
+    """
+
+    def __init__(self, hostname, username, password, conn_mode, vcpu, ram):
+        super(cat9kv_installer, self).__init__(hostname, username, password, conn_mode, vcpu, ram)
+        self.vms = [
+            cat9kv_vm(hostname, username, password, conn_mode, vcpu, ram, install_mode=True)
+        ]
+
+    def install(self):
+        self.logger.info("Installing cat9kv")
+        cat9kv = self.vms[0]
+        while not cat9kv.running:
+            cat9kv.work()
+        cat9kv.stop()
+        self.logger.info("Installation complete")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument(
+        "--trace", action="store_true", help="enable trace level logging"
+    )
+    parser.add_argument("--username", default="vrnetlab", help="Username")
+    parser.add_argument("--password", default="VR-netlab9", help="Password")
+    parser.add_argument("--install", action="store_true", help="Install cat9kv")
+    parser.add_argument("--hostname", default="cat9kv", help="Router hostname")
+    parser.add_argument(
+        "--connection-mode",
+        default="vrxcon",
+        help="Connection mode to use in the datapath",
+    )
+    parser.add_argument(
+        "--vcpu", type=int, default=4, help="Allocated vCPUs"
+    )
+    parser.add_argument(
+        "--ram", type=int, default=18432, help="Allocaetd RAM in MB"
+    )
+    
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    if args.install:
+        vr = cat9kv_installer(
+            args.hostname, args.username, args.password, args.connection_mode, args.vcpu, args.ram
+        )
+        vr.install()
+    else:
+        vr = cat9kv(args.hostname, args.username, args.password, args.connection_mode, args.vcpu, args.ram)
+        vr.start()

--- a/makefile.include
+++ b/makefile.include
@@ -13,7 +13,7 @@ docker-image:
 endif
 
 docker-clean-build:
-	-rm -f docker/*.qcow2* docker/*.tgz* docker/*.vmdk* docker/*.iso
+	-rm -f docker/*.qcow2* docker/*.tgz* docker/*.vmdk* docker/*.iso docker/*.xml
 
 docker-pre-build: ;
 

--- a/makefile.include
+++ b/makefile.include
@@ -25,6 +25,7 @@ docker-build-common: docker-clean-build docker-pre-build
 	@if [ "$(IMAGE)" = "$(VERSION)" ]; then echo "ERROR: Incorrect version string ($(IMAGE)). The regexp for extracting version information is likely incorrect, check the regexp in the Makefile or open an issue at https://github.com/plajjan/vrnetlab/issues/new including the image file name you are using."; exit 1; fi
 	@echo "Building docker image using $(IMAGE) as $(REGISTRY)vr-$(VR_NAME):$(VERSION)"
 	cp ../common/* docker/
+	@[ -f ./vswitch.xml ] && cp vswitch.xml docker/ || true
 	$(MAKE) IMAGE=$$IMAGE docker-build-image-copy
 	(cd docker; docker build --build-arg http_proxy=$(http_proxy) --build-arg HTTP_PROXY=$(HTTP_PROXY) --build-arg https_proxy=$(https_proxy) --build-arg HTTPS_PROXY=$(HTTPS_PROXY) --build-arg IMAGE=$(IMAGE) --build-arg VERSION=$(VERSION) -t $(REGISTRY)vr-$(VR_NAME):$(VERSION) .)
 


### PR DESCRIPTION
This PR adds support for the Cisco Catalyst 9000v. Most of the development was largely discussed in the containerlab discord.

There are two modes of Cat9kv that exist, UADP and q200. To switch between the versions, on the first boot of the image (build time), a vswitch.xml file which defines the 'board serial number' and a serial number to enable certain features. `vswitch.xml` can be obtained via CML.

Main changes made:

`vrnetlab.py`: 
- Add `minimum_dp_nics` for nodes that need to have a minimum number of interfaces (Cat9kv won't boot without 8 dataplane interfaces). By default this is 0, it shouldn't affect existing nodes.
- If `minimum_dp_nics` is set and there aren't enough NICs defined in the containerlab topology, `self.insufficient_nics` will be set to True, the added function `gen_dummy_nics()` will generate the qemu args for the remaining amount of NICs required to let the node meet the minimum number of NICs. This also works for the install process where 0 dataplane nics are defined by default.
(this could probably be used for xrv9k as well)

`makefile.include`
- Add *.xml files to be cleaned
- In `docker-build-common`, if `vswitch.xml` exists, copy it to the docker directory.

Add relevant files for cat9kv _README_, _Makefile_, _launch.py_, _Dockerfile_.

The default image tag will have `-UADP` suffixed as that's the default image created. If the user wants to submit a vswitch.xml file which defines the q200 ASIC they can perform `make docker-image asic=q200` and the tag will be suffixed with `-q200`.

The relevant containerlab PRs will also be made.
