### PR TITLE
Pass-through/transparent management interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ Other connection mode values are:
 * ovs-bridge - same as a regular bridge, but uses OvS. Can pass LACP traffic.
 * macvtap
 
+## Management interface
+
+There are two types of management connectivity for NOS VMs: _pass-through_ and _host-forwarded_ (legacy) management interfaces.
+
+_Pass-through management_ interfaces allows the use of the assigned management IP within the NOS VM, management traffic is transparently passed through to the VM, and the NOS configuration can accurately reflect the management IP. However, it is no longer possible to send or receive traffic directly in the vrnetlab container (e.g. for installing additional packages within the container).
+
+NOSes defaulting to _pass-through_ management interfaces are:
+- All vJunos routers
+
+In case of _host-forwarded_ management interfaces, certain ports are forwarded to the NOS VM IP, which is always 10.0.0.15/24. The management gateway in this case is 10.0.0.2/24, and outgoing traffic is NATed to the container management IP. This management interface connection mode does not allow for traffic such as LLDP to pass through the management interface.
+
+NOSes defaulting to _host-forwarded_ management interfaces are:
+- Every NOS not listed as pass-through management
+
+It is possible to change from the default management interface mode by setting the `CLAB_MGMT_PASSTHROUGH` environment variable to 'true' or 'false', however, it is left up to the user to provide a startup configuration compatible with the requested mode.
+
 ## Which vrnetlab routers are supported?
 Since the changes we made in this fork are VM specific, we added a few popular routing products:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Other connection mode values are:
 
 There are two types of management connectivity for NOS VMs: _pass-through_ and _host-forwarded_ (legacy) management interfaces.
 
-_Pass-through management_ interfaces allows the use of the assigned management IP within the NOS VM, management traffic is transparently passed through to the VM, and the NOS configuration can accurately reflect the management IP. However, it is no longer possible to send or receive traffic directly in the vrnetlab container (e.g. for installing additional packages within the container).
+_Pass-through management_ interfaces allows the use of the assigned management IP within the NOS VM, management traffic is transparently passed through to the VM, and the NOS configuration can accurately reflect the management IP. However, it is no longer possible to send or receive traffic directly in the vrnetlab container (e.g. for installing additional packages within the container), other than to pre-defined exceptions, such as the QEMU serial port on TCP port 5000.
 
 NOSes defaulting to _pass-through_ management interfaces are:
 - All vJunos routers

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -121,9 +121,9 @@ class VM:
             self.mgmt_gw_ipv4, self.mgmt_gw_ipv6 = self.get_mgmt_gw()
         else:
             self.mgmt_address_ipv4 = "10.0.0.15/24"
-            self.mgmt_address_ipv6 = None
+            self.mgmt_address_ipv6 = "2001:db8::2/64"
             self.mgmt_gw_ipv4 = "10.0.0.2"
-            self.mgmt_gw_ipv6 = None
+            self.mgmt_gw_ipv6 = "2001:db8::1"
 
         self.insuffucient_nics = False
         self.min_nics = 0

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -297,11 +297,11 @@ class VM:
         ip link set $TAP_IF mtu 65000
 
         # create tc eth<->tap redirect rules
-        tc qdisc add dev eth$INDEX ingress
-        tc filter add dev eth$INDEX parent ffff: protocol all u32 match u8 0 0 action mirred egress redirect dev tap$INDEX
+        tc qdisc add dev eth$INDEX clsact
+        tc filter add dev eth$INDEX ingress flower action mirred egress redirect dev tap$INDEX
 
-        tc qdisc add dev $TAP_IF ingress
-        tc filter add dev $TAP_IF parent ffff: protocol all u32 match u8 0 0 action mirred egress redirect dev eth$INDEX
+        tc qdisc add dev $TAP_IF clsact
+        tc filter add dev $TAP_IF ingress flower action mirred egress redirect dev eth$INDEX
         """
 
         with open("/etc/tc-tap-ifup", "w") as f:
@@ -316,11 +316,11 @@ class VM:
         ip link set tap0 mtu 65000
 
         # create tc eth<->tap redirect rules
-        tc qdisc add dev eth0 ingress
-        tc filter add dev eth0 parent ffff: protocol all u32 match u8 0 0 action mirred egress redirect dev tap0
+        tc qdisc add dev eth0 clsact
+        tc filter add dev eth0 ingress flower action mirred egress redirect dev tap0
 
-        tc qdisc add dev tap0 ingress
-        tc filter add dev tap0 parent ffff: protocol all u32 match u8 0 0 action mirred egress redirect dev eth0
+        tc qdisc add dev tap0 clsact
+        tc filter add dev tap0 ingress flower action mirred egress redirect dev eth0
         """
 
         with open("/etc/tc-tap-mgmt-ifup", "w") as f:

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -317,12 +317,10 @@ class VM:
 
         # create tc eth<->tap redirect rules
         tc qdisc add dev eth0 ingress
-        # add exception rules for ports 5000-5007 (mask everything but last 3 bits with 0xFFF8)
-        tc filter add dev eth0 parent ffff: protocol tcp u32 match ip dport 5000 0xfff8 action pass
         tc filter add dev eth0 parent ffff: protocol all u32 match u8 0 0 action mirred egress redirect dev tap0
 
         tc qdisc add dev tap0 ingress
-        tc filter add dev tap0 parent ffff: protocol all u32 match u8 0 0 action mirred egress redirect dev tap0
+        tc filter add dev tap0 parent ffff: protocol all u32 match u8 0 0 action mirred egress redirect dev eth0
         """
 
         with open("/etc/tc-tap-mgmt-ifup", "w") as f:

--- a/vjunosevolved/docker/init.conf
+++ b/vjunosevolved/docker/init.conf
@@ -25,7 +25,10 @@ interfaces {
     re0:mgmt-0 {
         unit 0 {
             family inet {
-                address {MGMT_IP_V4};
+                address {MGMT_IP_IPV4};
+            }
+            family inet {
+                address {MGMT_IP_IPV6};
             }
         }
     }
@@ -34,7 +37,12 @@ routing-instances {
     mgmt_junos {
         routing-options {
             static {
-                route 0.0.0.0/0 next-hop {MGMT_GW_V4};
+                route 0.0.0.0/0 next-hop {MGMT_GW_IPV4};
+            }
+            rib mgmt_junos.inet6.0 {
+                static {
+                    route ::/0 next-hop {MGMT_GW_IPV6};
+                }
             }
         }
     }

--- a/vjunosevolved/docker/init.conf
+++ b/vjunosevolved/docker/init.conf
@@ -25,7 +25,7 @@ interfaces {
     re0:mgmt-0 {
         unit 0 {
             family inet {
-                address 10.0.0.15/24;
+                address {MGMT_IP_V4};
             }
         }
     }
@@ -34,7 +34,7 @@ routing-instances {
     mgmt_junos {
         routing-options {
             static {
-                route 0.0.0.0/0 next-hop 10.0.0.2;
+                route 0.0.0.0/0 next-hop {MGMT_GW_V4};
             }
         }
     }

--- a/vjunosevolved/docker/launch.py
+++ b/vjunosevolved/docker/launch.py
@@ -70,6 +70,8 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
 
         cfg = cfg.replace("{MGMT_IP_IPV4}", self.mgmt_address_ipv4)
         cfg = cfg.replace("{MGMT_GW_IPV4}", self.mgmt_gw_ipv4)
+        cfg = cfg.replace("{MGMT_IP_IPV6}", self.mgmt_address_ipv6)
+        cfg = cfg.replace("{MGMT_GW_IPV6}", self.mgmt_gw_ipv6)
         cfg = cfg.replace("{HOSTNAME}", self.hostname)
         # replace CRYPT_PSWD file var with nodes given password
         # (Evo does not accept plaintext passwords in config)

--- a/vjunosevolved/docker/launch.py
+++ b/vjunosevolved/docker/launch.py
@@ -55,6 +55,7 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
             driveif="virtio",
             cpu="IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=off",
             smp="4,sockets=1,cores=4,threads=1",
+            mgmt_passthrough=True
         )
 
         # device hostname
@@ -67,16 +68,16 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         with open("init.conf", "r") as file:
             cfg = file.read()
 
-        # replace HOSTNAME file var with nodes given hostname
+        cfg = cfg.replace("{MGMT_IP_IPV4}", self.mgmt_address_ipv4)
+        cfg = cfg.replace("{MGMT_GW_IPV4}", self.mgmt_gw_ipv4)
+        cfg = cfg.replace("{HOSTNAME}", self.hostname)
         # replace CRYPT_PSWD file var with nodes given password
         # (Evo does not accept plaintext passwords in config)
-        new_cfg = cfg.replace("{HOSTNAME}", hostname).replace(
-            "{CRYPT_PSWD}", password_hash
-        )
+        cfg = cfg.replace("{CRYPT_PSWD}", password_hash)
 
         # write changes to init.conf file
         with open("init.conf", "w") as file:
-            file.write(new_cfg)
+            file.write(cfg)
 
         # pass in user startup config
         self.startup_config()

--- a/vjunosrouter/docker/init.conf
+++ b/vjunosrouter/docker/init.conf
@@ -25,7 +25,7 @@ interfaces {
     fxp0 {
         unit 0 {
             family inet {
-                address 10.0.0.15/24;
+                address {MGMT_IP_V4};
             }
         }
     }
@@ -34,7 +34,7 @@ routing-instances {
     mgmt_junos {
         routing-options {
             static {
-                route 0.0.0.0/0 next-hop 10.0.0.2;
+                route 0.0.0.0/0 next-hop {MGMT_GW_V4};
             }
         }
     }

--- a/vjunosrouter/docker/init.conf
+++ b/vjunosrouter/docker/init.conf
@@ -25,7 +25,10 @@ interfaces {
     fxp0 {
         unit 0 {
             family inet {
-                address {MGMT_IP_V4};
+                address {MGMT_IP_IPV4};
+            }
+            family inet6 {
+                address {MGMT_IP_IPV6};
             }
         }
     }
@@ -34,7 +37,12 @@ routing-instances {
     mgmt_junos {
         routing-options {
             static {
-                route 0.0.0.0/0 next-hop {MGMT_GW_V4};
+                route 0.0.0.0/0 next-hop {MGMT_GW_IPV4};
+            }
+            rib mgmt_junos.inet6.0 {
+                static {
+                    route ::/0 next-hop {MGMT_GW_IPV6};
+                }
             }
         }
     }

--- a/vjunosrouter/docker/launch.py
+++ b/vjunosrouter/docker/launch.py
@@ -64,6 +64,8 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
 
         cfg = cfg.replace("{MGMT_IP_IPV4}", self.mgmt_address_ipv4)
         cfg = cfg.replace("{MGMT_GW_IPV4}", self.mgmt_gw_ipv4)
+        cfg = cfg.replace("{MGMT_IP_IPV6}", self.mgmt_address_ipv6)
+        cfg = cfg.replace("{MGMT_GW_IPV6}", self.mgmt_gw_ipv6)
         cfg = cfg.replace("{HOSTNAME}", self.hostname)
 
         # write changes to init.conf file

--- a/vjunosrouter/docker/launch.py
+++ b/vjunosrouter/docker/launch.py
@@ -52,6 +52,7 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
             driveif="virtio",
             cpu="IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=on",
             smp="4,sockets=1,cores=4,threads=1",
+            mgmt_passthrough=True
         )
         # device hostname
         self.hostname = hostname
@@ -61,12 +62,13 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
         with open("init.conf", "r") as file:
             cfg = file.read()
 
-        # replace HOSTNAME file var with nodes given hostname
-        new_cfg = cfg.replace("{HOSTNAME}", hostname)
+        cfg = cfg.replace("{MGMT_IP_IPV4}", self.mgmt_address_ipv4)
+        cfg = cfg.replace("{MGMT_GW_IPV4}", self.mgmt_gw_ipv4)
+        cfg = cfg.replace("{HOSTNAME}", self.hostname)
 
         # write changes to init.conf file
         with open("init.conf", "w") as file:
-            file.write(new_cfg)
+            file.write(cfg)
 
         # pass in user startup config
         self.startup_config()

--- a/vjunosswitch/docker/init.conf
+++ b/vjunosswitch/docker/init.conf
@@ -25,7 +25,7 @@ interfaces {
     fxp0 {
         unit 0 {
             family inet {
-                address 10.0.0.15/24;
+                address {MGMT_IP_V4};
             }
         }
     }
@@ -34,7 +34,7 @@ routing-instances {
     mgmt_junos {
         routing-options {
             static {
-                route 0.0.0.0/0 next-hop 10.0.0.2;
+                route 0.0.0.0/0 next-hop {MGMT_GW_V4};
             }
         }
     }

--- a/vjunosswitch/docker/init.conf
+++ b/vjunosswitch/docker/init.conf
@@ -25,7 +25,10 @@ interfaces {
     fxp0 {
         unit 0 {
             family inet {
-                address {MGMT_IP_V4};
+                address {MGMT_IP_IPV4};
+            }
+            family inet6 {
+                address {MGMT_IP_IPV6};
             }
         }
     }
@@ -34,7 +37,12 @@ routing-instances {
     mgmt_junos {
         routing-options {
             static {
-                route 0.0.0.0/0 next-hop {MGMT_GW_V4};
+                route 0.0.0.0/0 next-hop {MGMT_GW_IPV4};
+            }
+            rib mgmt_junos.inet6.0 {
+                static {
+                    route ::/0 next-hop {MGMT_GW_IPV6};
+                }
             }
         }
     }

--- a/vjunosswitch/docker/launch.py
+++ b/vjunosswitch/docker/launch.py
@@ -64,6 +64,8 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
 
         cfg = cfg.replace("{MGMT_IP_IPV4}", self.mgmt_address_ipv4)
         cfg = cfg.replace("{MGMT_GW_IPV4}", self.mgmt_gw_ipv4)
+        cfg = cfg.replace("{MGMT_IP_IPV6}", self.mgmt_address_ipv6)
+        cfg = cfg.replace("{MGMT_GW_IPV6}", self.mgmt_gw_ipv6)
         cfg = cfg.replace("{HOSTNAME}", self.hostname)
 
         # write changes to init.conf file

--- a/vjunosswitch/docker/launch.py
+++ b/vjunosswitch/docker/launch.py
@@ -52,6 +52,7 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
             driveif="virtio",
             cpu="IvyBridge,vme=on,ss=on,vmx=on,f16c=on,rdrand=on,hypervisor=on,arat=on,tsc-adjust=on,umip=on,arch-capabilities=on,pdpe1gb=on,skip-l1dfl-vmentry=on,pschange-mc-no=on,bmi1=off,avx2=off,bmi2=off,erms=off,invpcid=off,rdseed=off,adx=off,smap=off,xsaveopt=off,abm=off,svm=on",
             smp="4,sockets=1,cores=4,threads=1",
+            mgmt_passthrough=True
         )
         # device hostname
         self.hostname = hostname
@@ -61,12 +62,13 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
         with open("init.conf", "r") as file:
             cfg = file.read()
 
-        # replace HOSTNAME file var with nodes given hostname
-        new_cfg = cfg.replace("{HOSTNAME}", hostname)
+        cfg = cfg.replace("{MGMT_IP_IPV4}", self.mgmt_address_ipv4)
+        cfg = cfg.replace("{MGMT_GW_IPV4}", self.mgmt_gw_ipv4)
+        cfg = cfg.replace("{HOSTNAME}", self.hostname)
 
         # write changes to init.conf file
         with open("init.conf", "w") as file:
-            file.write(new_cfg)
+            file.write(cfg)
 
         # pass in user startup config
         self.startup_config()


### PR DESCRIPTION
This PR adds pass-through as a mode for management interfaces. The default mode for management interfaces remains host-forwarded (which is the previous and only mode supported for management interfaces).

The pass-through mode functions by simply creating yet another tc mirred interface for the NOS VM management NIC instead of binding it to a user-mode, host-forwarded one.

The main advantages of transparently passing management traffic is:
- All protocols/traffic pass through and are visible from both the containerlab host and between vrnetlab containers, allowing for labbing to include management connectivity, e.g. via a firewall
- The NOS configuration accurately reflects the management IPs of the vrnetlab nodes. This is very useful when generating configurations from a source of truth.

The downside of this approach is that it is no longer possible to pass traffic directly from the vrnetlab container, which has two main implications, which means you cannot install/update packages, download files via curl, etc in the container.
Pre-defined exception traffic originating from outside the container (e.g. to the QEMU serial port listening on port 5000) can be selectively directed to the container.

With this change, three NOSes default to pass-through/transparent management:
- vJunos-router
- vJunos-switch
- vJunosEvolved

All other NOS types should not be impacted by this change.

The management interface mode can be overridden by passing the envvar `CLAB_MGMT_PASSTHROUGH` (true/false).

> [!TIP]
> For developers:
> 
> The `__init__` constructor of `vrnetlab.VM` now has an additional parameter `mgmt_passthrough`, which defaults to False. Setting this to True creates a tc mirred interface for the management/first NIC instead of the host-forwarded type. This can be overridden by the envvar described above, and the resolved value can be accessed through the `self.mgmt_nic_passthrough` attribute of `vrnetlab.VM`.
> 
> Two additional convenience attributes are also available for automatically generating startup configs:
> - `self.mgmt_address_ipv4` contains the management IP of the node in CIDR format.
This is either `10.0.0.15/24` for host-forwarded mode, or the actual management IP for pass-through mode.
> - `self.mgmt_gw_ipv4` contains the management default gateway for the node.
`10.0.0.2` for host-forwarded mode, or the actual management gateway IP for pass-through mode.
>
> To add new exception traffic that should be directed towards the VM, you need to add a new tc filter rule.
> An example rule is the following, for the QEMU serial port listening on TCP port 5000-5007.
> ```
> tc filter add dev eth0 ingress prio 1 protocol ip flower ip_proto tcp dst_port 5000-5007 action pass
> ```
>
> The exception traffic filters should be added first (lower priority numbers), before the eth0 mirred redirect rule, which should be the last.