### PR TITLE
Update & cleanup XRv9k install procedure.

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -672,18 +672,3 @@ def get_digits(input_str: str) -> int:
 
     non_string_chars = re.findall(r"\d", input_str)
     return int("".join(non_string_chars))
-
-
-class VR_Installer:
-    def __init__(self):
-        self.logger = logging.getLogger()
-        self.vm = None
-
-    def install(self):
-        vm = self.vm
-        while not vm.running:
-            self.logger.trace("%s working", self.__class__.__name__)
-            vm.work()
-        self.logger.debug("%s running, shutting down", self.__class__.__name__)
-        vm.stop()
-        self.logger.info("Installation complete")

--- a/xrv9k/Makefile
+++ b/xrv9k/Makefile
@@ -2,6 +2,7 @@ VENDOR=Cisco
 NAME=XRv9k
 IMAGE_FORMAT=qcow2
 IMAGE_GLOB=*qcow2*
+INSTALL=true
 
 # match versions like:
 # TODO: add example file names here
@@ -12,4 +13,10 @@ VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+\(
 
 -include ../makefile-sanity.include
 -include ../makefile.include
+
+ifeq ($(INSTALL),false)
+$(info Install mode disabled)
+else
 -include ../makefile-install.include
+endif
+

--- a/xrv9k/Makefile
+++ b/xrv9k/Makefile
@@ -17,6 +17,7 @@ VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+\(
 ifeq ($(INSTALL),false)
 $(info Install mode disabled)
 else
+$(info Install mode enabled)
 -include ../makefile-install.include
 endif
 

--- a/xrv9k/README.md
+++ b/xrv9k/README.md
@@ -20,19 +20,36 @@ non-9k see the 'xrv' directory instead.
 
 ## Building the docker image
 
-Obtain the XRv9k release from Cisco. They generally ship an iso for a custom
-install as well as a pre-built qcow2 image. Some releases the pre-built qcow2
-is quite large, so making your own from the iso is recommended. At some point
-we may support creating qcow2 from iso in vrnetlab, but that is currently not
-supported.
+By default the XRv9k build time will take ~20 minutes as the image undergoes a first boot installation phase. This greatly decreases boot times for your labs.
 
-Put the .qcow2 file in this directory and run `make docker-image` and you
-should be good to go. The resulting image is called `vrnetlab/vr-xrv9k`. You can tag it
-with something else if you want, like `my-repo.example.com/vr-xrv` and then
-push it to your repo. The tag is the same as the version of the XRv9k image,
-so if you have xrv9k-fullk9-x.vrr-6.2.1.qcow2 your final docker image will be 
-called vr-xrv9k:6.2.1
+The install procedure introduces some side effects as various values (such as macpool) are baked-in during this installation procedure.
+
+This can cause issues, and for this reason you may want to disable the pre-install procedure. You can do this by issuing:
+
+```
+make docker-image INSTALL=false
+```
+
+> Please note that disabling the install feature will mean the boot time of XRv9k will increase to 20+ minutes.
+
+### Installation steps
+
+1. Obtain the XRv9k image (.qcow2) from Cisco (or CML). A .iso version is also shipped but this is currently unsupported and you must convert the .iso to .qcow2.
+
+2. Place the .qcow2 file in this directory
+
+3. Perform `make docker-image` (or `make docker-image INSTALL=false`)
+
+4. Begin labbing. The image will be listed as `vrnetlab/vr-xrv9k` 
+
+> The tag is the same as the version of the XRv9k image,
+so if you have xrv9k-fullk9-x.vrr-6.2.1.qcow2 your final docker image will be called vr-xrv9k:6.2.1
+
+## Known working versions
 
 It's been tested to boot and respond to SSH with:
 
  * xrv9k-fullk9-x-7.2.1.qcow2
+ * xrv9k-fullk9-x-7.7.1.qcow2
+ * xrv9k-fullk9-x-7.11.1.qcow2
+

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -324,7 +324,13 @@ class XRV_vm(vrnetlab.VM):
         return False
 
 
-class XRV_Installer(vrnetlab.VR_Installer):
+class XRV(vrnetlab.VR):
+    def __init__(self, hostname, username, password, nics, conn_mode, vcpu, ram):
+        super(XRV, self).__init__(username, password)
+        self.vms = [XRV_vm(hostname, username, password, nics, conn_mode, vcpu, ram)]
+
+
+class XRV_Installer(XRV):
     """ XRV installer
         Will start the XRV and then shut it down. Booting the XRV for the
         first time requires the XRV itself to install internal packages
@@ -333,13 +339,17 @@ class XRV_Installer(vrnetlab.VR_Installer):
         decrease the normal startup time of the XRV.
     """
     def __init__(self, hostname, username, password, nics, conn_mode, vcpu, ram):
-        super().__init__()
-        self.vm = XRV_vm(hostname, username, password, nics, conn_mode, vcpu, ram, install=True)
-
-class XRV(vrnetlab.VR):
-    def __init__(self, hostname, username, password, nics, conn_mode, vcpu, ram):
         super(XRV, self).__init__(username, password)
-        self.vms = [XRV_vm(hostname, username, password, nics, conn_mode, vcpu, ram)]
+        self.vms = [XRV_vm(hostname, username, password, nics, conn_mode, vcpu, ram, install=True)]
+    
+    def install(self):
+        self.logger.info("Installing XRv9k")
+        xrv = self.vms[0]
+        while not xrv.running:
+            xrv.work()
+        time.sleep(30)
+        xrv.stop()
+        self.logger.info("Installation complete")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR does the following:

- Remove the installation functionality from `vrnetlab.py` and place it in the `launch.py` file for the xrv9k, similar to how the CSR1kv and Cat8kv perform their installation procedure.
- Add an `INSTALL` flag that is able to be passed by the user when building the image, if they wish to disable the installation step
- Update the README to reflect the new `INSTALL` flag.