### PR TITLE
Increase max_nics for cisco csr

### DIFF
--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -253,7 +253,7 @@ if __name__ == "__main__":
     parser.add_argument("--password", default="VR-netlab9", help="Password")
     parser.add_argument("--install", action="store_true", help="Install CSR")
     parser.add_argument("--hostname", default="csr1000v", help="Router Hostname")
-    parser.add_argument("--nics", type=int, default=9, help="Number of NICS")
+    parser.add_argument("--nics", type=int, default=31, help="Number of NICS")
     parser.add_argument(
         "--connection-mode",
         default="vrxcon",


### PR DESCRIPTION
Change the default value of 9 (allowing `GigabitEthernet2 -> GigabitEthernet10` for data interfaces) to 31 (`GigabitEthernet2 -> GigabitEthernet32`).

Closes https://github.com/hellt/vrnetlab/issues/273