### PR TITLE
AOS-CX: Update CPU and MEM values for newer versions

### DIFF
--- a/aoscx/README.md
+++ b/aoscx/README.md
@@ -16,11 +16,13 @@ docker tag vrnetlab/vr-aoscx:20210610000730 vrnetlab/vr-aoscx:10.07.0010
 Tested booting and responding to SSH:
 
 * `ArubaOS-CX_10_12_0006.ova` (`arubaoscx-disk-image-genericx86-p4-20230531220439.vmdk`)
+* `ArubaOS-CX_10_13_0005.ova` (`arubaoscx-disk-image-genericx86-p4-20231110145644.vmdk`)
+* `ArubaOS-CX_10_14_1000.ova` (`arubaoscx-disk-image-genericx86-p4-20240731173624.vmdk`)
 
 ## System requirements
 
-CPU: 2 core
+CPU: 4 core
 
-RAM: 4GB
+RAM: 8GB
 
 Disk: <1GB

--- a/aoscx/docker/launch.py
+++ b/aoscx/docker/launch.py
@@ -47,7 +47,7 @@ class AOSCX_vm(vrnetlab.VM):
             logging.getLogger().info("Disk image was not found")
             exit(1)
         super(AOSCX_vm, self).__init__(
-            username, password, disk_image=disk_image, ram=4096, cpu="host,level=9", smp="2"
+            username, password, disk_image=disk_image, ram=8192, cpu="host,level=9", smp="4"
         )
         self.hostname = hostname
         self.conn_mode = conn_mode


### PR DESCRIPTION
Seems that newer versions of AOS-CX requires more CPU and RAM to work well (despite it can boot with the old, lower values, some problems can happen in case of huge config)