### PR TITLE
Use gpg to manage ppa keys for IOL and change image naming scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 venv
 *.qcow2
+cisco*.bin
 *.gz
 *.xz
 *.vmdk

--- a/cisco/iol-l2/README.md
+++ b/cisco/iol-l2/README.md
@@ -52,7 +52,7 @@ and the image will be built and tagged. You can view the image by executing `doc
 ```
 containerlab@containerlab:~$ docker images
 REPOSITORY                      TAG         IMAGE ID       CREATED             SIZE
-vrnetlab/vr-iol-l2              17.12.01    0e5ee8ee8746   9 minutes ago       644MB
+vrnetlab/cisco_iol-l2           17.12.01    0e5ee8ee8746   9 minutes ago       644MB
 ```
 
 ## Usage
@@ -66,5 +66,5 @@ topology:
   nodes:
     iol:
       kind: cisco_iol
-      image: vrnetlab/vr-iol-l2:<tag>
+      image: vrnetlab/cisco_iol-l2:<tag>
 ```

--- a/cisco/iol-l2/docker/Dockerfile
+++ b/cisco/iol-l2/docker/Dockerfile
@@ -2,18 +2,21 @@ FROM public.ecr.aws/docker/library/debian:bookworm-slim
 
 # Install dependencies
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
     iproute2 \
     iputils-ping \
     net-tools \
     sudo \
+    curl \
+    ca-certificates \
     gnupg \
     supervisor \
     && apt-get clean
 
 # Add the GNS3 PPA for IOUYAP
 RUN echo "deb http://ppa.launchpad.net/gns3/ppa/ubuntu trusty main" >> /etc/apt/sources.list
-RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 9A2FD067A2E3EF7B
+RUN curl -fsSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb83aaabffbd82d21b543c8ea86c22c2ec6a24d7f' | \
+    gpg --dearmor -o /etc/apt/trusted.gpg.d/gns3.gpg
 
 # Update and install IOUYAP
 RUN apt-get update && \

--- a/cisco/iol/README.md
+++ b/cisco/iol/README.md
@@ -52,7 +52,7 @@ and the image will be built and tagged. You can view the image by executing `doc
 ```
 containerlab@containerlab:~$ docker images
 REPOSITORY                      TAG         IMAGE ID       CREATED          SIZE
-vrnetlab/vr-iol                 17.12.01    44dde64d56ad   21 hours ago     741MB
+vrnetlab/cisco_iol              17.12.01    44dde64d56ad   21 hours ago     741MB
 ```
 
 ## Usage

--- a/cisco/iol/docker/Dockerfile
+++ b/cisco/iol/docker/Dockerfile
@@ -2,18 +2,21 @@ FROM public.ecr.aws/docker/library/debian:bookworm-slim
 
 # Install dependencies
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
     iproute2 \
     iputils-ping \
     net-tools \
     sudo \
+    curl \
+    ca-certificates \
     gnupg \
     supervisor \
     && apt-get clean
 
 # Add the GNS3 PPA for IOUYAP
 RUN echo "deb http://ppa.launchpad.net/gns3/ppa/ubuntu trusty main" >> /etc/apt/sources.list
-RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 9A2FD067A2E3EF7B
+RUN curl -fsSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb83aaabffbd82d21b543c8ea86c22c2ec6a24d7f' | \
+    gpg --dearmor -o /etc/apt/trusted.gpg.d/gns3.gpg
 
 # Update and install IOUYAP
 RUN apt-get update && \

--- a/makefile.include
+++ b/makefile.include
@@ -1,4 +1,5 @@
-VR_NAME=$(shell basename $$(pwd))
+IMG_NAME=$(shell echo $(NAME) | tr '[:upper:]' '[:lower:]')
+IMG_VENDOR=$(shell echo $(VENDOR) | tr '[:upper:]' '[:lower:]')
 IMAGES=$(shell ls $(IMAGE_GLOB) 2>/dev/null)
 NUM_IMAGES=$(shell ls $(IMAGES) | wc -l)
 VRNETLAB_VERION=$$(git log -1 --format=format:"Commit: %H from %aD")
@@ -24,7 +25,7 @@ docker-build-image-copy:
 docker-build-common: docker-clean-build docker-pre-build
 	@if [ -z "$$IMAGE" ]; then echo "ERROR: No IMAGE specified"; exit 1; fi
 	@if [ "$(IMAGE)" = "$(VERSION)" ]; then echo "ERROR: Incorrect version string ($(IMAGE)). The regexp for extracting version information is likely incorrect, check the regexp in the Makefile or open an issue at https://github.com/plajjan/vrnetlab/issues/new including the image file name you are using."; exit 1; fi
-	@echo "Building docker image using $(IMAGE) as $(REGISTRY)vr-$(VR_NAME):$(VERSION)"
+	@echo "Building docker image using $(IMAGE) as $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION)"
 ifeq ($(NOT_VM_IMAGE), 1)
 	echo "ok"
 else
@@ -33,7 +34,7 @@ endif
 	@[ -f ./vswitch.xml ] && cp vswitch.xml docker/ || true
 	@[ -f ./.iourc ] && cp .iourc docker/ || true
 	$(MAKE) IMAGE=$$IMAGE docker-build-image-copy
-	(cd docker; docker build --build-arg http_proxy=$(http_proxy) --build-arg HTTP_PROXY=$(HTTP_PROXY) --build-arg https_proxy=$(https_proxy) --build-arg HTTPS_PROXY=$(HTTPS_PROXY) --build-arg IMAGE=$(IMAGE) --build-arg VERSION=$(VERSION) --label "vrnetlab-version=$(VRNETLAB_VERION)" -t $(REGISTRY)vr-$(VR_NAME):$(VERSION) .)
+	(cd docker; docker build --build-arg http_proxy=$(http_proxy) --build-arg HTTP_PROXY=$(HTTP_PROXY) --build-arg https_proxy=$(https_proxy) --build-arg HTTPS_PROXY=$(HTTPS_PROXY) --build-arg IMAGE=$(IMAGE) --build-arg VERSION=$(VERSION) --label "vrnetlab-version=$(VRNETLAB_VERION)" -t $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION) .)
 
 docker-build: docker-build-common
 
@@ -45,7 +46,7 @@ docker-push:
 docker-push-image:
 	@if [ -z "$$IMAGE" ]; then echo "ERROR: No IMAGE specified"; exit 1; fi
 	@if [ "$(IMAGE)" = "$(VERSION)" ]; then echo "ERROR: Incorrect version string"; exit 1; fi
-	docker push $(REGISTRY)vr-$(VR_NAME):$(VERSION)
+	docker push $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION)
 
 usage:
 	@echo "Usage: put the $(VENDOR) $(NAME) $(IMAGE_FORMAT) image in this directory and run:"


### PR DESCRIPTION
@kaelemc I had timeouts for adding the key from your original PR in #256, as well as deprecation warnings

So I change it to use gpg and key fetch with curl. 


Also I change the default naming scheme to be `{registry}/{vendor}_{name}:{version}` to match with how images are named in containerlab