### PR TITLE
Some Readme content edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The documentation provided in this fork only explains the parts that have been c
 At [containerlab](https://containerlab.srlinux.dev) we needed to have [a way to run virtual routers](https://containerlab.srlinux.dev/manual/vrnetlab/) alongside the containerized Network Operating Systems.
 
 Vrnetlab provides a perfect machinery to package most-common routing VMs in the container packaging. What upstream vrnetlab doesn't do, though, is creating datapath between the VMs in a "container-native" way.  
-Vrnetlab relies on a separate VM (vr-xcon) to stich sockets exposed on each container and that doesn't play well with the regular ways of interconnecting container workloads.
+Vrnetlab relies on a separate VM (vr-xcon) to stitch sockets exposed on each container and that doesn't play well with the regular ways of interconnecting container workloads.
 
 This fork adds additional option for `launch.py` script of the supported VMs called `connection-mode`. This option allows to choose the way vrnetlab will create datapath for the launched VMs.
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,45 @@
 # vrnetlab - VR Network Lab
 
-This is a fork of the original [plajjan/vrnetlab](https://github.com/plajjan/vrnetlab) project and was created specifically to make vrnetlab-based images runnable by [containerlab](https://containerlab.srlinux.dev).
+This is a fork of the original [plajjan/vrnetlab](https://github.com/plajjan/vrnetlab)
+project and was created specifically to make vrnetlab-based images runnable by
+[containerlab](https://containerlab.srlinux.dev).
 
-The documentation provided in this fork only explains the parts that have been changed from the upstream project. To get a general overview of the vrnetlab project itself, consider reading the [docs of the upstream repo](https://github.com/vrnetlab/vrnetlab/blob/master/README.md).
+The documentation provided in this fork only explains the parts that have been
+changed from the upstream project. To get a general overview of the vrnetlab
+project itself, consider reading the [docs of the upstream repo](https://github.com/vrnetlab/vrnetlab/blob/master/README.md).
 
 ## What is this fork about?
 
-At [containerlab](https://containerlab.srlinux.dev) we needed to have [a way to run virtual routers](https://containerlab.srlinux.dev/manual/vrnetlab/) alongside the containerized Network Operating Systems.
+At [containerlab](https://containerlab.srlinux.dev) we needed to have
+[a way to run virtual routers](https://containerlab.srlinux.dev/manual/vrnetlab/)
+alongside the containerized Network Operating Systems.
 
-Vrnetlab provides perfect machinery to package most-common routing VMs in container packaging. What upstream vrnetlab doesn't do, though, is create datapaths between the VMs in a "container-native" way.
+Vrnetlab provides perfect machinery to package most-common routing VMs in
+container packaging. What upstream vrnetlab doesn't do, though, is create
+datapaths between the VMs in a "container-native" way.
 
-Vrnetlab relies on a separate VM ([vr-xcon](https://github.com/vrnetlab/vrnetlab/tree/master/vr-xcon)) to stitch sockets exposed on each container and that doesn't play well with the regular ways of interconnecting container workloads.
+Vrnetlab relies on a separate VM ([vr-xcon](https://github.com/vrnetlab/vrnetlab/tree/master/vr-xcon))
+to stitch sockets exposed on each container and that doesn't play well with the
+regular ways of interconnecting container workloads.
 
-This fork adds the additional option `connection-mode` to the `launch.py` script of supported VMs. The `connection-mode` option controls how vrnetlab creates datapaths for launched VMs.
+This fork adds the additional option `connection-mode` to the `launch.py` script
+of supported VMs. The `connection-mode` option controls how vrnetlab creates
+datapaths for launched VMs.
 
-The `connection-mode` values make it possible to run vrnetlab containers with networking that doesn't require a separate container and is native to tools such as docker.
+The `connection-mode` values make it possible to run vrnetlab containers with
+networking that doesn't require a separate container and is native to tools such
+as docker.
 
 ### Container-native networking?
 
-Yes, the term is bloated. What it actually means is this fork makes it possible to add interfaces to a container hosting a qemu VM and vrnetlab will recognize those interfaces and stitch them with the VM interfaces.
+Yes, the term is bloated. What it actually means is this fork makes it possible
+to add interfaces to a container hosting a qemu VM and vrnetlab will recognize
+those interfaces and stitch them with the VM interfaces.
 
-With this you can, for example, add veth pairs between containers as you would normally and vrnetlab will make sure these ports get mapped to your routers' ports. In essence, that allows you to work with your vrnetlab containers like a normal container and get the datapath working in the same "native" way.
+With this you can, for example, add veth pairs between containers as you would
+normally and vrnetlab will make sure these ports get mapped to your routers'
+ports. In essence, that allows you to work with your vrnetlab containers like a
+normal container and get the datapath working in the same "native" way.
 
 > [!IMPORTANT]
 > Although the changes we made here are of a general purpose and you can run
@@ -63,7 +82,8 @@ Full list of connection mode values:
 
 ## Which vrnetlab routers are supported?
 
-Since the changes we made in this fork are VM specific, we added a few popular routing products:
+Since the changes we made in this fork are VM specific, we added a few popular
+routing products:
 
 * Arista vEOS
 * Cisco XRv9k

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ The default option that we use in containerlab for this setting is `connection-m
 Using tc redirection (tc-mirred) we get a transparent pipe between container's interfaces and VM's.
 
 We scrambled through many alternatives, which I described in
-[this post](https://web.archive.org/web/20220621131105/https://netdevops.me/2021/transparently-redirecting-packets/frames-between-interfaces/),
-but tc-redirect works best of them all.
+[this post](https://web.archive.org/web/20220621131105/https://netdevops.me/2021/transparently-redirecting-packets/frames-between-interfaces/)
+(archive.org copy), but tc-redirect works best of them all.
 
 ### Mode List
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Using tc redirection (tc-mirred) we get a transparent pipe between container's i
 
 We scrambled through many alternatives, which I described in
 [this post](https://netdevops.me/2021/transparently-redirecting-packetsframes-between-interfaces/),
-but tc-redirect works best of them all.
+but tc redirect (tc-mirred) works best of them all.
 
 ### Mode List
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vrnetlab - VR Network Lab
 
-This is a fork of the original [plajjan/vrnetlab](https://github.com/plajjan/vrnetlab) project. The fork has been created specifically to make vrnetlab-based images to be runnable by [containerlab](https://containerlab.srlinux.dev).
+This is a fork of the original [plajjan/vrnetlab](https://github.com/plajjan/vrnetlab) project and was created specifically to make vrnetlab-based images runnable by [containerlab](https://containerlab.srlinux.dev).
 
-The documentation provided in this fork only explains the parts that have been changed in any way from the upstream project. To get a general overview of the vrnetlab project itself, consider reading the docs of the upstream repo.
+The documentation provided in this fork only explains the parts that have been changed from the upstream project. To get a general overview of the vrnetlab project itself, consider reading the [docs of the upstream repo](https://github.com/vrnetlab/vrnetlab/blob/master/README.md).
 
 ## What is this fork about?
 At [containerlab](https://containerlab.srlinux.dev) we needed to have [a way to run virtual routers](https://containerlab.srlinux.dev/manual/vrnetlab/) alongside the containerized Network Operating Systems.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ The default option that we use in containerlab for this setting is `connection-m
 Using tc redirection (tc-mirred) we get a transparent pipe between container's interfaces and VM's.
 
 We scrambled through many alternatives, which I described in
-[this post](https://netdevops.me/2021/transparently-redirecting-packetsframes-between-interfaces/)
-(archive.org copy), but tc-redirect works best of them all.
+[this post](https://netdevops.me/2021/transparently-redirecting-packetsframes-between-interfaces/),
+but tc-redirect works best of them all.
 
 ### Mode List
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a fork of the original [plajjan/vrnetlab](https://github.com/plajjan/vrn
 The documentation provided in this fork only explains the parts that have been changed from the upstream project. To get a general overview of the vrnetlab project itself, consider reading the [docs of the upstream repo](https://github.com/vrnetlab/vrnetlab/blob/master/README.md).
 
 ## What is this fork about?
+
 At [containerlab](https://containerlab.srlinux.dev) we needed to have [a way to run virtual routers](https://containerlab.srlinux.dev/manual/vrnetlab/) alongside the containerized Network Operating Systems.
 
 Vrnetlab provides perfect machinery to package most-common routing VMs in container packaging. What upstream vrnetlab doesn't do, though, is create datapaths between the VMs in a "container-native" way.
@@ -16,6 +17,7 @@ This fork adds the additional option `connection-mode` to the `launch.py` script
 The `connection-mode` values make it possible to run vrnetlab containers with networking that doesn't require a separate container and is native to tools such as docker.
 
 ### Container-native networking?
+
 Yes, the term is bloated. What it actually means is this fork makes it possible to add interfaces to a container hosting a qemu VM and vrnetlab will recognize those interfaces and stitch them with the VM interfaces.
 
 With this you can, for example, add veth pairs between containers as you would normally and vrnetlab will make sure these ports get mapped to your routers' ports. In essence, that allows you to work with your vrnetlab containers like a normal container and get the datapath working in the same "native" way.
@@ -60,6 +62,7 @@ Full list of connection mode values:
 | macvtap         | :x:                 | Requires mounting entire `/dev` to a container namespace. Needs file descriptor manipulation due to no native qemu support.
 
 ## Which vrnetlab routers are supported?
+
 Since the changes we made in this fork are VM specific, we added a few popular routing products:
 
 * Arista vEOS
@@ -79,4 +82,5 @@ Since the changes we made in this fork are VM specific, we added a few popular r
 The rest are left untouched and can be contributed back by the community.
 
 ## Does the build process change?
+
 No. You build the images exactly as before.

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ This fork adds the additional option `connection-mode` to the `launch.py` script
 The `connection-mode` values make it possible to run vrnetlab containers with networking that doesn't require a separate container and is native to tools such as docker.
 
 ### Container-native networking?
-Yes, the term is bloated, what it actually means is that with the changes we made in this fork it is possible to add interfaces to a container that hosts a qemu VM and vrnetlab will recognize those interfaces and stitch them with the VM interfaces.
+Yes, the term is bloated. What it actually means is this fork makes it possible to add interfaces to a container hosting a qemu VM and vrnetlab will recognize those interfaces and stitch them with the VM interfaces.
 
-With this you can just add, say, veth pairs between the containers as you would do normally, and vrnetlab will make sure that these ports get mapped to your router' ports. In essence, that allows you to work with your vrnetlab containers like with a normal container and get the datapath working in the same "native" way.
+With this you can, for example, add veth pairs between containers as you would normally and vrnetlab will make sure these ports get mapped to your routers' ports. In essence, that allows you to work with your vrnetlab containers like a normal container and get the datapath working in the same "native" way.
 
 > [!IMPORTANT]
 > Although the changes we made here are of a general purpose and you can run
 > vrnetlab routers with docker CLI or any other container runtime, the purpose
 > of this work was to couple vrnetlab with containerlab.
 >
-> With this being said, we recommend the readers to start their journey from
+> With this being said, we recommend the readers start their journey from
 > this [documentation entry](https://containerlab.dev/manual/vrnetlab/)
 > which will show you how easy it is to run routers in a containerized setting.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ With this you can, for example, add veth pairs between containers as you would n
 
 As mentioned above, the major change this fork brings is the ability to run
 vrnetlab containers without requiring [vr-xcon](https://github.com/vrnetlab/vrnetlab/tree/master/vr-xcon)
-and instead using container-native networking.
+and instead uses container-native networking.
 
 For containerlab the default connection mode value is `connection-mode=tc`.
 With this particular mode we use **tc-mirred** redirects to stitch a container's

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The documentation provided in this fork only explains the parts that have been c
 ## What is this fork about?
 At [containerlab](https://containerlab.srlinux.dev) we needed to have [a way to run virtual routers](https://containerlab.srlinux.dev/manual/vrnetlab/) alongside the containerized Network Operating Systems.
 
-Vrnetlab provides perfect machinery to package most-common routing VMs in the container packaging. What upstream vrnetlab doesn't do, though, is creating datapath between the VMs in a "container-native" way.
+Vrnetlab provides perfect machinery to package most-common routing VMs in container packaging. What upstream vrnetlab doesn't do, though, is create datapaths between the VMs in a "container-native" way.
 
 Vrnetlab relies on a separate VM ([vr-xcon](https://github.com/vrnetlab/vrnetlab/tree/master/vr-xcon)) to stitch sockets exposed on each container and that doesn't play well with the regular ways of interconnecting container workloads.
 
-This fork adds additional option for `launch.py` script of the supported VMs called `connection-mode`. This option allows to choose the way vrnetlab will create datapath for the launched VMs.
+This fork adds the additional option `connection-mode` to the `launch.py` script of supported VMs. The `connection-mode` option controls how vrnetlab creates datapaths for launched VMs.
 
-By adding a few options a `connection-mode` value can be set to, we made it possible to run vrnetlab containers with the networking that doesn't require a separate container and is native to the tools like docker.
+The `connection-mode` values make it possible to run vrnetlab containers with networking that doesn't require a separate container and is native to tools such as docker.
 
 ### Container-native networking?
 Yes, the term is bloated, what it actually means is that with the changes we made in this fork it is possible to add interfaces to a container that hosts a qemu VM and vrnetlab will recognize those interfaces and stitch them with the VM interfaces.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ The default option that we use in containerlab for this setting is `connection-m
 
 Using tc redirection we get a transparent pipe between container's interfaces and VM's.
 
-We scrambled through many alternatives, which I described in [this post](https://netdevops.me/2021/transparently-redirecting-packets/frames-between-interfaces/), but tc-redirect works best of them all.
+We scrambled through many alternatives, which I described in
+[this post](https://web.archive.org/web/20220621131105/https://netdevops.me/2021/transparently-redirecting-packets/frames-between-interfaces/),
+but tc-redirect works best of them all.
 
 Other connection mode values are:
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ The documentation provided in this fork only explains the parts that have been c
 ## What is this fork about?
 At [containerlab](https://containerlab.srlinux.dev) we needed to have [a way to run virtual routers](https://containerlab.srlinux.dev/manual/vrnetlab/) alongside the containerized Network Operating Systems.
 
-Vrnetlab provides a perfect machinery to package most-common routing VMs in the container packaging. What upstream vrnetlab doesn't do, though, is creating datapath between the VMs in a "container-native" way.  
-Vrnetlab relies on a separate VM (vr-xcon) to stitch sockets exposed on each container and that doesn't play well with the regular ways of interconnecting container workloads.
+Vrnetlab provides perfect machinery to package most-common routing VMs in the container packaging. What upstream vrnetlab doesn't do, though, is creating datapath between the VMs in a "container-native" way.
+
+Vrnetlab relies on a separate VM ([vr-xcon](https://github.com/vrnetlab/vrnetlab/tree/master/vr-xcon)) to stitch sockets exposed on each container and that doesn't play well with the regular ways of interconnecting container workloads.
 
 This fork adds additional option for `launch.py` script of the supported VMs called `connection-mode`. This option allows to choose the way vrnetlab will create datapath for the launched VMs.
 
@@ -29,7 +30,7 @@ With this you can just add, say, veth pairs between the containers as you would 
 > which will show you how easy it is to run routers in a containerized setting.
 
 ## Connection modes
-As mentioned above, the major change this fork brings is the ability to run vrnetlab containers without requiring vr-xcon and by using container-native networking.
+As mentioned above, the major change this fork brings is the ability to run vrnetlab containers without requiring [vr-xcon](https://github.com/vrnetlab/vrnetlab/tree/master/vr-xcon) and by using container-native networking.
 
 The default option that we use in containerlab for this setting is `connection-mode=tc`. With this particular mode we use **tc-mirred** redirects to stitch container's interfaces `eth1+` with the ports of the qemu VM running inside.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The default option that we use in containerlab for this setting is `connection-m
 Using tc redirection (tc-mirred) we get a transparent pipe between container's interfaces and VM's.
 
 We scrambled through many alternatives, which I described in
-[this post](https://web.archive.org/web/20220621131105/https://netdevops.me/2021/transparently-redirecting-packets/frames-between-interfaces/)
+[this post](https://netdevops.me/2021/transparently-redirecting-packetsframes-between-interfaces/)
 (archive.org copy), but tc-redirect works best of them all.
 
 ### Mode List

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Full list of connection mode values:
 
 | Connection Mode | LACP Support        | Description |
 | --------------- | :-----------------: | :---------- |
-| tc-mirred       | :white_check_mark:  | Creates a linux bridge and attaches `eth` and `tap` interfaces to it.
+| tc-mirred       | :white_check_mark:  | Creates a linux bridge and attaches `eth` and `tap` interfaces to it. Cleanest solution for point-to-point links.
 | bridge          | :last_quarter_moon: | No additional kernel modules and has native qemu/libvirt support. Does not support passing STP. Requires restricting `MAC_PAUSE` frames in order to support LACP.
 | ovs-bridge      | :white_check_mark:  | Same as a regular bridge, but uses OvS (Open vSwitch).
 | macvtap         | :x:                 | Requires mounting entire `/dev` to a container namespace. Needs file descriptor manipulation due to no native qemu support.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ With this you can just add, say, veth pairs between the containers as you would 
 > of this work was to couple vrnetlab with containerlab.
 >
 > With this being said, we recommend the readers to start their journey from
-> this [documentation entry](https://containerlab.srlinux.dev/manual/vrnetlab/)
+> this [documentation entry](https://containerlab.dev/manual/vrnetlab/)
 > which will show you how easy it is to run routers in a containerized setting.
 
 ## Connection modes

--- a/README.md
+++ b/README.md
@@ -31,21 +31,26 @@ With this you can just add, say, veth pairs between the containers as you would 
 ## Connection modes
 As mentioned above, the major change this fork brings is the ability to run vrnetlab containers without requiring vr-xcon and by using container-native networking.
 
-The default option that we use in containerlab for this setting is `connection-mode=tc`. With this particular mode we use tc-mirred redirects to stitch container's interfaces `eth1+` with the ports of the qemu VM running inside.
+The default option that we use in containerlab for this setting is `connection-mode=tc`. With this particular mode we use **tc-mirred** redirects to stitch container's interfaces `eth1+` with the ports of the qemu VM running inside.
 
 ![tc](https://gitlab.com/rdodin/pics/-/wikis/uploads/4d31c06e6258e70edc887b17e0e758e0/image.png)
 
-Using tc redirection we get a transparent pipe between container's interfaces and VM's.
+Using tc redirection (tc-mirred) we get a transparent pipe between container's interfaces and VM's.
 
 We scrambled through many alternatives, which I described in
 [this post](https://web.archive.org/web/20220621131105/https://netdevops.me/2021/transparently-redirecting-packets/frames-between-interfaces/),
 but tc-redirect works best of them all.
 
-Other connection mode values are:
+### Mode List
 
-* bridge - creates a linux bridge and attaches `eth` and `tap` interfaces to it. Can't pass LACP traffic.
-* ovs-bridge - same as a regular bridge, but uses OvS. Can pass LACP traffic.
-* macvtap
+Full list of connection mode values:
+
+| Connection Mode | LACP Support        | Description |
+| --------------- | :-----------------: | :---------- |
+| tc-mirred       | :white_check_mark:  | Creates a linux bridge and attaches `eth` and `tap` interfaces to it.
+| bridge          | :last_quarter_moon: | No additional kernel modules and has native qemu/libvirt support. Does not support passing STP. Requires restricting `MAC_PAUSE` frames in order to support LACP.
+| ovs-bridge      | :white_check_mark:  | Same as a regular bridge, but uses OvS (Open vSwitch).
+| macvtap         | :x:                 | Requires mounting entire `/dev` to a container namespace. Needs file descriptor manipulation due to no native qemu support.
 
 ## Which vrnetlab routers are supported?
 Since the changes we made in this fork are VM specific, we added a few popular routing products:

--- a/README.md
+++ b/README.md
@@ -30,17 +30,23 @@ With this you can, for example, add veth pairs between containers as you would n
 > which will show you how easy it is to run routers in a containerized setting.
 
 ## Connection modes
-As mentioned above, the major change this fork brings is the ability to run vrnetlab containers without requiring [vr-xcon](https://github.com/vrnetlab/vrnetlab/tree/master/vr-xcon) and by using container-native networking.
 
-The default option that we use in containerlab for this setting is `connection-mode=tc`. With this particular mode we use **tc-mirred** redirects to stitch container's interfaces `eth1+` with the ports of the qemu VM running inside.
+As mentioned above, the major change this fork brings is the ability to run
+vrnetlab containers without requiring [vr-xcon](https://github.com/vrnetlab/vrnetlab/tree/master/vr-xcon)
+and instead using container-native networking.
 
-![tc](https://gitlab.com/rdodin/pics/-/wikis/uploads/4d31c06e6258e70edc887b17e0e758e0/image.png)
+For containerlab the default connection mode value is `connection-mode=tc`.
+With this particular mode we use **tc-mirred** redirects to stitch a container's
+interfaces `eth1+` with the ports of the qemu VM running inside.
 
-Using tc redirection (tc-mirred) we get a transparent pipe between container's interfaces and VM's.
+![diagram showing network connections via tc redirects](https://gitlab.com/rdodin/pics/-/wikis/uploads/4d31c06e6258e70edc887b17e0e758e0/image.png)
 
-We scrambled through many alternatives, which I described in
+Using tc redirection (tc-mirred) we get a transparent pipe between a container's
+interfaces and those of the VMs running within.
+
+We scrambled through many connection alternatives, which are described in
 [this post](https://netdevops.me/2021/transparently-redirecting-packetsframes-between-interfaces/),
-but tc redirect (tc-mirred) works best of them all.
+but tc redirect (tc-mirred :star:) works best of them all.
 
 ### Mode List
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,14 @@ Yes, the term is bloated, what it actually means is that with the changes we mad
 
 With this you can just add, say, veth pairs between the containers as you would do normally, and vrnetlab will make sure that these ports get mapped to your router' ports. In essence, that allows you to work with your vrnetlab containers like with a normal container and get the datapath working in the same "native" way.
 
-> Although the changes we made here are of a general purpose and you can run vrnetlab routers with docker CLI or any other container runtime, the purpose of this work was to couple vrnetlab with containerlab.  
-> With this being said, we recommend the readers to start their journey from this [documentation entry](https://containerlab.srlinux.dev/manual/vrnetlab/) which will show you how easy it is to run routers in a containerized setting.
+> [!IMPORTANT]
+> Although the changes we made here are of a general purpose and you can run
+> vrnetlab routers with docker CLI or any other container runtime, the purpose
+> of this work was to couple vrnetlab with containerlab.
+>
+> With this being said, we recommend the readers to start their journey from
+> this [documentation entry](https://containerlab.srlinux.dev/manual/vrnetlab/)
+> which will show you how easy it is to run routers in a containerized setting.
 
 ## Connection modes
 As mentioned above, the major change this fork brings is the ability to run vrnetlab containers without requiring vr-xcon and by using container-native networking.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ interfaces and those of the VMs running within.
 
 We scrambled through many connection alternatives, which are described in
 [this post](https://netdevops.me/2021/transparently-redirecting-packetsframes-between-interfaces/),
-but tc redirect (tc-mirred :star:) works best of them all.
+but tc redirect (tc-mirred :star:) works best of all.
 
 ### Mode List
 


### PR DESCRIPTION
Overall some minor items in the Readme content.

* Fix typo(s)
* Change quoted area to an Alert (a.k.a. admonition)
* Replace a broken netdevops.me hyperlink with an archive.org copy of that page
* Move the Connection Mode list into a table
* Various wording and sentence changes (admittedly my take and can be adjusted)
* Markdown linting-esque changes
  * (full MD linting and GH Actions for another PR!)
  * Surround MD headers with white space
  * Break long MD lines into shorter lines

I'm open to feedback and any tweaks/changes.