### PR TITLE
Add env variable "FORTIGATE_UUID" to set the VM UUID for license matching

### DIFF
--- a/fortigate/docker/launch.py
+++ b/fortigate/docker/launch.py
@@ -55,7 +55,7 @@ class FortiOS_vm(vrnetlab.VM):
         self.num_nics = 12
         self.nic_type = "virtio-net-pci"
         self.highest_port = 0
-        self.qemu_args.extend(["-uuid", str(uuid.uuid4())])
+        self.qemu_args.extend(["-uuid", os.getenv("FORTIGATE_UUID") or str(uuid.uuid4())])
         self.spins = 0
         self.running = None
 


### PR DESCRIPTION
Fortigate issues a free trial license that is tied to the UUID of the VM. There is 1 license per account

The UUID determines the device serial number; it can be viewed in the FortiCloud web site under "Asset Management"