### PR TITLE
Add relevant VRF & static routing configuration for Cisco nodes.

### DIFF
--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -164,8 +164,17 @@ class C8000v_vm(vrnetlab.VM):
         else:
             self.wait_write("ip domain-name example.com")
         self.wait_write("crypto key generate rsa modulus 2048")
+        
+        self.wait_write("vrf definition clab-mgmt")
+        self.wait_write("address-family ipv4")
+        self.wait_write("exit")
+        self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
+        self.wait_write("exit")
+        
+        self.wait_write("ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 10.0.0.2")
 
         self.wait_write("interface GigabitEthernet1")
+        self.wait_write("vrf forwarding clab-mgmt")
         self.wait_write("ip address 10.0.0.15 255.255.255.0")
         self.wait_write("no shut")
         self.wait_write("exit")

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -170,7 +170,7 @@ class C8000v_vm(vrnetlab.VM):
         self.wait_write("exit")
         self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
         self.wait_write("exit")
-        
+
         self.wait_write("ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 10.0.0.2")
 
         self.wait_write("interface GigabitEthernet1")

--- a/cat9kv/docker/launch.py
+++ b/cat9kv/docker/launch.py
@@ -173,7 +173,7 @@ class cat9kv_vm(vrnetlab.VM):
         self.wait_write("crypto key generate rsa modulus 2048")
 
         self.wait_write("no ip domain lookup")
-        
+
         # add mgmt vrf static route
         self.wait_write("ip route vrf Mgmt-vrf 0.0.0.0 0.0.0.0 10.0.0.2")
 

--- a/cat9kv/docker/launch.py
+++ b/cat9kv/docker/launch.py
@@ -173,6 +173,9 @@ class cat9kv_vm(vrnetlab.VM):
         self.wait_write("crypto key generate rsa modulus 2048")
 
         self.wait_write("no ip domain lookup")
+        
+        # add mgmt vrf static route
+        self.wait_write("ip route vrf Mgmt-vrf 0.0.0.0 0.0.0.0 10.0.0.2")
 
         self.wait_write("interface GigabitEthernet0/0")
         self.wait_write("ip address 10.0.0.15 255.255.255.0")

--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -158,8 +158,17 @@ class CSR_vm(vrnetlab.VM):
         else:
            self.wait_write("ip domain-name example.com")
         self.wait_write("crypto key generate rsa modulus 2048")
+        
+        self.wait_write("vrf definition clab-mgmt")
+        self.wait_write("address-family ipv4")
+        self.wait_write("exit")
+        self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
+        self.wait_write("exit")
+        
+        self.wait_write("ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 10.0.0.2")
 
         self.wait_write("interface GigabitEthernet1")
+        self.wait_write("vrf forwarding clab-mgmt")
         self.wait_write("ip address 10.0.0.15 255.255.255.0")
         self.wait_write("no shut")
         self.wait_write("exit")

--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -164,7 +164,7 @@ class CSR_vm(vrnetlab.VM):
         self.wait_write("exit")
         self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
         self.wait_write("exit")
-        
+
         self.wait_write("ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 10.0.0.2")
 
         self.wait_write("interface GigabitEthernet1")

--- a/n9kv/docker/launch.py
+++ b/n9kv/docker/launch.py
@@ -142,7 +142,7 @@ class N9KV_vm(vrnetlab.VM):
         # configure management vrf
         self.wait_write("vrf context management")
         self.wait_write("ip route 0.0.0.0/0 10.0.0.2")
-        self.wait_write("exit")     
+        self.wait_write("exit")
 
         # configure mgmt interface
         self.wait_write("interface mgmt0")

--- a/n9kv/docker/launch.py
+++ b/n9kv/docker/launch.py
@@ -78,21 +78,6 @@ class N9KV_vm(vrnetlab.VM):
             ]
         )
 
-    def gen_mgmt(self):
-        """
-        Augment the parent class function to add gRPC port forwarding
-        """
-        # call parent function to generate the mgmt interface
-        res = super(N9KV_vm, self).gen_mgmt()
-
-        # append gRPC forwarding if it was not added by common lib
-        if "hostfwd=tcp::50051-10.0.0.15:50051" not in res[-1]:
-            res[-1] = res[-1] + ",hostfwd=tcp::17051-10.0.0.15:50051"
-            vrnetlab.run_command(
-                ["socat", "TCP-LISTEN:50051,fork", "TCP:127.0.0.1:17051"],
-                background=True,
-            )
-        return res
 
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""
@@ -153,6 +138,11 @@ class N9KV_vm(vrnetlab.VM):
         self.wait_write(
             f"username {self.username} password 0 {self.password} role network-admin"
         )
+        
+        # configure management vrf
+        self.wait_write("vrf context management")
+        self.wait_write("ip route 0.0.0.0/0 10.0.0.2")
+        self.wait_write("exit")     
 
         # configure mgmt interface
         self.wait_write("interface mgmt0")

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -166,20 +166,41 @@ class XRV_vm(vrnetlab.VM):
         self.wait_write("show interface description")
         self.wait_write("configure")
         self.wait_write("hostname {}".format(self.hostname))
-        # configure netconf
+        
+        # configure management vrf
+        self.wait_write("vrf clab-mgmt")
+        self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
+        self.wait_write("address-family ipv4 unicast")
+        self.wait_write("exit")
+        self.wait_write("exit")
+        
+        # add static route for management
+        self.wait_write("router static")
+        self.wait_write("vrf clab-mgmt")
+        self.wait_write("address-family ipv4 unicast")
+        self.wait_write("0.0.0.0/0 10.0.0.2")
+        self.wait_write("exit")
+        self.wait_write("exit")
+        self.wait_write("exit")
+      
+        # configure ssh & netconf w/ vrf
         self.wait_write("ssh server v2")
+        self.wait_write("ssh server vrf clab-mgmt")
         self.wait_write("ssh server netconf port 830")  # for 5.1.1
-        self.wait_write("ssh server netconf vrf default")  # for 5.3.3
+        self.wait_write("ssh server netconf vrf clab-mgmt")  # for 5.3.3
         self.wait_write("netconf agent ssh")  # for 5.1.1
         self.wait_write("netconf-yang agent ssh")  # for 5.3.3
+        
         # configure gNMI
         self.wait_write("grpc port 57400")
         self.wait_write("grpc no-tls")
+        
         # configure xml agent
         self.wait_write("xml agent tty")
-
+        
         # configure mgmt interface
         self.wait_write("interface MgmtEth 0/0/CPU0/0")
+        self.wait_write("vrf clab-mgmt")
         self.wait_write("no shutdown")
         self.wait_write("ipv4 address 10.0.0.15/24")
         self.wait_write("exit")
@@ -208,23 +229,6 @@ class XRV_vm(vrnetlab.VM):
         # Commit and GTFO
         self.wait_write("commit")
         self.wait_write("exit")
-
-
-    def gen_mgmt(self):
-        """
-        Augment the parent class function to add gNMI port forwarding
-        """
-        # call parent function to generate first mgmt interface (e1000)
-        res = super(XRV_vm, self).gen_mgmt()
-
-        # append gNMI forwarding if it was not added by common lib
-        if "hostfwd=tcp::57400-10.0.0.15:57400" not in res[-1]:
-            res[-1] = res[-1] + ",hostfwd=tcp::17400-10.0.0.15:57400"
-            vrnetlab.run_command(
-                ["socat", "TCP-LISTEN:57400,fork", "TCP:127.0.0.1:17400"],
-                background=True,
-            )
-        return res
 
 
 class XRV(vrnetlab.VR):

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -193,6 +193,7 @@ class XRV_vm(vrnetlab.VM):
         
         # configure gNMI
         self.wait_write("grpc port 57400")
+        self.wait_write("grpc vrf clab-mgmt")
         self.wait_write("grpc no-tls")
         
         # configure xml agent

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -82,10 +82,10 @@ class XRV_vm(vrnetlab.VM):
                 "-netdev",
                 "user,id=mgmt,net=10.0.0.0/24,"
                 "tftp=/tftpboot,"
-				"hostfwd=tcp:0.0.0.0:22-10.0.0.15:22,"
-            	"hostfwd=udp:0.0.0.0:161-10.0.0.15:161," 
-            	"hostfwd=tcp:0.0.0.0:830-10.0.0.15:830," 
-            	"hostfwd=tcp:0.0.0.0:57400-10.0.0.15:57400,"
+                "hostfwd=tcp:0.0.0.0:22-10.0.0.15:22,"
+                "hostfwd=udp:0.0.0.0:161-10.0.0.15:161,"
+                "hostfwd=tcp:0.0.0.0:830-10.0.0.15:830,"
+                "hostfwd=tcp:0.0.0.0:57400-10.0.0.15:57400"
             ]
         )
         # dummy interface for xrv9k ctrl interface

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -80,7 +80,12 @@ class XRV_vm(vrnetlab.VM):
         res.extend(
             [
                 "-netdev",
-                "user,id=mgmt,net=10.0.0.0/24,tftp=/tftpboot,hostfwd=tcp::2022-10.0.0.15:22,hostfwd=udp::2161-10.0.0.15:161,hostfwd=tcp::2830-10.0.0.15:830,hostfwd=tcp::17400-10.0.0.15:57400",
+                "user,id=mgmt,net=10.0.0.0/24,"
+                "tftp=/tftpboot,"
+				"hostfwd=tcp:0.0.0.0:22-10.0.0.15:22,"
+            	"hostfwd=udp:0.0.0.0:161-10.0.0.15:161," 
+            	"hostfwd=tcp:0.0.0.0:830-10.0.0.15:830," 
+            	"hostfwd=tcp:0.0.0.0:57400-10.0.0.15:57400,"
             ]
         )
         # dummy interface for xrv9k ctrl interface
@@ -102,11 +107,6 @@ class XRV_vm(vrnetlab.VM):
                 "-netdev",
                 "tap,ifname=dev-dummy,id=dev-dummy,script=no,downscript=no",
             ]
-        )
-        # add socat for gNMI port we added on L76, since it's not part of vrnetlab core lib
-        vrnetlab.run_command(
-            ["socat", "TCP-LISTEN:57400,fork", "TCP:127.0.0.1:17400"],
-            background=True,
         )
 
         return res
@@ -238,10 +238,28 @@ class XRV_vm(vrnetlab.VM):
 
         self.wait_write("configure")
         self.wait_write(f"hostname {self.hostname}")
-        # configure netconf
+        
+        # configure management vrf
+        self.wait_write("vrf clab-mgmt")
+        self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
+        self.wait_write("address-family ipv4 unicast")
+        self.wait_write("exit")
+        self.wait_write("exit")
+        
+        # add static route for management
+        self.wait_write("router static")
+        self.wait_write("vrf clab-mgmt")
+        self.wait_write("address-family ipv4 unicast")
+        self.wait_write("0.0.0.0/0 10.0.0.2")
+        self.wait_write("exit")
+        self.wait_write("exit")
+        self.wait_write("exit")
+            
+        # configure ssh & netconf w/ vrf
         self.wait_write("ssh server v2")
+        self.wait_write("ssh server vrf clab-mgmt")
         self.wait_write("ssh server netconf port 830")  # for 5.1.1
-        self.wait_write("ssh server netconf vrf default")  # for 5.3.3
+        self.wait_write("ssh server netconf vrf clab-mgmt")  # for 5.3.3
         self.wait_write("netconf agent ssh")  # for 5.1.1
         self.wait_write("netconf-yang agent ssh")  # for 5.3.3
         # configure gNMI
@@ -250,9 +268,10 @@ class XRV_vm(vrnetlab.VM):
 
         # configure xml agent
         self.wait_write("xml agent tty")
-
+        
         # configure mgmt interface
-        self.wait_write("interface MgmtEth 0/RP0/CPU0/0")
+        self.wait_write("interface MgmtEth0/RP0/CPU0/0")
+        self.wait_write("vrf clab-mgmt")
         self.wait_write("no shutdown")
         self.wait_write("ipv4 address 10.0.0.15/24")
         self.wait_write("exit")

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -264,6 +264,7 @@ class XRV_vm(vrnetlab.VM):
         self.wait_write("netconf-yang agent ssh")  # for 5.3.3
         # configure gNMI
         self.wait_write("grpc port 57400")
+        self.wait_write("grpc vrf clab-mgmt")
         self.wait_write("grpc no-tls")
 
         # configure xml agent


### PR DESCRIPTION
Relevant to discord thread.

Removal of socat meant that Cisco vrnetlab nodes couldn't be accessed via the management interface due to a non-existent route.

This PR adds the relevant static routes and creates VRFs for nodes if necessary to ensure the default route installed for the management interface doesn't interfere with the default context where the users lab config would usually be.

I've tested everything on Rocky 9.3, I was able to SSH into all nodes with the changes.