### PR TITLE
add xrv9k cpu options

### DIFF
--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -56,6 +56,8 @@ class XRV_vm(vrnetlab.VM):
                 "smm=off",
                 "-boot",
                 "order=c",
+                "-cpu",
+                "qemu64,+ssse3,+sse4.1,+sse4.2",
                 "-serial",
                 "telnet:0.0.0.0:50%02d,server,nowait" % (self.num + 1),
                 "-serial",


### PR DESCRIPTION
xrv9k is way more stable like this, tested with AMD EPYC 7452 cpu and 11 xrv9k booting at same time on version 7.11.2.