### PR TITLE
Implement Scrapli 'core' and platform migration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PYTHONPATH=".:./common"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cisco*.bin
 *.xz
 *.vmdk
 *.iso
+*cidfile
 
 .DS_Store
 */.DS_Store

--- a/aoscx/README.md
+++ b/aoscx/README.md
@@ -16,11 +16,13 @@ docker tag vrnetlab/vr-aoscx:20210610000730 vrnetlab/vr-aoscx:10.07.0010
 Tested booting and responding to SSH:
 
 * `ArubaOS-CX_10_12_0006.ova` (`arubaoscx-disk-image-genericx86-p4-20230531220439.vmdk`)
+* `ArubaOS-CX_10_13_0005.ova` (`arubaoscx-disk-image-genericx86-p4-20231110145644.vmdk`)
+* `ArubaOS-CX_10_14_1000.ova` (`arubaoscx-disk-image-genericx86-p4-20240731173624.vmdk`)
 
 ## System requirements
 
-CPU: 2 core
+CPU: 4 core
 
-RAM: 4GB
+RAM: 8GB
 
 Disk: <1GB

--- a/aoscx/docker/launch.py
+++ b/aoscx/docker/launch.py
@@ -47,7 +47,7 @@ class AOSCX_vm(vrnetlab.VM):
             logging.getLogger().info("Disk image was not found")
             exit(1)
         super(AOSCX_vm, self).__init__(
-            username, password, disk_image=disk_image, ram=4096, cpu="host,level=9", smp="2"
+            username, password, disk_image=disk_image, ram=8192, cpu="host,level=9", smp="4"
         )
         self.hostname = hostname
         self.conn_mode = conn_mode

--- a/build-base-image.sh
+++ b/build-base-image.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# this script builds the vrnetlab base container image
+# that is used in the dockerfiles of the NOS images
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+sudo docker build -t ghcr.io/srl-labs/vrnetlab-base:$1 \
+    -f vrnetlab-base.dockerfile .

--- a/c8000v/docker/Dockerfile
+++ b/c8000v/docker/Dockerfile
@@ -1,20 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    inetutils-ping \
-    ssh \
-    telnet \
-    procps \
-    genisoimage \
- && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
 
 ARG VERSION
 ENV VERSION=${VERSION}

--- a/c8000v/docker/Dockerfile
+++ b/c8000v/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
 
 ARG VERSION
 ENV VERSION=${VERSION}

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -9,9 +9,10 @@ import subprocess
 import sys
 
 import vrnetlab
+from scrapli.driver.core import IOSXEDriver
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-
+DEFAULT_SCRAPLI_TIMEOUT = 900
 
 def handle_SIGCHLD(signal, frame):
     os.waitpid(-1, os.WNOHANG)
@@ -52,7 +53,7 @@ class C8000v_vm(vrnetlab.VM):
             logger.info("License found")
             self.license = True
 
-        super().__init__(username, password, disk_image=disk_image, ram=4096)
+        super().__init__(username, password, disk_image=disk_image, ram=4096, use_scrapli=True)
         self.install_mode = install_mode
         self.hostname = hostname
         self.conn_mode = conn_mode
@@ -60,7 +61,7 @@ class C8000v_vm(vrnetlab.VM):
         self.nic_type = "virtio-net-pci"
 
         if self.install_mode:
-            logger.trace("install mode")
+            self.logger.debug("Install mode")
             self.image_name = "config.iso"
             self.create_boot_image()
 
@@ -104,28 +105,27 @@ class C8000v_vm(vrnetlab.VM):
             self.start()
             return
 
-        (ridx, match, res) = self.tn.expect(
-            [b"Press RETURN to get started!", b"IOSXEBOOT-4-FACTORY_RESET"], 1
+        (ridx, match, res) = self.con_expect(
+            [b"Press RETURN to get started!", b"IOSXEBOOT-4-FACTORY_RESET"]
         )
         if match:  # got a match!
             if ridx == 0:  # login
-                self.logger.debug("matched, Press RETURN to get started.")
+                self.logger.info("matched, Press RETURN to get started.")
                 if self.install_mode:
-                    self.logger.debug("Now we wait for the device to reload")
+                    self.logger.info("Now we wait for the device to reload")
                 else:
                     self.wait_write("", wait=None)
-
-                    # run main config!
-                    self.bootstrap_config()
-                    # add startup config if present
-                    self.startup_config()
+                    
+                    self.apply_config()
+                    
                     # close telnet connection
-                    self.tn.close()
+                    self.scrapli_tn.close()
+                    
                     # startup time?
                     startup_time = datetime.datetime.now() - self.start_time
                     self.logger.info("Startup complete in: %s", startup_time)
-                    # mark as running
                     self.running = True
+                    
                     return
             elif ridx == 1:  # IOSXEBOOT-4-FACTORY_RESET
                 if self.install_mode:
@@ -139,7 +139,7 @@ class C8000v_vm(vrnetlab.VM):
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time
         if res != b"":
-            self.logger.trace("OUTPUT: %s", res.decode())
+            self.write_to_stdout(res)
             # reset spins if we saw some output
             self.spins = 0
 
@@ -147,83 +147,83 @@ class C8000v_vm(vrnetlab.VM):
 
         return
 
-    def bootstrap_config(self):
-        """Do the actual bootstrap config"""
-        self.logger.info("applying bootstrap configuration")
-
+    def apply_config(self):
+        
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        self.logger.info(f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)")
+        
+        # init scrapli
+        cat8kv_scrapli_dev = {
+            "host": "127.0.0.1",
+            "auth_bypass": True,
+            "auth_strict_key": False,
+            "timeout_socket": scrapli_timeout,
+            "timeout_transport": scrapli_timeout,
+            "timeout_ops": scrapli_timeout,
+        }
+        
         v4_mgmt_address = vrnetlab.cidr_to_ddn(self.mgmt_address_ipv4)
+                
+        cat8kv_config = f"""hostname {self.hostname}
+username {self.username} privilege 15 password {self.password}
+ip domain name example.com
+!
+crypto key generate rsa modulus 2048
+!
+line con 0
+logging synchronous
+!
+line vty 0 4
+logging synchronous
+login local
+transport input all
+!
+ipv6 unicast-routing
+!
+vrf definition clab-mgmt
+description Containerlab management VRF (DO NOT DELETE)
+address-family ipv4
+exit
+address-family ipv6
+exit
+exit
+!
+ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 {self.mgmt_gw_ipv4}
+ipv6 route vrf clab-mgmt ::/0 {self.mgmt_gw_ipv6}
+!
+interface GigabitEthernet 1
+description Containerlab management interface
+vrf forwarding clab-mgmt
+ip address {v4_mgmt_address[0]} {v4_mgmt_address[1]}
+ipv6 address {self.mgmt_address_ipv6}
+no shut
+exit
+!
+restconf
+netconf-yang
+netconf max-sessions 16
+netconf detailed-error
+!
+ip ssh server algorithm mac hmac-sha2-512
+ip ssh maxstartups 128
+!
+"""
 
-        self.wait_write("", None)
-        self.wait_write("enable", wait=">")
-        self.wait_write("configure terminal", wait=">")
-
-        self.wait_write(f"hostname {self.hostname}")
-        self.wait_write(
-            "username %s privilege 15 password %s" % (self.username, self.password)
-        )
-        if int(self.version.split(".")[0]) >= 16:
-            self.wait_write("ip domain name example.com")
+        con = IOSXEDriver(**cat8kv_scrapli_dev)
+        con.commandeer(conn=self.scrapli_tn)
+        
+        if os.path.exists(STARTUP_CONFIG_FILE):
+            self.logger.info("Startup configuration file found")
+            with open(STARTUP_CONFIG_FILE, "r") as config:
+                cat8kv_config += config.read()
         else:
-            self.wait_write("ip domain-name example.com")
-        self.wait_write("crypto key generate rsa modulus 2048")
+            self.logger.warning(f"User provided startup configuration is not found.")
 
-        self.wait_write("ipv6 unicast-routing")
+        res = con.send_configs(cat8kv_config.splitlines())
 
-        self.wait_write("vrf definition clab-mgmt")
-        self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
-        self.wait_write("address-family ipv4")
-        self.wait_write("exit")
-        self.wait_write("address-family ipv6")
-        self.wait_write("exit")
-        self.wait_write("exit")
-
-        self.wait_write(f"ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 {self.mgmt_gw_ipv4}")
-        self.wait_write(f"ipv6 route vrf clab-mgmt ::/0 {self.mgmt_gw_ipv6}")
-
-        self.wait_write("interface GigabitEthernet1")
-        self.wait_write("vrf forwarding clab-mgmt")
-        self.wait_write(f"ip address {v4_mgmt_address[0]} {v4_mgmt_address[1]}")
-        self.wait_write(f"ipv6 address {self.mgmt_address_ipv6}")
-        self.wait_write("no shut")
-        self.wait_write("exit")
-        self.wait_write("restconf")
-        self.wait_write("netconf-yang")
-        self.wait_write("netconf max-sessions 16")
-        # I did not find any documentation about this, but is seems like a good idea!?
-        self.wait_write("netconf detailed-error")
-        self.wait_write("ip ssh server algorithm mac hmac-sha2-512")
-        self.wait_write("ip ssh maxstartups 128")
-
-        self.wait_write("line vty 0 4")
-        self.wait_write("login local")
-        self.wait_write("transport input all")
-        self.wait_write("end")
-        self.wait_write("copy running-config startup-config")
-        self.wait_write("\r", "Destination")
-
-    def startup_config(self):
-        """Load additional config provided by user."""
-
-        if not os.path.exists(STARTUP_CONFIG_FILE):
-            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} is not found")
-            return
-
-        self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} exists")
-        with open(STARTUP_CONFIG_FILE) as file:
-            config_lines = file.readlines()
-            config_lines = [line.rstrip() for line in config_lines]
-            self.logger.trace(f"Parsed startup config file {STARTUP_CONFIG_FILE}")
-
-        self.logger.info(f"Writing lines from {STARTUP_CONFIG_FILE}")
-
-        self.wait_write("configure terminal")
-        # Apply lines from file
-        for line in config_lines:
-            self.wait_write(line)
-        # End and Save
-        self.wait_write("end")
-        self.wait_write("copy running-config startup-config")
-        self.wait_write("\r", "Destination")
+        for response in res:
+            self.logger.info(f"CONFIG:{response.channel_input}")
+            self.logger.info(f"RESULT:{response.result}")
 
 
 class C8000v(vrnetlab.VR):
@@ -240,17 +240,17 @@ class C8000v_installer(C8000v):
     """
 
     def __init__(self, hostname, username, password, conn_mode):
-        super(C8000v_installer, self).__init__(hostname, username, password, conn_mode)
+        super(C8000v, self).__init__(username, password)
         self.vms = [
             C8000v_vm(hostname, username, password, conn_mode, install_mode=True)
         ]
 
     def install(self):
         self.logger.info("Installing C8000v")
-        csr = self.vms[0]
-        while not csr.running:
-            csr.work()
-        csr.stop()
+        cat8kv = self.vms[0]
+        while not cat8kv.running:
+            cat8kv.work()
+        cat8kv.stop()
         self.logger.info("Installation complete")
 
 

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -220,6 +220,7 @@ ip ssh maxstartups 128
             self.logger.warning(f"User provided startup configuration is not found.")
 
         res = con.send_configs(cat8kv_config.splitlines())
+        res += con.send_commands(["write memory"], eager=True)
 
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -11,7 +11,6 @@ import sys
 import vrnetlab
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-DEFAULT_SCRAPLI_TIMEOUT = 900
 
 
 def handle_SIGCHLD(signal, frame):

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -13,6 +13,7 @@ import vrnetlab
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
 DEFAULT_SCRAPLI_TIMEOUT = 900
 
+
 def handle_SIGCHLD(signal, frame):
     os.waitpid(-1, os.WNOHANG)
 
@@ -52,7 +53,9 @@ class C8000v_vm(vrnetlab.VM):
             logger.info("License found")
             self.license = True
 
-        super().__init__(username, password, disk_image=disk_image, ram=4096, use_scrapli=True)
+        super().__init__(
+            username, password, disk_image=disk_image, ram=4096, use_scrapli=True
+        )
         self.install_mode = install_mode
         self.hostname = hostname
         self.conn_mode = conn_mode
@@ -67,10 +70,10 @@ class C8000v_vm(vrnetlab.VM):
             cfg = self.gen_bootstrap_config()
             if os.path.exists(STARTUP_CONFIG_FILE):
                 self.logger.info("Startup configuration file found")
-                with open (STARTUP_CONFIG_FILE, "r") as startup_config:
+                with open(STARTUP_CONFIG_FILE, "r") as startup_config:
                     cfg += startup_config.read()
             else:
-                self.logger.warning(f"User provided startup configuration is not found.")
+                self.logger.warning("User provided startup configuration is not found.")
             self.create_config_image(cfg)
 
         self.qemu_args.extend(["-cdrom", "/" + self.image_name])
@@ -79,9 +82,9 @@ class C8000v_vm(vrnetlab.VM):
         """
         Returns the configuration to load in install mode
         """
-        
+
         config = ""
-        
+
         if self.license:
             config += """do clock set 13:33:37 1 Jan 2010
 interface GigabitEthernet1
@@ -92,7 +95,7 @@ license accept end user agreement
 yes
 do license install tftp://10.0.0.2/license.lic
 """
-        
+
         config += """
 license boot level network-premier addon dna-premier
 platform console serial
@@ -107,9 +110,9 @@ do reload
         """
         Returns the system bootstrap configuration
         """
-        
+
         v4_mgmt_address = vrnetlab.cidr_to_ddn(self.mgmt_address_ipv4)
-                
+
         return f"""hostname {self.hostname}
 username {self.username} privilege 15 password {self.password}
 ip domain name example.com
@@ -168,7 +171,7 @@ ip ssh maxstartups 128
             "/" + self.image_name,
             "/iosxe_config.txt",
         ]
-        
+
         self.logger.debug("Generating boot ISO")
         subprocess.Popen(genisoimage_args).wait()
 
@@ -180,12 +183,12 @@ ip ssh maxstartups 128
             self.stop()
             self.start()
             return
-        
+
         (ridx, match, res) = self.con_expect(
             [b"CVAC-4-CONFIG_DONE", b"IOSXEBOOT-4-FACTORY_RESET"]
         )
         if match:  # got a match!
-            if ridx == 0 and not self.install_mode:   # configuration applied
+            if ridx == 0 and not self.install_mode:  # configuration applied
                 self.logger.info("CVAC Configuration has been applied.")
                 # close telnet connection
                 self.scrapli_tn.close()
@@ -214,6 +217,7 @@ ip ssh maxstartups 128
         self.spins += 1
 
         return
+
 
 class C8000v(vrnetlab.VR):
     def __init__(self, hostname, username, password, conn_mode):

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -220,7 +220,7 @@ ip ssh maxstartups 128
             self.logger.warning(f"User provided startup configuration is not found.")
 
         res = con.send_configs(cat8kv_config.splitlines())
-        res += con.send_commands(["write memory"], eager=True)
+        res += con.send_commands(["write memory"])
 
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -168,8 +168,9 @@ ip ssh maxstartups 128
             "/" + self.image_name,
             "/iosxe_config.txt",
         ]
-
-        subprocess.Popen(genisoimage_args)
+        
+        self.logger.debug("Generating boot ISO")
+        subprocess.Popen(genisoimage_args).wait()
 
     def bootstrap_spin(self):
         """This function should be called periodically to do work."""

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -134,7 +134,7 @@ class C8000v_vm(vrnetlab.VM):
                     self.running = True
                     return
                 else:
-                    self.log.warning("Unexpected reload while running")
+                    self.logger.warning("Unexpected reload while running")
 
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time

--- a/cat9kv/docker/Dockerfile
+++ b/cat9kv/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
 
 ARG VERSION
 ENV VERSION=${VERSION}

--- a/cat9kv/docker/Dockerfile
+++ b/cat9kv/docker/Dockerfile
@@ -1,22 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends \
-   bridge-utils \
-   iproute2 \
-   socat \
-   qemu-kvm \
-   qemu-utils \
-   python3 \
-   tcpdump \
-   inetutils-ping \
-   ssh \
-   telnet \
-   procps \
-   genisoimage \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
 
 ARG VERSION
 ENV VERSION=${VERSION}

--- a/cat9kv/docker/launch.py
+++ b/cat9kv/docker/launch.py
@@ -13,6 +13,7 @@ import vrnetlab
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
 DEFAULT_SCRAPLI_TIMEOUT = 900
 
+
 def handle_SIGCHLD(signal, frame):
     os.waitpid(-1, os.WNOHANG)
 
@@ -52,7 +53,7 @@ class cat9kv_vm(vrnetlab.VM):
             smp=f"cores={vcpu},threads=1,sockets=1",
             ram=ram,
             min_dp_nics=8,
-            use_scrapli=True
+            use_scrapli=True,
         )
         self.hostname = hostname
         self.conn_mode = conn_mode
@@ -86,7 +87,7 @@ class cat9kv_vm(vrnetlab.VM):
             self.logger.debug("No vswitch.xml file provided.")
 
         v4_mgmt_address = vrnetlab.cidr_to_ddn(self.mgmt_address_ipv4)
-                
+
         cat9kv_config = f"""hostname {self.hostname}
 username {self.username} privilege 15 password {self.password}
 ip domain name example.com
@@ -123,7 +124,7 @@ ip ssh server algorithm mac hmac-sha2-512
 
         if os.path.exists(STARTUP_CONFIG_FILE):
             self.logger.info("Startup configuration file found")
-            with open (STARTUP_CONFIG_FILE, "r") as startup_config:
+            with open(STARTUP_CONFIG_FILE, "r") as startup_config:
                 cat9kv_config += startup_config.read()
         else:
             self.logger.warning(f"User provided startup configuration is not found.")
@@ -158,7 +159,7 @@ ip ssh server algorithm mac hmac-sha2-512
             ],
         )
         if match:  # got a match!
-            if ridx == 0:   # configuration applied
+            if ridx == 0:  # configuration applied
                 self.logger.info("CVAC Configuration has been applied.")
                 # close telnet connection
                 self.scrapli_tn.close()
@@ -181,6 +182,7 @@ ip ssh server algorithm mac hmac-sha2-512
         self.spins += 1
 
         return
+
 
 class cat9kv(vrnetlab.VR):
     def __init__(self, hostname, username, password, conn_mode, vcpu, ram):

--- a/cat9kv/docker/launch.py
+++ b/cat9kv/docker/launch.py
@@ -205,6 +205,7 @@ ip ssh server algorithm mac hmac-sha2-512
         con.commandeer(conn=self.scrapli_tn)
         
         res = con.send_configs_from_file(STARTUP_CONFIG_FILE)
+        res += con.send_commands(["write memory"], eager=True)
     
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/cat9kv/docker/launch.py
+++ b/cat9kv/docker/launch.py
@@ -205,7 +205,7 @@ ip ssh server algorithm mac hmac-sha2-512
         con.commandeer(conn=self.scrapli_tn)
         
         res = con.send_configs_from_file(STARTUP_CONFIG_FILE)
-        res += con.send_commands(["write memory"], eager=True)
+        res += con.send_commands(["write memory"])
     
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/cat9kv/docker/launch.py
+++ b/cat9kv/docker/launch.py
@@ -11,7 +11,6 @@ import sys
 import vrnetlab
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-DEFAULT_SCRAPLI_TIMEOUT = 900
 
 
 def handle_SIGCHLD(signal, frame):

--- a/common/healthcheck.py
+++ b/common/healthcheck.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import sys
 
 try:

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -21,6 +21,8 @@ except ImportError:
 
 MAX_RETRIES = 60
 
+DEFAULT_SCRAPLI_TIMEOUT = 900
+
 # set fancy logging colours
 logging.addLevelName(
     logging.INFO, f"\x1b[1;32m\t{logging.getLevelName(logging.INFO)}\x1b[0m"

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -16,7 +16,6 @@ import sys
 
 try:
     from scrapli import Driver
-    from scrapli.logging import enable_basic_logging
 except ImportError:
     pass
 

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -120,7 +120,7 @@ class VM:
 
         # configure scrapli
         if self.use_scrapli:
-            # init scrapli -- main telnet device
+            # init scrapli_tn -- main telnet device
             scrapli_tn_dev = {
                 "host": "127.0.0.1",
                 "port": 5000 + num,
@@ -134,7 +134,7 @@ class VM:
 
             self.scrapli_tn = Driver(**scrapli_tn_dev)
 
-            # init scrapli -- qemu monitor device
+            # init scrapli_qm_dev -- qemu monitor device
             scrapli_qm_dev = {
                 "host": "127.0.0.1",
                 "port": 4000 + num,

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -1019,14 +1019,17 @@ class VR:
                 for vm in self.vms:
                     if (str(vm.num) in vm_num_list) or not fcontent:
                         try:
-                            vm.qm.write("system_reset\r".encode())
+                            if vm.use_scrapli:
+                                vm.scrapli_qm.channel.write("system_reset\r")
+                            else:
+                                vm.qm.write("system_reset\r".encode())
                             self.logger.debug(f"Sent qemu-monitor system_reset to VM num {vm.num} ")
                         except Exception as e:
-                            self.logger.debug(f"Failed to send qemu-monitor system_reset to VM num {vm.num} ({e})")
+                            self.logger.error(f"Failed to send qemu-monitor system_reset to VM num {vm.num} ({e})")
                 try:
                     os.remove('/reset')
                 except Exception as e:
-                    self.logger.debug(f"Failed to cleanup /reset file({e}). qemu-monitor system_reset will likely be triggered again on VMs")
+                    self.logger.error(f"Failed to cleanup /reset file({e}). qemu-monitor system_reset will likely be triggered again on VMs")
 
 class QemuBroken(Exception):
     """Our Qemu instance is somehow broken"""

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -362,7 +362,7 @@ class VM:
                     self.qm = telnetlib.Telnet("127.0.0.1", 4000 + self.num)
                 break
             except:
-                self.logger.info(
+                self.logger.error(
                     "Unable to connect to qemu monitor (port {}), retrying in a second (attempt {})".format(
                         4000 + self.num, i
                     )
@@ -383,7 +383,7 @@ class VM:
                     self.tn = telnetlib.Telnet("127.0.0.1", 5000 + self.num)
                 break
             except:
-                self.logger.info(
+                self.logger.error(
                     "Unable to connect to qemu monitor (port {}), retrying in a second (attempt {})".format(
                         5000 + self.num, i
                     )

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -22,6 +22,13 @@ except ImportError:
 
 MAX_RETRIES = 60
 
+# set fancy logging colours
+logging.addLevelName( logging.INFO, f"\x1B[1;32m\t{logging.getLevelName(logging.INFO)}\x1B[0m")
+logging.addLevelName( logging.WARN, f"\x1B[1;38;5;220m\t{logging.getLevelName(logging.WARN)}\x1B[0m")
+logging.addLevelName( logging.DEBUG, f"\x1B[1;94m\t{logging.getLevelName(logging.DEBUG)}\x1B[0m")
+logging.addLevelName( logging.ERROR, f"\x1B[1;91m\t{logging.getLevelName(logging.ERROR)}\x1B[0m")
+logging.addLevelName( logging.CRITICAL, f"\x1B[1;91m\t{logging.getLevelName(logging.CRITICAL)}\x1B[0m")
+
 
 def gen_mac(last_octet=None):
     """Generate a random MAC address that is in recognizable (0C:00) OUI space
@@ -94,13 +101,6 @@ class VM:
         
         # configure logging
         self.logger = logging.getLogger()
-        
-        # set fancy logging colours
-        logging.addLevelName( logging.INFO, f"\x1B[1;32m\t{logging.getLevelName(logging.INFO)}\x1B[0m")
-        logging.addLevelName( logging.WARN, f"\x1B[1;38;5;220m\t{logging.getLevelName(logging.WARN)}\x1B[0m")
-        logging.addLevelName( logging.DEBUG, f"\x1B[1;94m\t{logging.getLevelName(logging.DEBUG)}\x1B[0m")
-        logging.addLevelName( logging.ERROR, f"\x1B[1;91m\t{logging.getLevelName(logging.ERROR)}\x1B[0m")
-        logging.addLevelName( logging.CRITICAL, f"\x1B[1;91m\t{logging.getLevelName(logging.CRITICAL)}\x1B[0m")
         
         """
         Configure Scrapli logger to only be INFO level.

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -281,8 +281,8 @@ class VM:
         self.logger.info(f"Launching {self.__class__.__name__} with {self.smp} SMP/VCPU and {self.ram} M of RAM")
         
         # give nice colours. Red if disabled, Green if enabled
-        mgmt_passthrough_coloured = f"\x1B[32mEnabled\x1B[0m" if self.mgmt_passthrough else f"\x1B[31mDisabled\x1B[0m"
-        use_scrapli_coloured = f"\x1B[32mEnabled\x1B[0m" if self.use_scrapli else f"\x1B[31mDisabled\x1B[0m"
+        mgmt_passthrough_coloured = format_bool_color(self.mgmt_passthrough, "Enabled", "Disabled")
+        use_scrapli_coloured = format_bool_color(self.use_scrapli, "Enabled", "Disabled")
 
         self.logger.info(f"Scrapli: {use_scrapli_coloured}")
         self.logger.info(f"Transparent mgmt interface: {mgmt_passthrough_coloured}")
@@ -1056,3 +1056,14 @@ def cidr_to_ddn(prefix: str) -> list[str]:
 
     network = ipaddress.IPv4Interface(prefix)
     return [str(network.ip), str(network.netmask)]
+
+def format_bool_color(bool_var: bool, text_if_true: str, text_if_false: str) -> str:
+    """
+    Generate a ANSI escape code colored string based on a boolean.
+    
+    Args:
+    bool_var:       Boolean to be evaluated
+    text_if_true:   Text returned if bool_var is true -- ANSI Formatted in green color
+    text_if_false:  Text returned if bool_var is false -- ANSI Formatted in red color
+    """
+    return f"\x1B[32m{text_if_true}\x1B[0m" if bool_var else f"\x1B[31m{text_if_false}\x1B[0m"

--- a/csr/docker/Dockerfile
+++ b/csr/docker/Dockerfile
@@ -1,24 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-MAINTAINER Kristian Larsson <kristian@spritelink.net>
-MAINTAINER Denis Pointer <git@dpnet.ca>
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
-    tcpdump \
-    ssh \ 
-    inetutils-ping \
-    dnsutils \
-    telnet \
-    genisoimage \
- && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
 
 ARG VERSION
 ENV VERSION=${VERSION}

--- a/csr/docker/Dockerfile
+++ b/csr/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
 
 ARG VERSION
 ENV VERSION=${VERSION}

--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -215,6 +215,7 @@ netconf-yang
             self.logger.warning(f"User provided startup configuration is not found.")
 
         res = con.send_configs(csr_config.splitlines())
+        res += con.send_commands(["write memory"], eager=True)
     
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -215,7 +215,7 @@ netconf-yang
             self.logger.warning(f"User provided startup configuration is not found.")
 
         res = con.send_configs(csr_config.splitlines())
-        res += con.send_commands(["write memory"], eager=True)
+        res += con.send_commands(["write memory"])
     
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/dev-notes.md
+++ b/dev-notes.md
@@ -2,7 +2,9 @@
 
 ## vrnetlab module and vscode pylance
 
-since vrnetlab module is in the `common` dir the pylance extension in vscode will not be able to find the module reference in `launch.py` files. To fix this, add the following to the `settings.json` file in vscode:
+We added `.env` file in the root of the repo to add `common` dir to the python path so that the pylance extension can find the module.
+
+However, if this doesn't work for you, add the following to the `settings.json` file in vscode:
 
 ```json
 {

--- a/n9kv/docker/Dockerfile
+++ b/n9kv/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/n9kv/docker/Dockerfile
+++ b/n9kv/docker/Dockerfile
@@ -1,24 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-LABEL maintainer="Roman Dodin <roman@dodin.dev>, Kaelem Chandra <kc@kaelem.net>"
-
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   tftpd-hpa \
-   ssh \
-   inetutils-ping \
-   dnsutils \
-   openvswitch-switch \
-   iptables \
-   nftables \
-   telnet \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/n9kv/docker/launch.py
+++ b/n9kv/docker/launch.py
@@ -6,13 +6,11 @@ import os
 import re
 import signal
 import sys
-import time
 
 import vrnetlab
 from scrapli.driver.core import NXOSDriver
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-DEFAULT_SCRAPLI_TIMEOUT = 900
 
 
 def handle_SIGCHLD(signal, frame):
@@ -143,9 +141,9 @@ class N9KV_vm(vrnetlab.VM):
         return
 
     def apply_config(self):
-        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", vrnetlab.DEFAULT_SCRAPLI_TIMEOUT)
         self.logger.info(
-            f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)"
+            f"Scrapli timeout is {scrapli_timeout}s (default {vrnetlab.DEFAULT_SCRAPLI_TIMEOUT}s)"
         )
 
         # init scrapli

--- a/n9kv/docker/launch.py
+++ b/n9kv/docker/launch.py
@@ -180,7 +180,7 @@ feature grpc
             self.logger.warning(f"User provided startup configuration is not found.")
 
         res = con.send_configs(n9kv_config.splitlines())
-        con.send_config("copy running-config startup-config", eager=True)
+        con.send_config("copy running-config startup-config")
     
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/n9kv/docker/launch.py
+++ b/n9kv/docker/launch.py
@@ -53,7 +53,7 @@ class N9KV_vm(vrnetlab.VM):
             disk_image=disk_image,
             ram=10240,
             smp=4,
-            cpu="host,level=9",
+            cpu="host",
             use_scrapli=True,
         )
         self.hostname = hostname
@@ -120,8 +120,7 @@ class N9KV_vm(vrnetlab.VM):
 
                 # run main config!
                 self.apply_config()
-                # close telnet connection
-                self.scrapli_tn.close()
+
                 # startup time?
                 startup_time = datetime.datetime.now() - self.start_time
                 self.logger.info("Startup complete in: %s" % startup_time)
@@ -188,7 +187,7 @@ feature grpc
             with open(STARTUP_CONFIG_FILE, "r") as config:
                 n9kv_config += config.read()
         else:
-            self.logger.warning(f"User provided startup configuration is not found.")
+            self.logger.warning("User provided startup configuration is not found.")
 
         res = con.send_configs(n9kv_config.splitlines())
         con.send_config("copy running-config startup-config")
@@ -196,6 +195,8 @@ feature grpc
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")
             self.logger.info(f"RESULT:{response.result}")
+
+        con.close()
 
 
 class N9KV(vrnetlab.VR):

--- a/nxos/docker/Dockerfile
+++ b/nxos/docker/Dockerfile
@@ -1,20 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-LABEL org.opencontainers.image.authors="roman@dodin.dev"
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
-   && apt-get upgrade -qy \
-   && apt-get install -y \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   procps \
-   openvswitch-switch \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/nxos/docker/Dockerfile
+++ b/nxos/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/nxos/docker/launch.py
+++ b/nxos/docker/launch.py
@@ -82,8 +82,7 @@ class NXOS_vm(vrnetlab.VM):
 
                 # run main config!
                 self.apply_config()
-                # close telnet connection
-                self.scrapli_tn.close()
+
                 # startup time?
                 startup_time = datetime.datetime.now() - self.start_time
                 self.logger.info("Startup complete in: %s" % startup_time)
@@ -145,7 +144,7 @@ feature ssh
             with open(STARTUP_CONFIG_FILE, "r") as config:
                 nxos_config += config.read()
         else:
-            self.logger.warning(f"User provided startup configuration is not found.")
+            self.logger.warning("User provided startup configuration is not found.")
 
         res = con.send_configs(nxos_config.splitlines())
         con.send_config("copy running-config startup-config")
@@ -153,6 +152,8 @@ feature ssh
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")
             self.logger.info(f"RESULT:{response.result}")
+
+        con.close()
 
 
 class NXOS(vrnetlab.VR):

--- a/nxos/docker/launch.py
+++ b/nxos/docker/launch.py
@@ -9,9 +9,10 @@ import sys
 import time
 
 import vrnetlab
+from scrapli.driver.core import NXOSDriver
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-
+DEFAULT_SCRAPLI_TIMEOUT = 900
 
 def handle_SIGCHLD(signal, frame):
     os.waitpid(-1, os.WNOHANG)
@@ -44,7 +45,7 @@ class NXOS_vm(vrnetlab.VM):
             if re.search(".qcow2$", e):
                 disk_image = "/" + e
         super(NXOS_vm, self).__init__(
-            username, password, disk_image=disk_image, ram=4096, smp="2"
+            username, password, disk_image=disk_image, ram=4096, smp="2", use_scrapli=True
         )
         self.credentials = [["admin", "admin"]]
         self.hostname = hostname
@@ -59,7 +60,7 @@ class NXOS_vm(vrnetlab.VM):
             self.start()
             return
 
-        (ridx, match, res) = self.tn.expect([b"login:"], 1)
+        (ridx, match, res) = self.con_expect([b"login:"])
         if match:  # got a match!
             if ridx == 0:  # login
                 self.logger.debug("matched login prompt")
@@ -75,10 +76,9 @@ class NXOS_vm(vrnetlab.VM):
                 self.wait_write(password, wait="Password:")
 
                 # run main config!
-                self.bootstrap_config()
-                self.startup_config()
+                self.apply_config()
                 # close telnet connection
-                self.tn.close()
+                self.scrapli_tn.close()
                 # startup time?
                 startup_time = datetime.datetime.now() - self.start_time
                 self.logger.info("Startup complete in: %s" % startup_time)
@@ -89,7 +89,7 @@ class NXOS_vm(vrnetlab.VM):
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time
         if res != b"":
-            self.logger.trace("OUTPUT: %s" % res.decode())
+            self.write_to_stdout(res)
             # reset spins if we saw some output
             self.spins = 0
 
@@ -97,59 +97,56 @@ class NXOS_vm(vrnetlab.VM):
 
         return
 
-    def bootstrap_config(self):
-        """Do the actual bootstrap config"""
-        self.logger.info("applying bootstrap configuration")
-        self.wait_write("", None)
-        self.wait_write("configure")
-        self.wait_write(
-            "username %s password 0 %s role network-admin"
-            % (self.username, self.password)
-        )
-        self.wait_write("hostname %s" % (self.hostname))
-
-        # configure management vrf
-        self.wait_write("vrf context management")
-        self.wait_write(f"ip route 0.0.0.0/0 {self.mgmt_gw_ipv4}")
-        self.wait_write(f"ipv6 route ::/0 {self.mgmt_gw_ipv6}")
-        self.wait_write("exit")
-
-        # configure mgmt interface
-        self.wait_write("interface mgmt0")
-        self.wait_write(f"ip address {self.mgmt_address_ipv4}")
-        self.wait_write(f"ipv6 address {self.mgmt_address_ipv6}")
-        self.wait_write("exit")
+    def apply_config(self):  
         
-        # configure longer ssh keys
-        self.wait_write("no feature ssh")
-        self.wait_write("ssh key rsa 2048 force")
-        self.wait_write("feature ssh")
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        self.logger.info(f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)")
         
-        self.wait_write("exit")
-        self.wait_write("copy running-config startup-config")
+        # init scrapli
+        nxos_scrapli_dev = {
+            "host": "127.0.0.1",
+            "auth_bypass": True,
+            "auth_strict_key": False,
+            "timeout_socket": scrapli_timeout,
+            "timeout_transport": scrapli_timeout,
+            "timeout_ops": scrapli_timeout,
+        }
+                        
+        nxos_config = f"""hostname {self.hostname}
+username {self.username} password 0 {self.password} role network-admin
+!
+vrf context management
+ip route 0.0.0.0/0 {self.mgmt_gw_ipv4}
+ipv6 route ::/0 {self.mgmt_gw_ipv6}
+exit
+!
+interface mgmt0
+ip address {self.mgmt_address_ipv4}
+ipv6 address {self.mgmt_address_ipv6}
+exit
+!
+no feature ssh
+ssh key rsa 2048 force
+feature ssh
+!
+"""
 
-    def startup_config(self):
-        """Load additional config provided by user."""
+        con = NXOSDriver(**nxos_scrapli_dev)
+        con.commandeer(conn=self.scrapli_tn)
+        
+        if os.path.exists(STARTUP_CONFIG_FILE):
+            self.logger.info("Startup configuration file found")
+            with open(STARTUP_CONFIG_FILE, "r") as config:
+                nxos_config += config.read()
+        else:
+            self.logger.warning(f"User provided startup configuration is not found.")
 
-        if not os.path.exists(STARTUP_CONFIG_FILE):
-            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} is not found")
-            return
-
-        self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} exists")
-        with open(STARTUP_CONFIG_FILE) as file:
-            config_lines = file.readlines()
-            config_lines = [line.rstrip() for line in config_lines]
-            self.logger.trace(f"Parsed startup config file {STARTUP_CONFIG_FILE}")
-
-        self.logger.info(f"Writing lines from {STARTUP_CONFIG_FILE}")
-
-        self.wait_write("configure terminal")
-        # Apply lines from file
-        for line in config_lines:
-            self.wait_write(line)
-        # End and Save
-        self.wait_write("end")
-        self.wait_write("copy running-config startup-config")
+        res = con.send_configs(nxos_config.splitlines())
+        con.send_config("copy running-config startup-config", eager=True)
+    
+        for response in res:
+            self.logger.info(f"CONFIG:{response.channel_input}")
+            self.logger.info(f"RESULT:{response.result}")
 
 
 class NXOS(vrnetlab.VR):

--- a/nxos/docker/launch.py
+++ b/nxos/docker/launch.py
@@ -12,7 +12,6 @@ import vrnetlab
 from scrapli.driver.core import NXOSDriver
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-DEFAULT_SCRAPLI_TIMEOUT = 900
 
 
 def handle_SIGCHLD(signal, frame):
@@ -104,9 +103,9 @@ class NXOS_vm(vrnetlab.VM):
         return
 
     def apply_config(self):
-        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", vrnetlab.DEFAULT_SCRAPLI_TIMEOUT)
         self.logger.info(
-            f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)"
+            f"Scrapli timeout is {scrapli_timeout}s (default {vrnetlab.DEFAULT_SCRAPLI_TIMEOUT}s)"
         )
 
         # init scrapli

--- a/nxos/docker/launch.py
+++ b/nxos/docker/launch.py
@@ -142,7 +142,7 @@ feature ssh
             self.logger.warning(f"User provided startup configuration is not found.")
 
         res = con.send_configs(nxos_config.splitlines())
-        con.send_config("copy running-config startup-config", eager=True)
+        con.send_config("copy running-config startup-config")
     
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/nxos/docker/launch.py
+++ b/nxos/docker/launch.py
@@ -14,6 +14,7 @@ from scrapli.driver.core import NXOSDriver
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
 DEFAULT_SCRAPLI_TIMEOUT = 900
 
+
 def handle_SIGCHLD(signal, frame):
     os.waitpid(-1, os.WNOHANG)
 
@@ -45,7 +46,12 @@ class NXOS_vm(vrnetlab.VM):
             if re.search(".qcow2$", e):
                 disk_image = "/" + e
         super(NXOS_vm, self).__init__(
-            username, password, disk_image=disk_image, ram=4096, smp="2", use_scrapli=True
+            username,
+            password,
+            disk_image=disk_image,
+            ram=4096,
+            smp="2",
+            use_scrapli=True,
         )
         self.credentials = [["admin", "admin"]]
         self.hostname = hostname
@@ -97,11 +103,12 @@ class NXOS_vm(vrnetlab.VM):
 
         return
 
-    def apply_config(self):  
-        
+    def apply_config(self):
         scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
-        self.logger.info(f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)")
-        
+        self.logger.info(
+            f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)"
+        )
+
         # init scrapli
         nxos_scrapli_dev = {
             "host": "127.0.0.1",
@@ -111,7 +118,7 @@ class NXOS_vm(vrnetlab.VM):
             "timeout_transport": scrapli_timeout,
             "timeout_ops": scrapli_timeout,
         }
-                        
+
         nxos_config = f"""hostname {self.hostname}
 username {self.username} password 0 {self.password} role network-admin
 !
@@ -133,7 +140,7 @@ feature ssh
 
         con = NXOSDriver(**nxos_scrapli_dev)
         con.commandeer(conn=self.scrapli_tn)
-        
+
         if os.path.exists(STARTUP_CONFIG_FILE):
             self.logger.info("Startup configuration file found")
             with open(STARTUP_CONFIG_FILE, "r") as config:
@@ -143,7 +150,7 @@ feature ssh
 
         res = con.send_configs(nxos_config.splitlines())
         con.send_config("copy running-config startup-config")
-    
+
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")
             self.logger.info(f"RESULT:{response.result}")

--- a/ocnos/docker/launch.py
+++ b/ocnos/docker/launch.py
@@ -70,6 +70,7 @@ class OCNOS_vm(vrnetlab.VM):
             if ridx == 0:  # login
                 self.logger.debug("matched login prompt")
                 self.logger.debug("trying to log in with 'ocnos'")
+                time.sleep(15)
                 self.wait_write("ocnos", wait=None)
                 self.wait_write("ocnos", wait="Password:")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 description = "vrnetlab fork for Containerlab integration"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "scrapli>=2024.7.30.post1",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "vrnetlab"
+version = "0.1.0"
+description = "vrnetlab fork for Containerlab integration"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [project]
 dependencies = [
   "passlib>=1.7.4",
+  "pyyaml>=6.0.2",
   "scrapli>=2024.7.30.post1",
   "scrapli-community",
 ]
 description = "Building containers for VM-based Network OSes for Containerlab"
 name = "vrnetlab"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 version = "0.1.0"
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,14 @@
 [project]
+dependencies = [
+  "passlib>=1.7.4",
+  "scrapli>=2024.7.30.post1",
+  "scrapli-community",
+]
+description = "Building containers for VM-based Network OSes for Containerlab"
 name = "vrnetlab"
-version = "0.1.0"
-description = "vrnetlab fork for Containerlab integration"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = [
-    "scrapli>=2024.7.30.post1",
-]
+version = "0.1.0"
+
+[tool.uv.sources]
+scrapli-community = {git = "https://github.com/scrapli/scrapli_community", rev = "d862833"}

--- a/sros/README.md
+++ b/sros/README.md
@@ -109,7 +109,7 @@ NOTE: If only CF2 is provisioned, node will remap it to CF1.
 
 ## Usage with containerlab
 
-Refer to containerlab documentation piece on [vrnetlab integration](https://containerlab.srlinux.dev/manual/vrnetlab/) and vr-sros.
+Refer to containerlab documentation article on [vrnetlab integration](https://containerlab.dev/manual/vrnetlab/) and Containerlab.
 
 ## Extracting qcow2 disk image from a container image
 
@@ -118,7 +118,7 @@ It is possible to extract the original qcow2 disk image from an existing contain
 The following script takes an image name and the qcow2 image name to copy out from the container image:
 
 ```bash
-IMAGE=registry.srlinux.dev/pub/vr-sros:23.7.R1
+IMAGE=registry.srlinux.dev/pub/nokia_sros:24.10.R1
 VERSION=$(cut -d ':' -f 2 <<< $IMAGE)
 docker create --name sros-copy $IMAGE
 docker cp sros-copy:sros-vm-$VERSION.qcow2 .

--- a/sros/docker/Dockerfile
+++ b/sros/docker/Dockerfile
@@ -1,24 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-LABEL org.opencontainers.image.authors="roman@dodin.dev"
-
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends \
-   bridge-utils \
-   iproute2 \
-   python3 \
-   socat \
-   qemu-kvm \
-   qemu-utils \
-   tcpdump \
-   tftpd-hpa \
-   ssh \
-   inetutils-ping \
-   dnsutils \
-   iptables \
-   nftables \
-   telnet \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/sros/docker/Dockerfile
+++ b/sros/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/sros/docker/Dockerfile
+++ b/sros/docker/Dockerfile
@@ -1,9 +1,6 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+# base image dockerfile is defined in https://github.com/hellt/vrnetlab
+FROM ghcr.io/srl-labs/vrnetlab-base:0.2.0
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
-
-EXPOSE 22 80 443 161/udp 830 5000 10000-10099 57400
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -50,15 +50,15 @@ def getMem(vmMode: str, ram: int) -> int:
     if vmMode == "integrated":
         # Integrated VM can use both MEMORY and CP_MEMORY env vars
         if "MEMORY" in os.environ:
-            return 1024 * get_digits(os.getenv("MEMORY"))
+            return 1024 * vrnetlab.get_digits(os.getenv("MEMORY"))
         if "CP_MEMORY" in os.environ:
-            return 1024 * get_digits(os.getenv("CP_MEMORY"))
+            return 1024 * vrnetlab.get_digits(os.getenv("CP_MEMORY"))
     if vmMode == "cp":
         if "CP_MEMORY" in os.environ:
-            return 1024 * get_digits(os.getenv("CP_MEMORY"))
+            return 1024 * vrnetlab.get_digits(os.getenv("CP_MEMORY"))
     if vmMode == "lc":
         if "LC_MEMORY" in os.environ:
-            return 1024 * get_digits(os.getenv("LC_MEMORY"))
+            return 1024 * vrnetlab.get_digits(os.getenv("LC_MEMORY"))
     return 1024 * int(ram)
 
 

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1318,6 +1318,9 @@ class SROS_vm(vrnetlab.VM):
 
             self.switchConfigEngine()
 
+            # close scrapli device driver
+            self.sros_con.close()
+
     @property
     def ram(self):
         """Ignore environment variables here, since getMem function is used"""

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1129,14 +1129,14 @@ class SROS_vm(vrnetlab.VM):
         """Commit configuration. No-op for SR OS version <= 22 (classic CLI)"""
         if classic_cfg:
             return
-        res = self.sros_con.send_configs(["commit", "/"], strip_prompt=False)
+        res = self.sros_con.send_configs(["commit", "quit-config"], strip_prompt=False)
         self.log_scrapli_cmd_res(res)
 
     def commitBofConfig(self):
         """Commit configuration. No-op for SR OS version <= 22 (classic CLI)"""
         if classic_cfg:
             return
-        res = self.sros_con.send_configs(["commit", "/"], strip_prompt=False)
+        res = self.sros_con.send_configs(["commit", "quit-config"], strip_prompt=False)
         self.log_scrapli_cmd_res(res)
 
     def configureCards(self):
@@ -1274,10 +1274,10 @@ class SROS_vm(vrnetlab.VM):
             "timeout_transport": scrapli_timeout,
             "timeout_ops": scrapli_timeout,
         }
-        
+
         # SROS <= 22 use classic configuration mode by defaults
         # other functions rely on this variable to determine what cmds to send
-        global classic_cfg 
+        global classic_cfg
         classic_cfg = True if SROS_VERSION.major <= 22 or SROS_VERSION.magc else False
 
         if config_exists:
@@ -1303,8 +1303,6 @@ class SROS_vm(vrnetlab.VM):
         self.log_scrapli_cmd_res(res)
 
         self.commitBofConfig()
-        
-        self.persistBofAndConfig()
 
         # apply common configuration if config file was not provided
         if not config_exists:
@@ -1327,6 +1325,8 @@ class SROS_vm(vrnetlab.VM):
                 self.configure_power(self.variant["power"])
 
             self.commitConfig()
+
+            self.persistBofAndConfig()
 
             self.switchConfigEngine()
 

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1163,7 +1163,7 @@ class SROS_vm(vrnetlab.VM):
         """Switch configuration engine"""
         if SROS_VERSION.major <= 22 or SROS_VERSION.magc:
             # for SR OS version <= 22, we enforce MD-CLI by switching to it
-            res = self.sros_con.send_confgs(
+            res = self.sros_con.send_configs(
                 [
                     f"/configure system management-interface configuration-mode {self.mode}"
                 ], strip_prompt=False
@@ -1261,7 +1261,7 @@ class SROS_vm(vrnetlab.VM):
         }
         
         if SROS_VERSION.major <= 22 or SROS_VERSION.magc:
-            sros_scrapli_dev["variant"] = "cassic"
+            sros_scrapli_dev["variant"] = "classic"
         
         # self.scrapli_logger.setLevel(logging.DEBUG)        
         self.sros_con = Scrapli(**sros_scrapli_dev)

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1290,8 +1290,6 @@ class SROS_vm(vrnetlab.VM):
         self.log_scrapli_cmd_res(res)
 
         self.commitBofConfig()
-        # save bof config on disk
-        self.persistBofAndConfig()
 
         # apply common configuration if config file was not provided
         if not config_exists:
@@ -1317,8 +1315,10 @@ class SROS_vm(vrnetlab.VM):
 
             self.switchConfigEngine()
 
-            # close scrapli device driver
-            self.sros_con.close()
+        self.persistBofAndConfig()
+
+        # close scrapli device driver
+        self.sros_con.close()
 
     @property
     def ram(self):

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1171,8 +1171,8 @@ class SROS_vm(vrnetlab.VM):
 
     def switchConfigEngine(self):
         """Switch configuration engine"""
-        if classic_cfg:
-            # for SR OS version <= 22, we enforce MD-CLI by switching to it
+        if (SROS_VERSION.major >= 19 and SROS_VERSION.major <= 22) or SROS_VERSION.magc:
+            # for SR OS versions 19-22 inclusive, we enforce MD-CLI by switching to it
             res = self.sros_con.send_configs(
                 [
                     f"/configure system management-interface configuration-mode {self.mode}"

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1277,8 +1277,15 @@ class SROS_vm(vrnetlab.VM):
 
         if SROS_VERSION.major <= 22 or SROS_VERSION.magc:
             sros_scrapli_dev["variant"] = "classic"
+        elif config_exists:
+            with open("/tftpboot/config.txt") as startup_cfg:
+                for line in startup_cfg:
+                    l_clean = line.strip()
+                    if "configure" == l_clean and "{" not in l_clean:
+                        self.logger.debug("Detected classic startup configuration")
+                        sros_scrapli_dev["variant"] = "classic"
+                        break
 
-        # self.scrapli_logger.setLevel(logging.DEBUG)
         self.sros_con = Scrapli(**sros_scrapli_dev)
         self.sros_con.commandeer(conn=self.scrapli_tn)
 

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -13,7 +13,6 @@ from typing import Dict
 import vrnetlab
 from scrapli import Scrapli
 
-DEFAULT_SCRAPLI_TIMEOUT = 900
 DEBUG_SCRAPLI = True if os.getenv("DEBUG_SCRAPLI", "false").lower() == "true" else False
 
 
@@ -1253,9 +1252,9 @@ class SROS_vm(vrnetlab.VM):
         # thus it must be applied unconditionally
 
         # init scrapli sros driver
-        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", vrnetlab.DEFAULT_SCRAPLI_TIMEOUT)
         self.logger.info(
-            f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)"
+            f"Scrapli timeout is {scrapli_timeout}s (default {vrnetlab.DEFAULT_SCRAPLI_TIMEOUT}s)"
         )
 
         # check if config was provided

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,15 @@ version = 1
 requires-python = ">=3.11"
 
 [[package]]
+name = "passlib"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554 },
+]
+
+[[package]]
 name = "scrapli"
 version = "2024.7.30.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -11,12 +20,26 @@ wheels = [
 ]
 
 [[package]]
-name = "vrnetlab"
-version = "0.1.0"
-source = { virtual = "." }
+name = "scrapli-community"
+version = "2024.7.30"
+source = { git = "https://github.com/scrapli/scrapli_community?rev=d862833#d86283316eee66799d43a7ef62bf0e20565d31a8" }
 dependencies = [
     { name = "scrapli" },
 ]
 
+[[package]]
+name = "vrnetlab"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "passlib" },
+    { name = "scrapli" },
+    { name = "scrapli-community" },
+]
+
 [package.metadata]
-requires-dist = [{ name = "scrapli", specifier = ">=2024.7.30.post1" }]
+requires-dist = [
+    { name = "passlib", specifier = ">=1.7.4" },
+    { name = "scrapli", specifier = ">=2024.7.30.post1" },
+    { name = "scrapli-community", git = "https://github.com/scrapli/scrapli_community?rev=d862833" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,7 @@
+version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "vrnetlab"
+version = "0.1.0"
+source = { virtual = "." }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.11"
+requires-python = ">=3.11, <3.13"
 
 [[package]]
 name = "passlib"
@@ -8,6 +8,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612 },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040 },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829 },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167 },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952 },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301 },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638 },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980 },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
 ]
 
 [[package]]
@@ -33,6 +59,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "passlib" },
+    { name = "pyyaml" },
     { name = "scrapli" },
     { name = "scrapli-community" },
 ]
@@ -40,6 +67,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "passlib", specifier = ">=1.7.4" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "scrapli", specifier = ">=2024.7.30.post1" },
     { name = "scrapli-community", git = "https://github.com/scrapli/scrapli_community?rev=d862833" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,21 @@ version = 1
 requires-python = ">=3.11"
 
 [[package]]
+name = "scrapli"
+version = "2024.7.30.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/1b/27dd7f93b72e49222fc26bde23f720c24e3779bc6946b46d7977150b67a2/scrapli-2024.7.30.post1.tar.gz", hash = "sha256:4a7b862ff66c1fabba5f0c5673cc5c46a46e24e0ebf19c37a56c398cbc3ccfde", size = 104341 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/4d/af60aaf236f738dae6bf7daec613b9efa241a56d0822afde25f0e1463a5a/scrapli-2024.7.30.post1-py3-none-any.whl", hash = "sha256:59b96836f38d27498b141f6153ae0e169a5c806480f5e1f24cbb37ea74021e6f", size = 145809 },
+]
+
+[[package]]
 name = "vrnetlab"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "scrapli" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "scrapli", specifier = ">=2024.7.30.post1" }]

--- a/vios/docker/Dockerfile
+++ b/vios/docker/Dockerfile
@@ -1,18 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-LABEL org.opencontainers.image.authors="xtothj@gmail.com"
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends \
-   bridge-utils \
-   iproute2 \
-   python3 \
-   socat \
-   qemu-kvm \
-   qemu-utils \
-   tcpdump \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/vios/docker/Dockerfile
+++ b/vios/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/vios/docker/launch.py
+++ b/vios/docker/launch.py
@@ -12,6 +12,7 @@ from scrapli.driver.core import IOSXEDriver
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
 DEFAULT_SCRAPLI_TIMEOUT = 900
 
+
 def handle_SIGCHLD(_signal, _frame):
     os.waitpid(-1, os.WNOHANG)
 
@@ -53,7 +54,7 @@ class VIOS_vm(vrnetlab.VM):
             smp="1",
             ram=512,
             driveif="virtio",
-            use_scrapli=True
+            use_scrapli=True,
         )
 
         self.hostname = hostname
@@ -108,12 +109,12 @@ class VIOS_vm(vrnetlab.VM):
         self.spins += 1
         return
 
-
-    def apply_config(self):  
-        
+    def apply_config(self):
         scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
-        self.logger.info(f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)")
-        
+        self.logger.info(
+            f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)"
+        )
+
         # init scrapli
         vios_scrapli_dev = {
             "host": "127.0.0.1",
@@ -123,9 +124,9 @@ class VIOS_vm(vrnetlab.VM):
             "timeout_transport": scrapli_timeout,
             "timeout_ops": scrapli_timeout,
         }
-        
+
         v4_mgmt_address = vrnetlab.cidr_to_ddn(self.mgmt_address_ipv4)
-                        
+
         vios_config = f"""hostname {self.hostname}
 username {self.username} privilege 15 password {self.password}
 ip domain-name example.com
@@ -177,7 +178,7 @@ no banner incoming
 
         con = IOSXEDriver(**vios_scrapli_dev)
         con.commandeer(conn=self.scrapli_tn)
-        
+
         if os.path.exists(STARTUP_CONFIG_FILE):
             self.logger.info("Startup configuration file found")
             with open(STARTUP_CONFIG_FILE, "r") as config:
@@ -187,7 +188,7 @@ no banner incoming
 
         res = con.send_configs(vios_config.splitlines())
         res += con.send_commands(["write memory"])
-    
+
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")
             self.logger.info(f"RESULT:{response.result}")

--- a/vios/docker/launch.py
+++ b/vios/docker/launch.py
@@ -7,9 +7,10 @@ import signal
 import sys
 
 import vrnetlab
+from scrapli.driver.core import IOSXEDriver
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-
+DEFAULT_SCRAPLI_TIMEOUT = 900
 
 def handle_SIGCHLD(_signal, _frame):
     os.waitpid(-1, os.WNOHANG)
@@ -52,6 +53,7 @@ class VIOS_vm(vrnetlab.VM):
             smp="1",
             ram=512,
             driveif="virtio",
+            use_scrapli=True
         )
 
         self.hostname = hostname
@@ -68,13 +70,12 @@ class VIOS_vm(vrnetlab.VM):
             self.start()
             return
 
-        (ridx, match, res) = self.tn.expect(
+        (ridx, match, res) = self.con_expect(
             [
                 rb"Would you like to enter the initial configuration dialog\? \[yes/no\]:",
                 b"Press RETURN to get started!",
                 b"Router>",
             ],
-            1,
         )
 
         if match:
@@ -86,106 +87,109 @@ class VIOS_vm(vrnetlab.VM):
                 for _ in range(3):
                     self.wait_write("\r", wait=None)
             elif ridx == 2:
-                self._enter_config_mode()
-                self._bootstrap_config()
-                self._load_startup_config()
-                self._save_config()
+                self.apply_config()
 
                 # close telnet connection
-                self.tn.close()
+                self.scrapli_tn.close()
                 # startup time
                 startup_time = datetime.datetime.now() - self.start_time
                 self.logger.info(f"Startup complete in: {startup_time}")
                 # mark as running
                 self.running = True
+                return
 
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time
         if res != b"":
-            self.logger.trace(f"OUTPUT: {res.decode()}")
+            self.write_to_stdout(res)
             # reset spins if we saw some output
             self.spins = 0
 
         self.spins += 1
         return
 
-    def _enter_config_mode(self):
-        self.logger.info("Entering configuration mode")
 
-        self.wait_write("enable", wait=None)
-        self.wait_write("configure terminal")
-
-    def _bootstrap_config(self):
-        self.logger.info("Applying initial configuration")
-
-        self.wait_write(f"hostname {self.hostname}")
-        self.wait_write(f"ip domain-name {self.hostname}.clab")
-        self.wait_write("no ip domain-lookup")
+    def apply_config(self):  
         
-        # Explicitly enable IPv6
-        self.wait_write("ipv6 unicast-routing")
-
-        self.wait_write(f"username {self.username} privilege 15 secret {self.password}")
-
-        self.wait_write("line con 0")
-        self.wait_write("logging synchronous")
-        self.wait_write("exec-timeout 0 0")
-        self.wait_write("login local")
-        self.wait_write("exit")
-
-        self.wait_write("line vty 0 4")
-        self.wait_write("logging synchronous")
-        self.wait_write("exec-timeout 0 0")
-        self.wait_write("transport input ssh")
-        self.wait_write("login local")
-        self.wait_write("exit")
-
-        self.wait_write("vrf definition clab-mgmt")
-        self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
-        self.wait_write("address-family ipv4")
-        self.wait_write("exit")
-        self.wait_write("address-family ipv6")
-        self.wait_write("exit")
-        self.wait_write("exit")
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        self.logger.info(f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)")
+        
+        # init scrapli
+        vios_scrapli_dev = {
+            "host": "127.0.0.1",
+            "auth_bypass": True,
+            "auth_strict_key": False,
+            "timeout_socket": scrapli_timeout,
+            "timeout_transport": scrapli_timeout,
+            "timeout_ops": scrapli_timeout,
+        }
         
         v4_mgmt_address = vrnetlab.cidr_to_ddn(self.mgmt_address_ipv4)
+                        
+        vios_config = f"""hostname {self.hostname}
+username {self.username} privilege 15 password {self.password}
+ip domain-name example.com
+no ip domain-lookup
+!
+line con 0
+logging synchronous
+exec timeout 0 0
+!
+line vty 0 4
+logging synchronous
+login local
+transport input all
+exec timeout 0 0
+!
+ipv6 unicast-routing
+!
+vrf definition clab-mgmt
+description Containerlab management VRF (DO NOT DELETE)
+address-family ipv4
+exit
+address-family ipv6
+exit
+exit
+!
+ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 {self.mgmt_gw_ipv4}
+ipv6 route vrf clab-mgmt ::/0 {self.mgmt_gw_ipv6}
+!
+interface GigabitEthernet0/0
+description Containerlab management interface
+vrf forwarding clab-mgmt
+ip address {v4_mgmt_address[0]} {v4_mgmt_address[1]}
+ipv6 address {self.mgmt_address_ipv6}
+no shut
+exit
+!
+crypto key generate rsa modulus 2048
+ip ssh version 2
+!
+netconf ssh
+netconf max-sessions 16
+snmp-server community public rw
+!
+no banner exec
+no banner login
+no banner incoming
+!   
+"""
 
-        self.wait_write("interface GigabitEthernet0/0")
-        self.wait_write("vrf forwarding clab-mgmt")
-        self.wait_write(f"ip address {v4_mgmt_address[0]} {v4_mgmt_address[1]}")
-        self.wait_write(f"ipv6 address {self.mgmt_address_ipv6}")
-        self.wait_write("no shutdown")
-        self.wait_write("exit")
+        con = IOSXEDriver(**vios_scrapli_dev)
+        con.commandeer(conn=self.scrapli_tn)
         
-        self.wait_write(f"ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 {self.mgmt_gw_ipv4}")
-        self.wait_write(f"ipv6 route vrf clab-mgmt ::/0 {self.mgmt_gw_ipv6}")
+        if os.path.exists(STARTUP_CONFIG_FILE):
+            self.logger.info("Startup configuration file found")
+            with open(STARTUP_CONFIG_FILE, "r") as config:
+                vios_config += config.read()
+        else:
+            self.logger.warning(f"User provided startup configuration is not found.")
 
-        self.wait_write("crypto key generate rsa modulus 2048")
-        self.wait_write("ip ssh version 2")
-
-        self.wait_write("netconf ssh")
-        self.wait_write("netconf max-sessions 16")
-        self.wait_write("snmp-server community public rw")
-
-        self.wait_write("no banner exec")
-        self.wait_write("no banner login")
-        self.wait_write("no banner incoming")
-
-    def _load_startup_config(self):
-        if not os.path.exists(STARTUP_CONFIG_FILE):
-            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} not found")
-            return
-
-        self.logger.trace(f"Loading startup config file {STARTUP_CONFIG_FILE}")
-        with open(STARTUP_CONFIG_FILE) as file:
-            for line in (line.rstrip() for line in file):
-                self.wait_write(line)
-
-    def _save_config(self):
-        self.logger.info("Saving configuration")
-
-        self.wait_write("end")
-        self.wait_write("write memory")
+        res = con.send_configs(vios_config.splitlines())
+    
+        for response in res:
+            self.logger.info(f"CONFIG:{response.channel_input}")
+            self.logger.info(f"RESULT:{response.result}")
 
 
 class VIOS(vrnetlab.VR):

--- a/vios/docker/launch.py
+++ b/vios/docker/launch.py
@@ -186,7 +186,7 @@ no banner incoming
             self.logger.warning(f"User provided startup configuration is not found.")
 
         res = con.send_configs(vios_config.splitlines())
-        res += con.send_commands(["write memory"], eager=True)
+        res += con.send_commands(["write memory"])
     
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/vios/docker/launch.py
+++ b/vios/docker/launch.py
@@ -10,7 +10,6 @@ import vrnetlab
 from scrapli.driver.core import IOSXEDriver
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-DEFAULT_SCRAPLI_TIMEOUT = 900
 
 
 def handle_SIGCHLD(_signal, _frame):

--- a/vios/docker/launch.py
+++ b/vios/docker/launch.py
@@ -186,6 +186,7 @@ no banner incoming
             self.logger.warning(f"User provided startup configuration is not found.")
 
         res = con.send_configs(vios_config.splitlines())
+        res += con.send_commands(["write memory"], eager=True)
     
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/vios/docker/launch.py
+++ b/vios/docker/launch.py
@@ -89,8 +89,6 @@ class VIOS_vm(vrnetlab.VM):
             elif ridx == 2:
                 self.apply_config()
 
-                # close telnet connection
-                self.scrapli_tn.close()
                 # startup time
                 startup_time = datetime.datetime.now() - self.start_time
                 self.logger.info(f"Startup complete in: {startup_time}")
@@ -109,9 +107,9 @@ class VIOS_vm(vrnetlab.VM):
         return
 
     def apply_config(self):
-        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", vrnetlab.DEFAULT_SCRAPLI_TIMEOUT)
         self.logger.info(
-            f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)"
+            f"Scrapli timeout is {scrapli_timeout}s (default {vrnetlab.DEFAULT_SCRAPLI_TIMEOUT}s)"
         )
 
         # init scrapli
@@ -183,7 +181,7 @@ no banner incoming
             with open(STARTUP_CONFIG_FILE, "r") as config:
                 vios_config += config.read()
         else:
-            self.logger.warning(f"User provided startup configuration is not found.")
+            self.logger.warning("User provided startup configuration is not found.")
 
         res = con.send_configs(vios_config.splitlines())
         res += con.send_commands(["write memory"])
@@ -191,6 +189,9 @@ no banner incoming
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")
             self.logger.info(f"RESULT:{response.result}")
+
+        # close the scrapli connection
+        con.close()
 
 
 class VIOS(vrnetlab.VR):

--- a/vrnetlab-base.dockerfile
+++ b/vrnetlab-base.dockerfile
@@ -26,4 +26,4 @@ RUN apt-get update -qy \
    && rm -rf /var/lib/apt/lists/*
 
 RUN pip install https://github.com/carlmontanari/scrapli/archive/refs/tags/2024.07.30.post1.zip --break-system-packages
-RUN pip install -e git+https://github.com/kaelemc/scrapli_community.git@sros_regex_fix#egg=scrapli_community --break-system-packages
+RUN pip install git+https://github.com/scrapli/scrapli_community --break-system-packages

--- a/vrnetlab-base.dockerfile
+++ b/vrnetlab-base.dockerfile
@@ -20,9 +20,10 @@ RUN apt-get update -qy \
    telnet \
    python3-pip \
    python3-passlib \
+   git \
    dosfstools \
    genisoimage \
    && rm -rf /var/lib/apt/lists/*
 
-RUN pip install https://github.com/carlmontanari/scrapli/archive/refs/tags/2024.07.30.post1.zip \
-   https://github.com/scrapli/scrapli_community/archive/refs/tags/2024.07.30.zip --break-system-packages
+RUN pip install https://github.com/carlmontanari/scrapli/archive/refs/tags/2024.07.30.post1.zip --break-system-packages
+RUN pip install -e git+https://github.com/kaelemc/scrapli_community.git@sros_regex_fix#egg=scrapli_community --break-system-packages

--- a/vrnetlab-base.dockerfile
+++ b/vrnetlab-base.dockerfile
@@ -1,0 +1,28 @@
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
+LABEL org.opencontainers.image.authors="roman@dodin.dev"
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qy \
+   && apt-get install -y --no-install-recommends \
+   bridge-utils \
+   iproute2 \
+   python3 \
+   socat \
+   qemu-kvm \
+   qemu-utils \
+   tcpdump \
+   tftpd-hpa \
+   ssh \
+   inetutils-ping \
+   dnsutils \
+   iptables \
+   nftables \
+   telnet \
+   python3-pip \
+   python3-passlib \
+   dosfstools \
+   genisoimage \
+   && rm -rf /var/lib/apt/lists/*
+
+RUN pip install https://github.com/carlmontanari/scrapli/archive/refs/tags/2024.07.30.post1.zip \
+   https://github.com/scrapli/scrapli_community/archive/refs/tags/2024.07.30.zip --break-system-packages

--- a/vrnetlab-base.dockerfile
+++ b/vrnetlab-base.dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update -qy \
    bridge-utils \
    iproute2 \
    python3 \
+   python3-pip \
+   python3-passlib \
    socat \
    qemu-kvm \
    qemu-utils \
@@ -18,12 +20,10 @@ RUN apt-get update -qy \
    iptables \
    nftables \
    telnet \
-   python3-pip \
-   python3-passlib \
    git \
    dosfstools \
    genisoimage \
    && rm -rf /var/lib/apt/lists/*
 
 RUN pip install https://github.com/carlmontanari/scrapli/archive/refs/tags/2024.07.30.post1.zip --break-system-packages
-RUN pip install git+https://github.com/scrapli/scrapli_community --break-system-packages
+RUN pip install git+https://github.com/scrapli/scrapli_community@d862833 --break-system-packages

--- a/xrv/Makefile
+++ b/xrv/Makefile
@@ -2,6 +2,7 @@ VENDOR=Cisco
 NAME=XRv
 IMAGE_FORMAT=vmdk
 IMAGE_GLOB=*vmdk*
+QCOW=$(shell ls *qcow2* 2>/dev/null)
 
 # match versions like:
 # iosxrv-k9-demo-5.3.3.51U.vmdk
@@ -13,3 +14,14 @@ VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+\(
 
 -include ../makefile-sanity.include
 -include ../makefile.include
+
+convert-image:
+	@if [ -z "$QCOW" ]; then echo "\033[1;31mERROR:\033[0m No .qcow2 image found"; exit 1; fi
+	@printf "\033[1;32mFound image $(QCOW)\033[0m.\n"
+ifeq (, $(shell which qemu-img))
+	@printf "\033[1;31mERROR\033[0m: qemu-img not found. Please install 'qemu-img' or 'qemu-utils'.\n"; exit 1;
+endif
+	$(eval FILE_NAME := $(shell basename $(QCOW) .qcow2))
+	qemu-img convert -cpf qcow2 -O vmdk $(QCOW) $(FILE_NAME).vmdk
+
+

--- a/xrv/docker/Dockerfile
+++ b/xrv/docker/Dockerfile
@@ -1,20 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-LABEL org.opencontainers.image.authors="roman@dodin.dev"
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
-   && apt-get upgrade -qy \
-   && apt-get install -y \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   procps \
-   openvswitch-switch \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/xrv/docker/Dockerfile
+++ b/xrv/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -14,7 +14,6 @@ import vrnetlab
 from scrapli.driver.core import IOSXRDriver
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-DEFAULT_SCRAPLI_TIMEOUT = 900
 
 
 def handle_SIGCHLD(signal, frame):
@@ -126,9 +125,9 @@ class XRV_vm(vrnetlab.VM):
         return
 
     def apply_config(self):
-        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", vrnetlab.DEFAULT_SCRAPLI_TIMEOUT)
         self.logger.info(
-            f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)"
+            f"Scrapli timeout is {scrapli_timeout}s (default {vrnetlab.DEFAULT_SCRAPLI_TIMEOUT}s)"
         )
 
         # init scrapli

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -176,7 +176,7 @@ grpc vrf clab-mgmt
 grpc no-tls
 !
 xml agent tty
-!
+root
 """
 
         con = IOSXRDriver(**xrv_scrapli_dev)

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -11,9 +11,10 @@ import telnetlib
 import time
 
 import vrnetlab
+from scrapli.driver.core import IOSXRDriver
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-
+DEFAULT_SCRAPLI_TIMEOUT = 900
 
 def handle_SIGCHLD(signal, frame):
     os.waitpid(-1, os.WNOHANG)
@@ -46,12 +47,11 @@ class XRV_vm(vrnetlab.VM):
             if re.search(".vmdk", e):
                 disk_image = "/" + e
         super(XRV_vm, self).__init__(
-            username, password, disk_image=disk_image, ram=3072
-        )
+            username, password, disk_image=disk_image, ram=3072, use_scrapli=True)
         self.hostname = hostname
         self.conn_mode = conn_mode
         self.num_nics = 128
-        self.credentials = [["admin", "admin"]]
+        self.credentials = []
 
         self.xr_ready = False
 
@@ -64,7 +64,7 @@ class XRV_vm(vrnetlab.VM):
             self.start()
             return
 
-        (ridx, match, res) = self.tn.expect(
+        (ridx, match, res) = self.con_expect(
             [
                 b"Press RETURN to get started",
                 b"SYSTEM CONFIGURATION COMPLETE",
@@ -72,7 +72,6 @@ class XRV_vm(vrnetlab.VM):
                 b"Username:",
                 b"^[^ ]+#",
             ],
-            1,
         )
         if match:  # got a match!
             if ridx == 0:  # press return to get started, so we press return!
@@ -92,23 +91,22 @@ class XRV_vm(vrnetlab.VM):
                 self.wait_write(self.password, wait="Enter secret again:")
                 self.credentials.insert(0, [self.username, self.password])
             if ridx == 3:  # matched login prompt, so should login
-                self.logger.debug("matched login prompt")
+                self.logger.info("matched login prompt")
                 try:
                     username, password = self.credentials.pop(0)
                 except IndexError as exc:
                     self.logger.error("no more credentials to try")
                     return
-                self.logger.debug(
+                self.logger.info(
                     "trying to log in with %s / %s" % (username, password)
                 )
                 self.wait_write(username, wait=None)
                 self.wait_write(password, wait="Password:")
             if self.xr_ready == True and ridx == 4:
                 # run main config!
-                self.bootstrap_config()
-                self.startup_config()
+                self.apply_config()
                 # close telnet connection
-                self.tn.close()
+                self.scrapli_tn.close()
                 # startup time?
                 startup_time = datetime.datetime.now() - self.start_time
                 self.logger.info("Startup complete in: %s" % startup_time)
@@ -119,7 +117,7 @@ class XRV_vm(vrnetlab.VM):
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time
         if res != b"":
-            self.logger.trace("OUTPUT: %s" % res.decode())
+            self.write_to_stdout(res)
             # reset spins if we saw some output
             self.spins = 0
 
@@ -127,115 +125,84 @@ class XRV_vm(vrnetlab.VM):
 
         return
 
-    def bootstrap_config(self):
-        """Do the actual bootstrap config"""
-        self.logger.info("applying bootstrap configuration")
-        self.wait_write("", None)
+    def apply_config(self):  
+        
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        self.logger.info(f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)")
+        
+        # init scrapli
+        xrv_scrapli_dev = {
+            "host": "127.0.0.1",
+            "auth_bypass": True,
+            "auth_strict_key": False,
+            "timeout_socket": scrapli_timeout,
+            "timeout_transport": scrapli_timeout,
+            "timeout_ops": scrapli_timeout,
+        }
+                        
+        xrv_config = f"""hostname {self.hostname}
+vrf clab-mgmt
+description Containerlab management VRF (DO NOT DELETE)
+address-family ipv4 unicast
+exit
+address-family ipv6 unicast
+root
+!
+router static
+vrf clab-mgmt
+address-family ipv4 unicast
+0.0.0.0/0 {self.mgmt_gw_ipv4}
+address-family ipv6 unicast
+::/0 {self.mgmt_gw_ipv6}
+root
+!
+interface MgmtEth 0/0/CPU0/0
+description Containerlab management interface
+vrf clab-mgmt
+ipv4 address {self.mgmt_address_ipv4}
+ipv6 address {self.mgmt_address_ipv6}
+no shut
+exit
+!
+ssh server v2
+ssh server vrf clab-mgmt
+ssh server netconf port 830
+ssh server netconf vrf clab-mgmt
+netconf agent ssh
+netconf-yang agent ssh
+!
+grpc port 57400
+grpc vrf clab-mgmt
+grpc no-tls
+!
+xml agent tty
+!
+"""
 
-        self.wait_write("terminal length 0")
-
-        self.wait_write("crypto key generate rsa")
-        # check if we are prompted to overwrite current keys
-        (ridx, match, res) = self.tn.expect(
+        con = IOSXRDriver(**xrv_scrapli_dev)
+        con.commandeer(conn=self.scrapli_tn)
+        
+        if os.path.exists(STARTUP_CONFIG_FILE):
+            self.logger.info("Startup configuration file found")
+            with open(STARTUP_CONFIG_FILE, "r") as config:
+                xrv_config += config.read()
+        else:
+            self.logger.warning(f"User provided startup configuration is not found.")
+                    
+        # configure SSH keys
+        con.send_interactive(
             [
-                b"How many bits in the modulus",
-                b"Do you really want to replace them",
-                b"^[^ ]+#",
-            ],
-            10,
+                ("crypto key generate rsa", "How many bits in the modulus [2048]", False),
+                ("2048", "#", True),
+            ]
         )
-        if match:  # got a match!
-            if ridx == 0:
-                self.wait_write("2048", None)
-            elif ridx == 1:  # press return to get started, so we press return!
-                self.wait_write("no", None)
 
-        # make sure we get our prompt back
-        self.wait_write("")
-
-        if self.username and self.password:
-            self.wait_write("admin")
-            self.wait_write("configure")
-            self.wait_write("username %s group root-system" % (self.username))
-            self.wait_write("username %s group cisco-support" % (self.username))
-            self.wait_write("username %s secret %s" % (self.username, self.password))
-            self.wait_write("commit")
-            self.wait_write("exit")
-            self.wait_write("exit")
-
-        self.wait_write("show interface description")
-        self.wait_write("configure")
-        self.wait_write("hostname {}".format(self.hostname))
-        
-        # configure management vrf
-        self.wait_write("vrf clab-mgmt")
-        self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
-        self.wait_write("address-family ipv4 unicast")
-        self.wait_write("exit")
-        self.wait_write("address-family ipv6 unicast")
-        self.wait_write("exit")
-        self.wait_write("exit")
-        
-        # add static route for management
-        self.wait_write("router static")
-        self.wait_write("vrf clab-mgmt")
-        self.wait_write("address-family ipv4 unicast")
-        self.wait_write(f"0.0.0.0/0 {self.mgmt_gw_ipv4}")
-        self.wait_write("exit")
-        self.wait_write("address-family ipv6 unicast")
-        self.wait_write(f"::/0 {self.mgmt_gw_ipv6}")
-        self.wait_write("exit")
-        self.wait_write("exit")
-        self.wait_write("exit")
-      
-        # configure ssh & netconf w/ vrf
-        self.wait_write("ssh server v2")
-        self.wait_write("ssh server vrf clab-mgmt")
-        self.wait_write("ssh server netconf port 830")  # for 5.1.1
-        self.wait_write("ssh server netconf vrf clab-mgmt")  # for 5.3.3
-        self.wait_write("netconf agent ssh")  # for 5.1.1
-        self.wait_write("netconf-yang agent ssh")  # for 5.3.3
-        
-        # configure gNMI
-        self.wait_write("grpc port 57400")
-        self.wait_write("grpc vrf clab-mgmt")
-        self.wait_write("grpc no-tls")
-        
-        # configure xml agent
-        self.wait_write("xml agent tty")
-        
-        # configure mgmt interface
-        self.wait_write("interface MgmtEth 0/0/CPU0/0")
-        self.wait_write("vrf clab-mgmt")
-        self.wait_write("no shutdown")
-        self.wait_write(f"ipv4 address {self.mgmt_address_ipv4}")
-        self.wait_write(f"ipv6 address {self.mgmt_address_ipv6}")
-        self.wait_write("exit")
-        self.wait_write("commit")
-        self.wait_write("exit")
-
-    def startup_config(self):
-        """Load additional config provided by user."""
-
-        if not os.path.exists(STARTUP_CONFIG_FILE):
-            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} is not found")
-            return
-
-        self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} exists")
-        with open(STARTUP_CONFIG_FILE) as file:
-            config_lines = file.readlines()
-            config_lines = [line.rstrip() for line in config_lines]
-            self.logger.trace(f"Parsed startup config file {STARTUP_CONFIG_FILE}")
-
-        self.logger.info(f"Writing lines from {STARTUP_CONFIG_FILE}")
-
-        self.wait_write("configure")
-        # Apply lines from file
-        for line in config_lines:
-            self.wait_write(line)
-        # Commit and GTFO
-        self.wait_write("commit")
-        self.wait_write("exit")
+        res = con.send_configs(xrv_config.splitlines())
+        con.send_configs(["commit best-effort label CLAB_BOOTSTRAP", "end"], eager=True)
+    
+        for response in res:
+            self.logger.info(f"CONFIG:{response.channel_input}")
+            self.logger.info(f"RESULT:{response.result}")
 
 
 class XRV(vrnetlab.VR):

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -242,7 +242,6 @@ if __name__ == "__main__":
         )
     )
 
-    logger.debug(f"Environment variables: {os.environ}")
     vrnetlab.boot_delay()
 
     vr = XRV(args.hostname, args.username, args.password, args.connection_mode)

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -198,7 +198,7 @@ root
         )
 
         res = con.send_configs(xrv_config.splitlines())
-        res += con.send_configs(["commit best-effort label CLAB_BOOTSTRAP", "end"], eager=True)
+        res += con.send_configs(["commit best-effort label CLAB_BOOTSTRAP", "end"])
     
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -198,7 +198,7 @@ xml agent tty
         )
 
         res = con.send_configs(xrv_config.splitlines())
-        con.send_configs(["commit best-effort label CLAB_BOOTSTRAP", "end"], eager=True)
+        res += con.send_configs(["commit best-effort label CLAB_BOOTSTRAP", "end"], eager=True)
     
         for response in res:
             self.logger.info(f"CONFIG:{response.channel_input}")

--- a/xrv9k/docker/Dockerfile
+++ b/xrv9k/docker/Dockerfile
@@ -1,23 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-LABEL org.opencontainers.image.authors="roman@dodin.dev"
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
-   && apt-get upgrade -qy \
-   && apt-get install -y \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   ssh \
-   telnet \
-   inetutils-ping \
-   dnsutils \
-   openvswitch-switch \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/xrv9k/docker/Dockerfile
+++ b/xrv9k/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.0.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -218,7 +218,7 @@ xml agent tty
         
         with IOSXRDriver(**xrv9k_scrapli_dev) as con:
             res = con.send_configs(xrv9k_config.splitlines())
-            con.send_configs(["commit best-effort label CLAB_BOOTSTRAP", "end"], eager=True)
+            res += con.send_configs(["commit best-effort label CLAB_BOOTSTRAP", "end"], eager=True)
     
             for response in res:
                 self.logger.info(f"CONFIG:{response.channel_input}")

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -10,9 +10,10 @@ import time
 
 
 import vrnetlab
+from scrapli.driver.core import IOSXRDriver
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-
+DEFAULT_SCRAPLI_TIMEOUT = 900
 
 def handle_SIGCHLD(signal, frame):
     os.waitpid(-1, os.WNOHANG)
@@ -39,13 +40,13 @@ def trace(self, message, *args, **kws):
 logging.Logger.trace = trace
 
 
-class XRV_vm(vrnetlab.VM):
+class XRv9k_vm(vrnetlab.VM):
     def __init__(self, hostname, username, password, nics, conn_mode, vcpu, ram, install=False):
         disk_image = None
         for e in sorted(os.listdir("/")):
             if not disk_image and re.search(".qcow2", e):
                 disk_image = "/" + e
-        super(XRV_vm, self).__init__(username, password, disk_image=disk_image, ram=ram, smp=f"cores={vcpu},threads=1,sockets=1")
+        super(XRv9k_vm, self).__init__(username, password, disk_image=disk_image, ram=ram, smp=f"cores={vcpu},threads=1,sockets=1", use_scrapli=True)
         self.hostname = hostname
         self.conn_mode = conn_mode
         self.num_nics = nics
@@ -66,9 +67,6 @@ class XRV_vm(vrnetlab.VM):
                 "telnet:0.0.0.0:50%02d,server,nowait" % (self.num + 3),
             ]
         )
-        self.credentials = []
-
-        self.xr_ready = False
 
     def gen_mgmt(self):
         """Generate qemu args for the mgmt interface(s)"""
@@ -110,82 +108,44 @@ class XRV_vm(vrnetlab.VM):
             self.start()
             return
 
-        (ridx, match, res) = self.tn.expect(
+        (ridx, match, res) = self.con_expect(
             [
                 b"Press RETURN to get started",
-                b"Not settable: Success",  # no SYSTEM CONFIGURATION COMPLETE in xrv9k?
                 b"Enter root-system [U|u]sername",
-                b"Username:",
+                b"XR partition preparation completed successfully",
             ],
-            1,
         )
         
-        xr_login = False    # whether we are logged into the shell or not
-
         if match:  # got a match!
             if ridx == 0:  # press return to get started, so we press return!
-                self.logger.debug("got 'press return to get started...'")
+                self.logger.info("got 'press return to get started...'")
                 self.wait_write("", wait=None)
-            if ridx == 1:  # system configuration complete
-                self.logger.info(
-                    "IOS XR system configuration is complete, should be able to proceed with bootstrap configuration"
-                )
-                self.wait_write("", wait=None)
-                self.xr_ready = True
-            if ridx == 2:  # initial user config
-                # if we are installing and we reach this point, we are finished and don't need to bootstrap
-                if self.install_mode:
-                    self.running = True
-                    return
-                self.logger.info("Creating initial user")
+            if ridx == 1 and not self.install_mode:  # initial user config
+                self.logger.info("Caught user creation prompt. Creating initial user")
                 self.wait_write(self.username, wait=None)
                 self.wait_write(self.password, wait="Enter secret:")
                 self.wait_write(self.password, wait="Enter secret again:")
-                self.credentials.insert(0, [self.username, self.password])
-            if ridx == 3:  # matched login prompt, so should login
-                self.logger.debug("matched login prompt")
-                
-                try:
-                    username, password = self.credentials[0]
-                except IndexError:
-                    self.logger.error("no credentials populated")
-                    return
+                self.write_to_stdout(self.scrapli_tn.channel.read())
 
-                self.logger.debug(
-                    "trying to log in with %s / %s" % (username, password)
-                )
-                self.wait_write(username, wait=None)
-                self.wait_write(password, wait="Password:")
-                
-                _, match, res = self.tn.expect([b"ios#"], 3)
-                if match:
-                    self.logger.debug("logged in with %s / %s successfully" % (username, password))
-                    xr_login = True
-                else:
-                    self.logger.error("could not login with %s / %s" % (username, password))
-                    
-            if self.xr_ready is True and xr_login is True:
-                # run main config!
-                if not self.bootstrap_config():
-                    # main config failed :/
-                    self.logger.debug("bootstrap_config failed, restarting device")
-                    self.stop()
-                    self.start()
-                    return
-                self.startup_config()
-                # close telnet connection
-                self.tn.close()
+                self.apply_config()
+
                 # startup time?
                 startup_time = datetime.datetime.now() - self.start_time
                 self.logger.info("Startup complete in: %s" % startup_time)
                 # mark as running
                 self.running = True
                 return
+            if ridx == 2 and self.install_mode:
+                # SDR/XR image bake is complete, install finished
+                install_time = datetime.datetime.now() - self.start_time
+                self.logger.info("Install complete in: %s", install_time)
+                self.running = True
+                return
 
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time
         if res != b"":
-            self.logger.trace("OUTPUT: %s" % res.decode())
+            self.write_to_stdout(res)
             # reset spins if we saw some output
             self.spins = 0
 
@@ -193,155 +153,102 @@ class XRV_vm(vrnetlab.VM):
 
         return
 
-    def bootstrap_config(self):
-        """Do the actual bootstrap config"""
-        self.logger.info("applying bootstrap configuration")
-        self.wait_write("", None)
-
-        self.wait_write("terminal length 0")
-
-        self.wait_write("crypto key generate rsa")
-        # check if we are prompted to overwrite current keys
-        (ridx, match, res) = self.tn.expect(
-            [
-                b"How many bits in the modulus",
-                b"Do you really want to replace them",
-                b"^[^ ]+#",
-            ],
-            10,
-        )
-        if match:  # got a match!
-            if ridx == 0:
-                self.wait_write("2048", None)
-            elif ridx == 1:  # press return to get started, so we press return!
-                self.wait_write("no", None)
-
-        # make sure we get our prompt back
-        self.wait_write("")
-
-        # wait for linecard to show up
-        if not self._wait_config("show platform | in LC", "IOS XR RUN"):
-            return False
-
-        self.wait_write("configure")
-        self.wait_write(f"hostname {self.hostname}")
+    def apply_config(self):
         
-        # configure management vrf
-        self.wait_write("vrf clab-mgmt")
-        self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
-        self.wait_write("address-family ipv4 unicast")
-        self.wait_write("exit")
-        self.wait_write("address-family ipv6 unicast")
-        self.wait_write("exit")
-        self.wait_write("exit")
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        self.logger.info(f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)")
         
-        # add static route for management
-        self.wait_write("router static")
-        self.wait_write("vrf clab-mgmt")
-        self.wait_write("address-family ipv4 unicast")
-        self.wait_write(f"0.0.0.0/0 {self.mgmt_gw_ipv4}")
-        self.wait_write("exit")
-        self.wait_write("address-family ipv6 unicast")
-        self.wait_write(f"::/0 {self.mgmt_gw_ipv6}")
-        self.wait_write("exit")
-        self.wait_write("exit")
-        self.wait_write("exit")
-            
-        # configure ssh & netconf w/ vrf
-        self.wait_write("ssh server v2")
-        self.wait_write("ssh server vrf clab-mgmt")
-        self.wait_write("ssh server netconf port 830")  # for 5.1.1
-        self.wait_write("ssh server netconf vrf clab-mgmt")  # for 5.3.3
-        self.wait_write("netconf agent ssh")  # for 5.1.1
-        self.wait_write("netconf-yang agent ssh")  # for 5.3.3
-        # configure gNMI
-        self.wait_write("grpc port 57400")
-        self.wait_write("grpc vrf clab-mgmt")
-        self.wait_write("grpc no-tls")
-
-        # configure xml agent
-        self.wait_write("xml agent tty")
+        # init scrapli
+        xrv9k_scrapli_dev = {
+            "host": "127.0.0.1",
+            "port": 5000 + self.num,
+            "auth_username": self.username,
+            "auth_password": self.password,
+            "auth_strict_key": False,
+            "transport": "telnet",
+            "timeout_socket": scrapli_timeout,
+            "timeout_transport": scrapli_timeout,
+            "timeout_ops": scrapli_timeout,
+        }
+                        
+        xrv9k_config = f"""hostname {self.hostname}
+vrf clab-mgmt
+description Containerlab management VRF (DO NOT DELETE)
+address-family ipv4 unicast
+exit
+address-family ipv6 unicast
+root
+!
+router static
+vrf clab-mgmt
+address-family ipv4 unicast
+0.0.0.0/0 {self.mgmt_gw_ipv4}
+address-family ipv6 unicast
+::/0 {self.mgmt_gw_ipv6}
+root
+!
+interface MgmtEth 0/RP0/CPU0/0
+description Containerlab management interface
+vrf clab-mgmt
+ipv4 address {self.mgmt_address_ipv4}
+ipv6 address {self.mgmt_address_ipv6}
+no shutdown
+exit
+!
+ssh server v2
+ssh server vrf clab-mgmt
+ssh server netconf
+!
+grpc port 57400
+grpc vrf clab-mgmt
+grpc no-tls
+!
+xml agent tty
+!
+"""
         
-        # configure mgmt interface
-        self.wait_write("interface MgmtEth0/RP0/CPU0/0")
-        self.wait_write("vrf clab-mgmt")
-        self.wait_write("no shutdown")
-        self.wait_write(f"ipv4 address {self.mgmt_address_ipv4}")
-        self.wait_write(f"ipv6 address {self.mgmt_address_ipv6}")
-        self.wait_write("commit")
-        self.wait_write("end")
-
-        return True
-
-    def startup_config(self):
-        """Load additional config provided by user."""
-
-        if not os.path.exists(STARTUP_CONFIG_FILE):
-            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} is not found")
-            return
-
-        self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} exists")
-        with open(STARTUP_CONFIG_FILE) as file:
-            config_lines = file.readlines()
-            config_lines = [line.rstrip() for line in config_lines]
-            self.logger.trace(f"Parsed startup config file {STARTUP_CONFIG_FILE}")
-
-        self.logger.info(f"Writing lines from {STARTUP_CONFIG_FILE}")
-
-        self.wait_write("configure")
-        # Apply lines from file
-        for line in config_lines:
-            self.wait_write(line)
-        # Commit and GTFO
-        self.wait_write("commit")
-        self.wait_write("exit")
+        if os.path.exists(STARTUP_CONFIG_FILE):
+            self.logger.info("Startup configuration file found")
+            with open(STARTUP_CONFIG_FILE, "r") as config:
+                xrv9k_config += config.read()
+        else:
+            self.logger.warning(f"User provided startup configuration is not found.")
+        
+        self.scrapli_tn.close()
+        
+        with IOSXRDriver(**xrv9k_scrapli_dev) as con:
+            res = con.send_configs(xrv9k_config.splitlines())
+            con.send_configs(["commit best-effort label CLAB_BOOTSTRAP", "end"], eager=True)
+    
+            for response in res:
+                self.logger.info(f"CONFIG:{response.channel_input}")
+                self.logger.info(f"RESULT:{response.result}")
 
 
-    def _wait_config(self, show_cmd, expect):
-        """Some configuration takes some time to "show up".
-        To make sure the device is really ready, wait here.
-        """
-        self.logger.debug("waiting for {} to appear in {}".format(expect, show_cmd))
-        wait_spins = 0
-        # 10s * 90 = 900s = 15min timeout
-        while wait_spins < 90:
-            self.wait_write(show_cmd, wait=None)
-            _, match, data = self.tn.expect([expect.encode("UTF-8")], timeout=10)
-            self.logger.trace(data.decode("UTF-8"))
-            if match:
-                self.logger.debug("a wild {} has appeared!".format(expect))
-                return True
-            wait_spins += 1
-        self.logger.error("{} not found in {}".format(expect, show_cmd))
-        return False
-
-
-class XRV(vrnetlab.VR):
+class XRv9k(vrnetlab.VR):
     def __init__(self, hostname, username, password, nics, conn_mode, vcpu, ram):
-        super(XRV, self).__init__(username, password)
-        self.vms = [XRV_vm(hostname, username, password, nics, conn_mode, vcpu, ram)]
+        super(XRv9k, self).__init__(username, password)
+        self.vms = [XRv9k_vm(hostname, username, password, nics, conn_mode, vcpu, ram)]
 
 
-class XRV_Installer(XRV):
-    """ XRV installer
-        Will start the XRV and then shut it down. Booting the XRV for the
-        first time requires the XRV itself to install internal packages
+class XRv9k_Installer(XRv9k):
+    """ XRv9k installer
+        Will start the XRv9k and then shut it down. Booting the XRv9k for the
+        first time requires the XRv9k itself to install internal packages
         then it will restart. Subsequent boots will not require this restart.
         By running this "install" when building the docker image we can
-        decrease the normal startup time of the XRV.
+        decrease the normal startup time of the XRv9k.
     """
     def __init__(self, hostname, username, password, nics, conn_mode, vcpu, ram):
-        super(XRV, self).__init__(username, password)
-        self.vms = [XRV_vm(hostname, username, password, nics, conn_mode, vcpu, ram, install=True)]
+        super(XRv9k, self).__init__(username, password)
+        self.vms = [XRv9k_vm(hostname, username, password, nics, conn_mode, vcpu, ram, install=True)]
     
     def install(self):
         self.logger.info("Installing XRv9k")
         xrv = self.vms[0]
         while not xrv.running:
             xrv.work()
-        time.sleep(30)
         xrv.stop()
-        self.logger.info("Installation complete")
 
 
 if __name__ == "__main__":
@@ -377,11 +284,10 @@ if __name__ == "__main__":
     if args.trace:
         logger.setLevel(1)
 
-    logger.debug(f"Environment variables: {os.environ}")
     vrnetlab.boot_delay()
 
     if args.install:
-        vr = XRV_Installer(
+        vr = XRv9k_Installer(
             args.hostname,
             args.username,
             args.password,
@@ -392,7 +298,7 @@ if __name__ == "__main__":
         )
         vr.install()
     else:
-        vr = XRV(
+        vr = XRv9k(
             args.hostname,
             args.username,
             args.password,

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -218,7 +218,7 @@ root
         
         with IOSXRDriver(**xrv9k_scrapli_dev) as con:
             res = con.send_configs(xrv9k_config.splitlines())
-            res += con.send_configs(["commit best-effort label CLAB_BOOTSTRAP", "end"], eager=True)
+            res += con.send_configs(["commit best-effort label CLAB_BOOTSTRAP", "end"])
     
             for response in res:
                 self.logger.info(f"CONFIG:{response.channel_input}")

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -221,7 +221,7 @@ root
             with open(STARTUP_CONFIG_FILE, "r") as config:
                 xrv9k_config += config.read()
         else:
-            self.logger.warning(f"User provided startup configuration is not found.")
+            self.logger.warning("User provided startup configuration is not found.")
 
         self.scrapli_tn.close()
 

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -12,7 +12,6 @@ import vrnetlab
 from scrapli.driver.core import IOSXRDriver
 
 STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
-DEFAULT_SCRAPLI_TIMEOUT = 900
 
 
 def handle_SIGCHLD(signal, frame):
@@ -163,9 +162,9 @@ class XRv9k_vm(vrnetlab.VM):
         return
 
     def apply_config(self):
-        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", DEFAULT_SCRAPLI_TIMEOUT)
+        scrapli_timeout = os.getenv("SCRAPLI_TIMEOUT", vrnetlab.DEFAULT_SCRAPLI_TIMEOUT)
         self.logger.info(
-            f"Scrapli timeout is {scrapli_timeout}s (default {DEFAULT_SCRAPLI_TIMEOUT}s)"
+            f"Scrapli timeout is {scrapli_timeout}s (default {vrnetlab.DEFAULT_SCRAPLI_TIMEOUT}s)"
         )
 
         # init scrapli

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -204,7 +204,7 @@ grpc vrf clab-mgmt
 grpc no-tls
 !
 xml agent tty
-!
+root
 """
         
         if os.path.exists(STARTUP_CONFIG_FILE):


### PR DESCRIPTION
This PR implements scrapli to the 'core' functions, and uses the driver for some platforms.

## Changes

### vrnetlab base image

A new vrnetlab 'base' image is added. This image should be used as the base for all migrated platforms.

It contains common pkgs preinstalled as well as Scrapli & Scrapli community.

### Scrapli 'core'

The core now uses Scrapli's `Driver` for serial console and qemu monitor connections. 

Scrapli is imported in `vrnetlab.py` but will *not* throw an error if not found, which means scrapli and telnetlib may co-exist.

Setting `use_scrapli` to `True` in the class initializer will enable Scrapli for the serial console and qemu monitor connections.

Core functions `wait_write`, `expect` and `read_until` now have Scrapli equivalents.

#### wait_write

`wait_write` can effectively still be used as normal. Inside the function if `use_scrapli` was set to true then the `wait_write_scrapli` function is run instead.

`wait_write_scrapli` replicates the functionality of `wait_write`, but using the Scrapli serial console connection instead of telnetlib. 

`wait_write_scrapli` currently doesn't have support for `con`, `clean_buffer` or `hold` args.

#### expect

`expect` was part of telnetlib. The scrapli compatible version is the `con_expect` function.

`con_expect` aims to replicate the functionality of `telnetlib.expect`

It accepts a list of byte-strings which are used for regex matching something on the console.

Like `telnetlib.expect` it will return the list index of the first thing that it matched, the re match object and the read console buffer up until the match (or timeout).

*Unlike* telnetlib, the timeout is optional and `con_expect` will *not* block forever. Rather the timeout in this case is used for how long you wish to *block for*.

My personal opinion is to not use the timeout/block, it makes behaviour less reliable.

#### read_until

`read_until` was another function of telnetlib, the Scrapli compatible function is `con_read_until`. Generally this wasn't used directly in any nodes, but rather for the `wait_write` function.

`con_read_until` will continously read and output the serial console buffer to stdout until the string it must match on is matched.

It returns the entire buffer of the console read until the match.

By default `con_read_until` is blocking, however there is a timeout arg if the function should be required to timeout after some amount of time.

#### Logging

- Logging formatted has been improved -- Logs levels are coloured via ANSI escape code now.
- Common logs are done on vrnetlab side now:
    - Env vars
    - If transparent mgmt intf is in use
    - If scrapli is in use
    - SMP/vCPU and RAM settings

#### Misc

These are fairly opinionated additions:

`write_to_stdout` has been added. It's a simple helper function to write something to the stdout and flush the buffer so everything is written.

The main usage is to print console output, the jusitifcation is because it looks uglier when console output is printed by the logger.

Another addition is the `format_bool_color` function. This is simply used to return text which is ANSI formatted in green or red depending on if some boolean is true or false.

## Migrated platforms

- Cisco CSR1kv -- Uses CVAC (mounted ISO)
- Cisco Cat8kv -- Uses CVAC (mounted ISO)
- Cisco Cat9kv -- Uses CVAC (mounted ISO)
- Cisco vIOS -- `IOSXEDriver`
- Cisco NX-OS -- `NXOSDriver`
- Cisco Nexus 9000v -- `NXOSDriver`
- Cisco IOS-XRv -- `IOSXRDriver`
- Cisco IOS-XRv9k -- `IOSXRDriver`
- Nokia SR-OS -- `nokia_sros` platform from Scrapli Community

I plan to implement other platforms later down the line; time permitting.

## Migration steps

There are two ways you can migrate:

- Maintain wait_write functionality but use Scrapli as the telnet backend.
- Migrate everything to Scrapli and use the platform implementation for config management.

### Steps

- Migrate the Dockerfile to `ghcr.io/srl-labs/vrnetlab-base` as the base image.
- In the class initializer, set `use_scrapli` to `True`.
- Change `self.tn.expect()` to `self.con_expect()` and remove the timeout.
- Change the console buffer printing to use the `self.write_to_stdout()` instead of trace or debug logging.
- Change the telnet close from `self.tn.close()` to `self.scrapli_tn.close()`

**Extra steps if migrating to Scrapli platform/driver**
- Create the scrapli device configuration and open the connection:
    - You can close the `self.scrapli_tn` connection and open either manually or use the context manager (see XRv9k).
    - (RECOMMENDED) You can commandeer the existing `self.scrapli_tn` connection, so the new driver uses the existing transport (see `vIOS`)
- (OPTIONAL) Implement the `SCRAPLI_TIMEOUT` env var to let the user control the driver timeout.