### PR TITLE
Add support for PAN hotfix releases.

### DIFF
--- a/pan/Makefile
+++ b/pan/Makefile
@@ -6,7 +6,7 @@ IMAGE_GLOB=*.qcow2
 # match versions like:
 # PA-VNM-KVM-7.0.1.qcow2
 # PA-VM-KVM-10.0.6.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.*-\([0-9]\{1,2\}\.[0-9]\{1,2\}.[0-9]\{1,2\}\)\.qcow2$$/\1/')
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.*-\([0-9]\{1,2\}\.[0-9]\{1,2\}.[0-9]\{1,2\}\(\|-h[0-9]\{1,2\}\)\)\.qcow2$$/\1/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include


### PR DESCRIPTION
Minor regular expression update to support hotfix releases.

An example of this is PA-VM-KVM-11.1.2-h3.qcow2.