### PR TITLE
add pre-defined variant for SecGW - SR-7 with ISA2 MDA

### DIFF
--- a/sros/README.md
+++ b/sros/README.md
@@ -35,6 +35,7 @@ By selecting a certain variant (referred by its `name`) the VSIM will start with
 |  sr-7s-fp4   | distributed |      sfm-s+xcm-7s      |           s36-100gb-qsfp28           |   4+6    |    36    |
 |    sr-14s    | distributed |     sfm-s+xcm-14s      |           s36-100gb-qsfp28           |   4+6    |    36    |
 |    sr-a4     | distributed |         cpm-a          |       maxp10-10/1gb-msec-sfp+        |   4+4    |    10    |
+|  sr-7-secgw  | distributed |          cpm5          |  me12-10/1gb-sfp+ and isa2-tunnel    |   4+6    |    16    |
 | ixr-e-small  | distributed | imm14-10g-sfp++4-1g-tx |         m14-10g-sfp++4-1g-tx         |   3+4    |    18    |
 |  ixr-e-big   | distributed |       cpm-ixr-e        |      m24-sfp++8-sfp28+2-qsfp28       |   3+4    |    34    |
 |    ixr-e2    | integrated  |       cpm-ixr-e2       |     m2-qsfpdd+2-qsfp28+24-sfp28      |    4     |    34    |

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -430,6 +430,29 @@ SROS_VARIANTS = {
             }
         ],
     },
+    "sr-7-secgw": {
+        "deployment_model": "distributed",
+        # control plane (CPM)
+        "max_nics": 16,
+        "power": {"modules": 10, "shelves": 2},
+        "cp": {
+            "min_ram": 4,
+            "timos_line": "slot=A chassis=SR-7 sfm=m-sfm6-7/12 card=cpm5",
+        },
+        # line card (IOM/XCM)
+        "lcs": [
+            {
+                "min_ram": 6,
+                "timos_line": "slot=1 chassis=SR-7 sfm=m-sfm6-7/12 card=iom4-e mda/1=me12-10/1gb-sfp+ mda/2=isa2-tunnel",
+                "card_config": """
+                /configure sfm 1 sfm-type m-sfm6-7/12
+                /configure card 1 card-type iom4-e
+                /configure card 1 mda 1 mda-type me12-10/1gb-sfp+
+                /configure card 1 mda 2 mda-type isa2-tunnel
+                """,
+            }
+        ],
+    },
     "sr-14s": {
         "deployment_model": "distributed",
         # control plane (CPM)


### PR DESCRIPTION
Tested with Release 23.10.R4-1 and should also work with older releases.