### PR TITLE
backdoor to reset VR

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -696,6 +696,18 @@ class VR:
                 else:
                     self.update_health(1, "starting")
 
+            #backdoor to trigger a system reset on all VMs via qemu-monitor
+            if os.path.exists('/reset'):
+                for vm in self.vms:
+                    try:
+                        vm.qm.write("system_reset\r".encode())
+                        self.logger.debug(f"Sent qemu-monitor system_reset to VM num {vm.num} ")
+                    except Exception as e:
+                        self.logger.debug(f"Failed to send qemu-monitor system_reset to VM num {vm.num} ({e})")
+                try:
+                    os.remove('/reset')
+                except Exception as e:
+                    self.logger.debug(f"Failed to cleanup /reset file({e}). qemu-monitor system_reset will likely be triggered again on VMs")
 
 class QemuBroken(Exception):
     """Our Qemu instance is somehow broken"""


### PR DESCRIPTION
Sometimes one or more VR VM hangs. Hopefully a qemu-monitor **system_reset** command can recover most (if not all) scenarios, without disrupting existing VM properties.

To trigger a reset of all VMs, just create a file named "/reset" in the container
`sudo docker exec -it jmac-sros-sr touch /reset`