### PR TITLE
backdoor to reset VR or specific VMs

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -696,14 +696,20 @@ class VR:
                 else:
                     self.update_health(1, "starting")
 
-            #backdoor to trigger a system reset on all VMs via qemu-monitor
+            #file-based signalling backdoor to trigger a system reset (via qemu-monitor) on all or specific VMs.
+            #if file is empty: reset whole VR (all VMs)
+            #if file is non-empty: reset only specified VMs (comma separated list)
             if os.path.exists('/reset'):
+                with open('/reset','rt') as f:
+                    fcontent=f.read().strip()
+                vm_num_list=fcontent.split(',')
                 for vm in self.vms:
-                    try:
-                        vm.qm.write("system_reset\r".encode())
-                        self.logger.debug(f"Sent qemu-monitor system_reset to VM num {vm.num} ")
-                    except Exception as e:
-                        self.logger.debug(f"Failed to send qemu-monitor system_reset to VM num {vm.num} ({e})")
+                    if (str(vm.num) in vm_num_list) or not fcontent:
+                        try:
+                            vm.qm.write("system_reset\r".encode())
+                            self.logger.debug(f"Sent qemu-monitor system_reset to VM num {vm.num} ")
+                        except Exception as e:
+                            self.logger.debug(f"Failed to send qemu-monitor system_reset to VM num {vm.num} ({e})")
                 try:
                     os.remove('/reset')
                 except Exception as e:

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -696,6 +696,18 @@ class VR:
                 else:
                     self.update_health(1, "starting")
 
+            #backdoor to trigger a system reset on all VMs via qemu-monitor
+            if os.path.exists('/reset'):
+                for vm in self.vms:
+                    try:
+                        vm.qm.write("system_reset\r".encode())
+                        self.logger.debug(f"Sent qemu-monitor system_reset to VM num {vm.num} ")
+                    except Exception as e:
+                        self.logger.debug(f"Failed to send qemu-monitor system_reset to VM num {vm.num} ({e})")
+                try:
+                    os.remove('/reset')
+                except Exception as e:
+                    self.logger.debug(f"Failed to cleanup /reset file({e}). qemu-monitor system_reset will likely be triggered again on VMs")
 
 class QemuBroken(Exception):
     """Our Qemu instance is somehow broken"""


### PR DESCRIPTION
File-based signalling interface to send a qemu-monitor **system_reset** command to all or a subset of the VR component VMs . This acts like an hardware reset button without disrupting existing qemu VM properties (interfaces, disks...). It should recover a VM in hang state without need to re-deploy the whole clab topology. Also useful in some test scenarios.

### Usage: 
Create a file named "reset" under the root path of the container. There are two possibilities:
- **To reset the VR**, create an empty file:
eg: `sudo docker exec container_name_or_id touch /reset` -> reset all component VMs

- **To reset specific VMs**, include a comma separated list of VM numbers in the file contents.
eg: `sudo docker exec container_name_or_id sh -c 'echo "0" > /reset'` -> reset VM 0
eg: `sudo docker exec container_name_or_id sh -c 'echo "1,2" > /reset'` -> reset VM 1 & VM 2
