### PR TITLE
fix sros qcow regex pattern

### DIFF
--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1544,8 +1544,8 @@ class SROS(vrnetlab.VR):
 
     def extractVersion(self):
         """extractVersion extracts the SR OS version from the qcow2 image name"""
-        # https://regex101.com/r/SPefOu/1
-        pattern = r"(magc-)?\S+-((\d{1,3})\.(\d{1,2})\.\w(\d{1,2}(?:-\d{1,2})?))\.qcow2"
+        # https://regex101.com/r/V9jNHc/1
+        pattern = r"(magc-)?\S+-((\d{1,3})\.(\d{1,2})\.\w(\d{1,2}(?:-\d{1,2})?))\.qcow2$"
         match_found = False
 
         for e in os.listdir("/"):


### PR DESCRIPTION
Make qcow pattern match the end of string. Otherwise it may pick up "license" file instead of actual image file.

Proofs.
Build and run the image with the upstream script:
```
$ docker run -it  --privileged --name ixr23-10   vrnetlab/nokia_vsr:23.10.R2
chmod: cannot access '/tftpboot': No such file or directory
2024-10-10 04:35:39,114: launch     DEBUG    acting flags: username 'vrnetlab', password 'VR-netlab9', connection-mode 'vrxcon', variant 'sr-1'
2024-10-10 04:35:39,114: launch     DEBUG    Environment variables: environ({'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'HOSTNAME': 'cb388c2301bf', 'TERM': 'xterm', 'HOME': '/root', 'LC_CTYPE': 'C.UTF-8'})
2024-10-10 04:35:39,115: launch     INFO     Parsed SR OS version: SROSVersion(magc=False, version='23.10.R2', major=23, minor=10, patch='2')
2024-10-10 04:35:39,117: launch     ERROR    License is missing! Provide a license file with a sros-vsr-23.10.R2.qcow2.license.license name next to the qcow2 image.
```
It says `Provide a license file with a sros-vsr-23.10.R2.qcow2.license.license `, which indicates that it took a license file instead of a qcow image.

If I exec into a container, I see that the license is there. But when launch.py is run, it rewrites the license file into a `sros.qcow2`, and the real image is left intact.
```
$ docker run -it  --privileged --name ixr23-10 --entrypoint=/bin/bash  vrnetlab/nokia_vsr:23.10.R2
root@4eef932b64ad:/# ls -la sros*
-rw-r--r-- 1 root root 476053504 Oct  8 05:36 sros-vsr-23.10.R2.qcow2
-rw-r--r-- 1 root root       943 Oct  8 05:36 sros-vsr-23.10.R2.qcow2.license

root@4eef932b64ad:/# ./launch.py 
chmod: cannot access '/tftpboot': No such file or directory
2024-10-10 04:36:20,039: launch     DEBUG    acting flags: username 'vrnetlab', password 'VR-netlab9', connection-mode 'vrxcon', variant 'sr-1'
2024-10-10 04:36:20,040: launch     DEBUG    Environment variables: environ({'HOSTNAME': '4eef932b64ad', 'PWD': '/', 'HOME': '/root', 'TERM': 'xterm', 'SHLVL': '1', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', '_': './launch.py', 'LC_CTYPE': 'C.UTF-8'})
2024-10-10 04:36:20,041: launch     INFO     Parsed SR OS version: SROSVersion(magc=False, version='23.10.R2', major=23, minor=10, patch='2')
2024-10-10 04:36:20,044: launch     ERROR    License is missing! Provide a license file with a sros-vsr-23.10.R2.qcow2.license.license name next to the qcow2 image.
root@4eef932b64ad:/# ls -la tftpboot
total 8
drwxr-xr-x 2 root root 4096 Oct 10 04:36 .
drwxr-xr-x 1 root root 4096 Oct 10 04:36 ..
root@4eef932b64ad:/# ls -la sros*
-rw-r--r-- 1 root root 476053504 Oct  8 05:36 sros-vsr-23.10.R2.qcow2
-rw-r--r-- 1 root root       943 Oct  8 05:36 sros.qcow2
root@4eef932b64ad:/# exit
exit

```