### PR TITLE
Replace iptables with socat for SR OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ venv
 .python-version
 
 *.xml
+
+clab-*

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ venv
 
 .envrc
 .python-version
+
+*.xml

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -308,15 +308,16 @@ class VM:
         res.append(
             "user,id=p00,net=10.0.0.0/24,"
             "tftp=/tftpboot,"
-            "hostfwd=tcp::2022-10.0.0.15:22,"  # ssh
-            "hostfwd=udp::2161-10.0.0.15:161,"  # snmp
-            "hostfwd=tcp::2830-10.0.0.15:830,"  # netconf
-            "hostfwd=tcp::2080-10.0.0.15:80,"  # http
-            "hostfwd=tcp::2443-10.0.0.15:443,"  # https
-            "hostfwd=tcp::49339-10.0.0.15:9339,"  # iana gnmi/gnoi
-            "hostfwd=tcp::47400-10.0.0.15:57400,"  # nokia gnmi/gnoi
-            "hostfwd=tcp::56030-10.0.0.15:6030,"  # gnmi/gnoi arista
-            "hostfwd=tcp::52767-10.0.0.15:32767"  # gnmi/gnoi juniper
+            "hostfwd=tcp:0.0.0.0:22-10.0.0.15:22,"  # ssh
+            "hostfwd=udp:0.0.0.0:161-10.0.0.15:161,"  # snmp
+            "hostfwd=tcp:0.0.0.0:830-10.0.0.15:830,"  # netconf
+            "hostfwd=tcp:0.0.0.0:80-10.0.0.15:80,"  # http
+            "hostfwd=tcp:0.0.0.0:443-10.0.0.15:443,"  # https
+            "hostfwd=tcp:0.0.0.0:9339-10.0.0.15:9339,"  # iana gnmi/gnoi
+            "hostfwd=tcp:0.0.0.0:57400-10.0.0.15:57400,"  # nokia gnmi/gnoi
+            "hostfwd=tcp:0.0.0.0:6030-10.0.0.15:6030,"  # gnmi/gnoi arista
+            "hostfwd=tcp:0.0.0.0:32767-10.0.0.15:32767,"  # gnmi/gnoi juniper
+            "hostfwd=tcp:0.0.0.0:8080-10.0.0.15:8080"  # sonic gnmi/gnoi, other http apis
         )
         return res
 
@@ -637,46 +638,10 @@ class VR:
         health_file.write("%d %s" % (exit_status, message))
         health_file.close()
 
-    def start(self, add_fwd_rules=True):
+    def start(self):
         """Start the virtual router"""
         self.logger.debug("Starting vrnetlab %s" % self.__class__.__name__)
         self.logger.debug("VMs: %s" % self.vms)
-        if add_fwd_rules:
-            run_command(
-                ["socat", "TCP-LISTEN:22,fork", "TCP:127.0.0.1:2022"], background=True
-            )
-            run_command(
-                ["socat", "UDP-LISTEN:161,fork", "UDP:127.0.0.1:2161"], background=True
-            )
-            run_command(
-                ["socat", "TCP-LISTEN:830,fork", "TCP:127.0.0.1:2830"], background=True
-            )
-            run_command(
-                ["socat", "TCP-LISTEN:80,fork", "TCP:127.0.0.1:2080"], background=True
-            )
-            run_command(
-                ["socat", "TCP-LISTEN:443,fork", "TCP:127.0.0.1:2443"], background=True
-            )
-            # IANA gnmi/gnoi
-            run_command(
-                ["socat", "TCP-LISTEN:9339,fork", "TCP:127.0.0.1:49339"],
-                background=True,
-            )
-            # Nokia gnmi/gnoi
-            run_command(
-                ["socat", "TCP-LISTEN:57400,fork", "TCP:127.0.0.1:47400"],
-                background=True,
-            )
-            # Arista gnmi/gnoi
-            run_command(
-                ["socat", "TCP-LISTEN:57400,fork", "TCP:127.0.0.1:47400"],
-                background=True,
-            )
-            # Juniper gnmi/gnoi
-            run_command(
-                ["socat", "TCP-LISTEN:32767,fork", "TCP:127.0.0.1:52767"],
-                background=True,
-            )
 
         started = False
         while True:

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1621,19 +1621,23 @@ def create_socat_fwd():
         vrnetlab.run_command(
             [
                 "socat",
-                f"UDP4-LISTEN:{port},fork,reuseaddr,bind='{ipv4}'",
+                f"UDP4-LISTEN:{port},fork,bind='{ipv4}'",
                 f"UDP4:{SROS_MGMT_V4_ADDR}:{port}",
             ],
             background=True,
         )
-    vrnetlab.run_command(
-        [
-            "socat",
-            f"UDP6-LISTEN:{port},fork,reuseaddr,bind='{ipv6}'",
-            f"UDP6:'{SROS_MGMT_V6_ADDR}':{port}",
-        ],
-        background=True,
-    )
+        # for some reason socat does not allow to bind to an address and specify port in the same command for udp6
+        # waiting for comments from maintainers
+        # socat UDP6-LISTEN:161,bind='2001:172:20:20::a' UDP6:'200::1':161
+        # 2024/07/13 18:28:29 socat[397] E port specification not allowed in this bind option
+        # vrnetlab.run_command(
+        #     [
+        #         "socat",
+        #         f"UDP6-LISTEN:{port},fork,bind='{ipv6}'",
+        #         f"UDP6:'{SROS_MGMT_V6_ADDR}':{port}",
+        #     ],
+        #     background=True,
+        # )
 
 
 if __name__ == "__main__":

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1603,7 +1603,7 @@ def create_socat_fwd():
         vrnetlab.run_command(
             [
                 "socat",
-                f"TCP4-LISTEN:{port},fork,reuseaddr,bind='{ipv4}'",
+                f"TCP4-LISTEN:{port},fork,reuseaddr,bind={ipv4}",
                 f"TCP4:{SROS_MGMT_V4_ADDR}:{port}",
             ],
             background=True,
@@ -1611,8 +1611,8 @@ def create_socat_fwd():
         vrnetlab.run_command(
             [
                 "socat",
-                f"TCP6-LISTEN:{port},fork,reuseaddr,bind='{ipv6}'",
-                f"TCP6:'{SROS_MGMT_V6_ADDR}':{port}",
+                f"TCP6-LISTEN:{port},fork,reuseaddr,bind=[{ipv6}]",
+                f"TCP6:[{SROS_MGMT_V6_ADDR}]:{port}",
             ],
             background=True,
         )
@@ -1621,23 +1621,19 @@ def create_socat_fwd():
         vrnetlab.run_command(
             [
                 "socat",
-                f"UDP4-LISTEN:{port},fork,bind='{ipv4}'",
+                f"UDP4-LISTEN:{port},fork,bind={ipv4}",
                 f"UDP4:{SROS_MGMT_V4_ADDR}:{port}",
             ],
             background=True,
         )
-        # for some reason socat does not allow to bind to an address and specify port in the same command for udp6
-        # waiting for comments from maintainers
-        # socat UDP6-LISTEN:161,bind='2001:172:20:20::a' UDP6:'200::1':161
-        # 2024/07/13 18:28:29 socat[397] E port specification not allowed in this bind option
-        # vrnetlab.run_command(
-        #     [
-        #         "socat",
-        #         f"UDP6-LISTEN:{port},fork,bind='{ipv6}'",
-        #         f"UDP6:'{SROS_MGMT_V6_ADDR}':{port}",
-        #     ],
-        #     background=True,
-        # )
+        vrnetlab.run_command(
+            [
+                "socat",
+                f"UDP6-LISTEN:{port},fork,bind=[{ipv6}]",
+                f"UDP6:[{SROS_MGMT_V6_ADDR}]:{port}",
+            ],
+            background=True,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
iptables is a bit of a problem. The zoo with iptables [legacy], nftables and distros is hard to manage.
Socat might be way more reliable.


## Issues

The problem with socat is that we don't have a way to perform SNAT when SR OS initiates a connection towards the outside network. It will come with SRC IP of BOF primary interface, and containerlab host won't be able to route it...