### PR TITLE
Replace GNS3 PPA with netdevops gemfury repo (for IOUYAP) in IOL Dockerfile

### DIFF
--- a/cisco/iol/docker/Dockerfile
+++ b/cisco/iol/docker/Dockerfile
@@ -12,10 +12,9 @@ RUN apt-get update && \
     gnupg \
     && apt-get clean
 
-# Add the GNS3 PPA for IOUYAP
-RUN echo "deb http://ppa.launchpad.net/gns3/ppa/ubuntu trusty main" >> /etc/apt/sources.list
-RUN curl -fsSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb83aaabffbd82d21b543c8ea86c22c2ec6a24d7f' | \
-    gpg --dearmor -o /etc/apt/trusted.gpg.d/gns3.gpg
+# Add containerlab gemfury for custom IOUYAP
+RUN echo "deb [trusted=yes] https://netdevops.fury.site/apt/ /" | \
+sudo tee -a /etc/apt/sources.list.d/netdevops.list
 
 # Update and install IOUYAP
 RUN apt-get update && \


### PR DESCRIPTION
As the title says. Replace the GNS3 PPA with the netdevops.fury gemfury repo which hosts the custom build of IOUYAP that @DanPartelly has made.

Will take it out of draft status once testing is complete.