### PR TITLE
Fix launch.py for ios xrv >7.1

### DIFF
--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -232,8 +232,8 @@ class XRV_vm(vrnetlab.VM):
         # make sure we get our prompt back
         self.wait_write("")
 
-        # wait for call-home in config
-        if not self._wait_config("show running-config call-home", "service active"):
+        # wait for linecard to show up
+        if not self._wait_config("show platform | in LC", "IOS XR RUN"):
             return False
 
         self.wait_write("configure")


### PR DESCRIPTION
IOS XRv 24.2.2 does not show call-home configuration.
waiting for the linecard to give status IOS XR RUN works instead.

Tested with 24.2.2, 7.11.2 and 7.9.2