### PR TITLE
Adding VR_NAME otherwise it will not build

### DIFF
--- a/fortigate/Makefile
+++ b/fortigate/Makefile
@@ -1,4 +1,5 @@
 VENDOR=Fortigate
+VR_NAME=fortios
 IMAGE_FORMAT=qcow2
 IMAGE_GLOB=*.qcow2
 -include ../makefile-sanity.include


### PR DESCRIPTION
VR_NAME is not defined in the Make file.
The docker build will fail as the image tag "-t $(REGISTRY)vr-$(VR_NAME):$(VERSION)" requires VR_NAME to be defined. 