### PR TITLE
Dell OS10 improvements

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -342,11 +342,11 @@ class VM:
         res.append(self.nic_type + f",netdev=p00,mac={mac}")
         res.append("-netdev")
         res.append(
-            f"user,id=p00,net={self.mgmt_subnet},host={host},dns={dns},dhcpstart={guest},"
-            f"hostfwd=tcp:0.0.0.0:22-{guest}:22,"    # ssh
-            f"hostfwd=udp:0.0.0.0:161-{guest}:161,"  # snmp
-            "".join([ f"hostfwd=tcp:0.0.0.0:{p}-{guest}:{p}," for p in self.mgmt_tcp_ports ])
-            "tftp=/tftpboot"
+            f"user,id=p00,net={self.mgmt_subnet},host={host},dns={dns},dhcpstart={guest}," +
+            f"hostfwd=tcp:0.0.0.0:22-{guest}:22," +   # ssh
+            f"hostfwd=udp:0.0.0.0:161-{guest}:161," +  # snmp
+            (",".join([ f"hostfwd=tcp:0.0.0.0:{p}-{guest}:{p}" for p in self.mgmt_tcp_ports ])) +
+            ",tftp=/tftpboot"
         )
         return res
 
@@ -552,7 +552,7 @@ class VM:
                 con.write("\r".encode())
                 time.sleep(10)
                 res = con.read_until(wait.encode())
-            
+
             cleaned_buf = (
                 (con.read_very_eager()) if clean_buffer else None
             )  # Clear any remaining characters in buffer

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -496,7 +496,7 @@ class VM:
         self.stop()
         self.start()
 
-    def wait_write(self, cmd, wait="__defaultpattern__", con=None, clean_buffer=False):
+    def wait_write(self, cmd, wait="__defaultpattern__", con=None, clean_buffer=False, hold=""):
         """Wait for something on the serial port and then send command
 
         Defaults to using self.tn as connection but this can be overridden
@@ -518,6 +518,12 @@ class VM:
             self.logger.trace(f"waiting for '{wait}' on {con_name}")
             res = con.read_until(wait.encode())
 
+            while (hold and (hold in res.decode())):
+                self.logger.trace(f"Holding pattern '{hold}' detected: {res.decode()}, retrying in 10s...")
+                con.write("\r".encode())
+                time.sleep(10)
+                res = con.read_until(wait.encode())
+            
             cleaned_buf = (
                 (con.read_very_eager()) if clean_buffer else None
             )  # Clear any remaining characters in buffer

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -324,7 +324,8 @@ class VM:
           57400 - nokia gnmi/gnoi
         """
         if self.mgmt_host_ip+1>=self.mgmt_guest_ip:
-            self.logger.error(f"Guest IP ({self.mgmt_guest_ip}) must be at least 2 higher than host IP({self.mgmt_host_ip})")
+            self.logger.error("Guest IP (%s) must be at least 2 higher than host IP(%s)", 
+                              self.mgmt_guest_ip, self.mgmt_host_ip)
 
         network = ipaddress.ip_network(self.mgmt_subnet)
         host = str(network[self.mgmt_host_ip])

--- a/ftosv/README.md
+++ b/ftosv/README.md
@@ -200,10 +200,10 @@ Password:
 
 5. After the login (username: *admin*, password: *admin* or *linuxadmin*/*linuxadmin* followed by *su admin*), once the system is ready and the prompt appears, you need to **stop ztd** with the command `ztd cancel`. Then, `write memory` and `reload`.
 6. Once the reload is completed, you can shutdown the qemu-system host as the image has been built. With 10.5.2.4, it creates an image of approximately 7G.
-7. Next is to convert from vmdk to qcow2.
+7. Next is to convert from vmdk to qcow2 (tip: try adding "-c" for compression, may reduce qcow2 size to ~30%)
 
 ```bash
-qemu-img convert -f vmdk -O qcow2 OS10-Disk-1.0.0.vmdk dellftos.{VERSION}.qcow2
+qemu-img convert -f vmdk -O qcow2 -c OS10-Disk-1.0.0.vmdk dellftos.{VERSION}.qcow2
 ```
 
 Once this is complete, you'll be left with a qcow2 image that can then be built with the make command. To help validate output, here are the sizes of the 2 files.

--- a/ftosv/README.md
+++ b/ftosv/README.md
@@ -233,14 +233,3 @@ NOTE:
 * CPU: 4 core
 * RAM: 4GB
 * Disk: <10GB
-
-## Caveats / Working vs Non-Working images
-
-Currently, the readiness check is performed by checking for the `OS10#` prompt after the login.
-
-Before version *10.5.6.1*, Dell OS10 allows you to login even if the system is still loading, displaying a `System is loading...` text, and showing the prompt only after the loading is completed.
-
-Apparently, starting from *10.5.6.1*, now you still can login even if the system is still loading, but you are presented a prompt in the format `loading-OS10#` - which, unfortunately, matches `OS10#`. If you launch any command on the *loading* prompt, you get an error.
-
-However, this **seems** to be solved again on *10.5.6.4*.
-

--- a/ftosv/docker/launch.py
+++ b/ftosv/docker/launch.py
@@ -111,9 +111,7 @@ class FTOS_vm(vrnetlab.VM):
                 except IndexError as exc:
                     self.logger.error("no more credentials to try")
                     return
-                self.logger.debug(
-                    "trying to log in with %s / %s", username, password)
-                )
+                self.logger.debug("trying to log in with %s / %s", username, password)
                 self.wait_write(username, wait=None)
                 self.wait_write(password, wait="Password:")
 

--- a/ftosv/docker/launch.py
+++ b/ftosv/docker/launch.py
@@ -163,16 +163,16 @@ class FTOS_vm(vrnetlab.VM):
         """Load additional config provided by user."""
 
         if not os.path.exists(STARTUP_CONFIG_FILE):
-            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} is not found")
+            self.logger.trace("Startup config file %s is not found", STARTUP_CONFIG_FILE)
             return
 
-        self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} exists")
+        self.logger.trace("Startup config file %s exists", STARTUP_CONFIG_FILE)
         with open(STARTUP_CONFIG_FILE) as file:
             config_lines = file.readlines()
             config_lines = [line.rstrip() for line in config_lines]
-            self.logger.trace(f"Parsed startup config file {STARTUP_CONFIG_FILE}")
+            self.logger.trace("Parsed startup config file %s", STARTUP_CONFIG_FILE)
 
-        self.logger.info(f"Writing lines from {STARTUP_CONFIG_FILE}")
+        self.logger.info("Writing lines from %s", STARTUP_CONFIG_FILE)
 
         self.wait_write("configure terminal")
         # Apply lines from file

--- a/ftosv/docker/launch.py
+++ b/ftosv/docker/launch.py
@@ -78,21 +78,23 @@ class FTOS_vm(vrnetlab.VM):
             ]
         )
 
-    def gen_mgmt(self,subnet="169.254.127.0/24",host_ip=2,guest_ip=15,tcp_ports=[443,830]):
+    def gen_mgmt(self):
         """
         Augment the parent class function to add gRPC port forwarding
 
-        TCP ports:
+        TCP ports forwarded:
         443 - OS10 REST API
         830 - Netconf
         """
+        self.mgmt_subnet = "169.254.127.0/24"
+        self.mgmt_tcp_ports = [443,830]
         # call parent function to generate the mgmt interface
-        res = super(FTOS_vm, self).gen_mgmt(subnet=subnet,host_ip=host_ip,guest_ip=guest_ip,tcp_ports=tcp_ports)
+        res = super(FTOS_vm, self).gen_mgmt()
 
         # append gRPC forwarding if it was not added by common lib. confirm gNMI agent port number, default port is different than 50051?
         # gRPC Network Management Interface agent requires the switch in non default SmartFabric switch-operating-mode
-        network = ipaddress.ip_network(subnet)
-        guest = str(network[guest_ip])
+        network = ipaddress.ip_network(self.mgmt_subnet)
+        guest = str(network[self.mgmt_guest_ip])
         if f"hostfwd=tcp::50051-{guest}:50051" not in res[-1]:
             res[-1] = res[-1] + f",hostfwd=tcp::17051-{guest}:50051"
             vrnetlab.run_command(

--- a/ftosv/docker/launch.py
+++ b/ftosv/docker/launch.py
@@ -159,23 +159,6 @@ class FTOS_vm(vrnetlab.VM):
         )
 
         # No need to reconfigure mgmt IP; causes issues with parallel Netlab provisioning
-
-        # configure mgmt interface, put it in separate vrf before it has any configs
-        # self.wait_write("interface mgmt 1/1/1")
-        # self.wait_write("no ip address")
-        # self.wait_write("no ipv6 address autoconfig")
-        # self.wait_write("exit")
-# 
-        # self.wait_write("ip vrf management")
-        # self.wait_write("interface management")
-        # self.wait_write("exit")
-
-        # self.wait_write("interface mgmt 1/1/1")
-        # self.wait_write("no ip address dhcp")
-        # self.wait_write("ip address 169.254.127.15/24")
-        # self.wait_write("exit")
-        # self.wait_write("management route 0.0.0.0/0 169.254.127.2")
-        # self.wait_write("exit")
         self.wait_write("copy running-configuration startup-configuration")
         self.wait_write("")
 

--- a/ftosv/docker/launch.py
+++ b/ftosv/docker/launch.py
@@ -112,7 +112,7 @@ class FTOS_vm(vrnetlab.VM):
                     self.logger.error("no more credentials to try")
                     return
                 self.logger.debug(
-                    "trying to log in with %s / %s" % (username, password)
+                    "trying to log in with %s / %s", username, password)
                 )
                 self.wait_write(username, wait=None)
                 self.wait_write(password, wait="Password:")
@@ -124,7 +124,7 @@ class FTOS_vm(vrnetlab.VM):
                 self.tn.close()
                 # startup time?
                 startup_time = datetime.datetime.now() - self.start_time
-                self.logger.info("Startup complete in: %s" % startup_time)
+                self.logger.info("Startup complete in: %s", startup_time)
                 # mark as running
                 self.running = True
                 return
@@ -132,7 +132,7 @@ class FTOS_vm(vrnetlab.VM):
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time
         if res != b"":
-            self.logger.trace("OUTPUT: %s" % res.decode())
+            self.logger.trace("OUTPUT: %s", res.decode())
             # reset spins if we saw some output
             self.spins = 0
 

--- a/ftosv/docker/launch.py
+++ b/ftosv/docker/launch.py
@@ -144,7 +144,7 @@ class FTOS_vm(vrnetlab.VM):
         """Do the actual bootstrap config"""
         self.logger.info("applying bootstrap configuration once system is ready")
         self.wait_write("", None)
-        self.wait_write("configure", wait="OS10#")
+        self.wait_write("configure", wait="OS10#", hold="loading-OS10#")
         self.wait_write(f"hostname {self.hostname}")
         self.wait_write("service simple-password")
         self.wait_write(


### PR DESCRIPTION
* Wait while system gives "loading" prompt
* Add note on qcow2 compression, reduced image to ~30% in my case for 10.5.6.6:
```-rw-r--r--  1 jvanbemmel jvanbemmel 2336227328 Oct 31 08:54 dellftos.10.5.6.6.qcow2```

More general changes:
* Refactor management IP network settings, make them configurable
* Change Dell OS10 management link to private 169.254.127.0/24 range, to minimize chance at overlap with other configs ( original 10.0.0.0/24 is way too common ... )
* Forward only the TCP ports used by the platform, not the full set of those used by all other platforms
* Address warnings caused by format strings to logger