### PR TITLE
Add Cisco vIOS L2 support

### DIFF
--- a/viosl2/Makefile
+++ b/viosl2/Makefile
@@ -1,0 +1,12 @@
+VENDOR=Cisco
+NAME=vIOSL2
+IMAGE_FORMAT=qcow2
+IMAGE_GLOB=*.qcow2
+
+# Match images like:
+# - cisco_viosl2-15.2.qcow2
+# Extract version, for example: 15.2
+VERSION=$(shell echo $(IMAGE) | sed -e 's/cisco_viosl2-\(.*\)\.qcow2/\1/')
+
+-include ../makefile-sanity.include
+-include ../makefile.include

--- a/viosl2/README.md
+++ b/viosl2/README.md
@@ -1,0 +1,98 @@
+# Cisco vIOS L2
+
+This is the vrnetlab docker image for Cisco vIOS L2 switch. Everything is based on the vios vrnetlab router files and
+modified to support the vIOS L2 image.
+
+## Justification
+
+Cisco vIOS L2 is a virtual switch that can be used for testing and development purposes.
+It is older than IOL L2 (running only 15.x IOS version), however, it has several advantages:
+
+- Small memory footprint (768MB vs 4GB+ for IOS XE). With KSM enabled, the memory usage can be even lower.
+- Easy to run on a laptop or a small server with limited resources for education purposes.
+- Good for scalability testing of applications, when you don't need all new features of IOS XE.
+
+## Building the docker image
+
+Qemu disk image can be obtained from Cisco Modeling Labs (CML).
+More information about Cisco vIOS:
+<https://developer.cisco.com/docs/modeling-labs/iosvl2/>
+
+Once you extract disk image, rename the image file to the following format:
+`cisco_viosl2-[VERSION].qcow2`
+Where `[VERSION]` is the desired version of the image, for example `15.2` or `15.2.2020`.
+
+Finally, you can build the docker image with the `make docker-image` command.
+
+Tested with versions:
+
+- 15.2 (image: vios_l2-adventerprisek9-m.ssa.high_iron_20200929.qcow2)
+
+## System requirements
+
+- CPU: 1 core
+- RAM: 768MB
+- Disk: <1GB
+
+## Network interfaces
+
+The router supports up to 16 GigabitEthernet interfaces.
+
+- The first interface `GigaEthernet0/0` is used as the management interface (it is placed in separated VRF) and is 
+  mapped to the docker container interface `eth0`.
+- The rest of the interfaces are numbered from `GigaEthernet0/1` and are used as data interfaces.
+  They are mapped to the docker container interfaces `eth1`, `eth2`, etc.
+- The interfaces are used in groups of four, e.g. `GigaEthernet0/0` to `GigaEthernet0/3`, `GigaEthernet1/0-3` to
+  `GigaEthernet1/3`, etc.
+
+## Management plane
+
+The following protocols are enabled on the management interface:
+
+- CLI SSH on port 22
+- NETCONF via SSH on port 22 (the same credentials are used as for CLI SSH)
+- SNMPv2c on port 161 (`public` used as community string)
+
+## Environment variables
+
+| ID              | Description               | Default |
+|-----------------|---------------------------|---------|
+| USERNAME        | SSH username              | admin   |
+| PASSWORD        | SSH password              | admin   |
+| HOSTNAME        | device hostname           | viosl2  |
+| TRACE           | enable trace logging      | false   |
+| CONNECTION_MODE | interface connection mode | tc      |
+
+## Configuration persistence
+
+The startup configuration can be provided by mounting a file to `/config/startup-config.cfg`.
+The changes done in the switch configuration during runtime are not automatically persisted outside
+the container - after stopping the container, the content of the flash/NVRAM is lost.
+User is responsible for persistence of the changes, for example, by copying the configuration
+to mounted startup-configuration file.
+
+## Sample containerlab topology
+
+```yaml
+name: viosl2-lab
+
+topology:
+  kinds:
+    linux:
+      image: vrnetlab/cisco_viosl2:15.2
+  nodes:
+    viosl2-1:
+      kind: linux
+      binds:
+        - viosl2-1.cfg:/config/startup-config.cfg
+      env:
+        HOSTNAME: viosl2-1
+    viosl2-2:
+      kind: linux
+      binds:
+        - viosl2-2.cfg:/config/startup-config.cfg
+      env:
+        HOSTNAME: viosl2-2
+  links:
+    - endpoints: ["viosl2-1:eth1","viosl2-2:eth1"]
+```

--- a/viosl2/docker/Dockerfile
+++ b/viosl2/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
+LABEL org.opencontainers.image.authors="xtothj@gmail.com"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+   && apt-get install -y --no-install-recommends \
+   bridge-utils \
+   iproute2 \
+   python3 \
+   socat \
+   qemu-kvm \
+   qemu-utils \
+   tcpdump \
+   procps \
+   && rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY $IMAGE* /
+COPY *.py /
+
+EXPOSE 22 161/udp 5000 10000-10099
+HEALTHCHECK CMD ["/healthcheck.py"]
+ENTRYPOINT ["/launch.py"]

--- a/viosl2/docker/launch.py
+++ b/viosl2/docker/launch.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+import datetime
+import logging
+import os
+import re
+import signal
+import sys
+
+import vrnetlab
+
+STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
+
+
+def handle_SIGCHLD(_signal, _frame):
+    os.waitpid(-1, os.WNOHANG)
+
+
+def handle_SIGTERM(_signal, _frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+
+
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+
+
+logging.Logger.trace = trace
+
+
+class VIOS_vm(vrnetlab.VM):
+    def __init__(self, hostname: str, username: str, password: str, conn_mode: str):
+        disk_image = None
+        for e in os.listdir("/"):
+            if re.search(".qcow2$", e):
+                disk_image = "/" + e
+        if not disk_image:
+            raise Exception("No disk image found")
+
+        super(VIOS_vm, self).__init__(
+            username=username,
+            password=password,
+            disk_image=disk_image,
+            smp="1",
+            ram=768,
+            driveif="virtio",
+        )
+
+        self.hostname = hostname
+        self.conn_mode = conn_mode
+        # device supports up to 16 interfaces (1 management interface + 15 data interfaces)
+        self.num_nics = 15
+        self.running = False
+        self.spins = 0
+
+    def bootstrap_spin(self):
+        if self.spins > 300:
+            # too many spins with no result -> give up
+            self.stop()
+            self.start()
+            return
+
+        (ridx, match, res) = self.tn.expect(
+            [
+                rb"Would you like to enter the initial configuration dialog\? \[yes/no\]:",
+                b"Press RETURN to get started!",
+                b"Switch>",
+            ],
+            1,
+        )
+
+        if match:
+            if ridx == 0:
+                self.logger.info("Skipping initial configuration dialog")
+                self.wait_write("no", wait=None)
+            elif ridx == 1:
+                self.logger.info("Entering user EXEC mode")
+                for _ in range(3):
+                    self.wait_write("\r", wait=None)
+            elif ridx == 2:
+                self._enter_config_mode()
+                self._bootstrap_config()
+                self._load_startup_config()
+                self._save_config()
+
+                # close telnet connection
+                self.tn.close()
+                # startup time
+                startup_time = datetime.datetime.now() - self.start_time
+                self.logger.info(f"Startup complete in: {startup_time}")
+                # mark as running
+                self.running = True
+
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        if res != b"":
+            self.logger.trace(f"OUTPUT: {res.decode()}")
+            # reset spins if we saw some output
+            self.spins = 0
+
+        self.spins += 1
+        return
+
+    def _enter_config_mode(self):
+        self.logger.info("Entering configuration mode")
+
+        self.wait_write("enable", wait=None)
+        self.wait_write("configure terminal")
+
+    def _bootstrap_config(self):
+        self.logger.info("Applying initial configuration")
+
+        self.wait_write(f"hostname {self.hostname}")
+        self.wait_write(f"ip domain-name {self.hostname}.clab")
+        self.wait_write("no ip domain-lookup")
+        
+        # Explicitly enable IPv6
+        self.wait_write("ipv6 unicast-routing")
+
+        self.wait_write(f"username {self.username} privilege 15 secret {self.password}")
+
+        self.wait_write("line con 0")
+        self.wait_write("logging synchronous")
+        self.wait_write("exec-timeout 0 0")
+        self.wait_write("login local")
+        self.wait_write("exit")
+
+        self.wait_write("line vty 0 4")
+        self.wait_write("logging synchronous")
+        self.wait_write("exec-timeout 0 0")
+        self.wait_write("transport input ssh")
+        self.wait_write("login local")
+        self.wait_write("exit")
+
+        self.wait_write("vrf definition clab-mgmt")
+        self.wait_write("description Containerlab management VRF (DO NOT DELETE)")
+        self.wait_write("address-family ipv4")
+        self.wait_write("exit")
+        self.wait_write("address-family ipv6")
+        self.wait_write("exit")
+        self.wait_write("exit")
+
+        v4_mgmt_address = vrnetlab.cidr_to_ddn(self.mgmt_address_ipv4)
+
+        self.wait_write("interface GigabitEthernet0/0")
+        self.wait_write("no switchport")
+        self.wait_write("vrf forwarding clab-mgmt")
+        self.wait_write(f"ip address {v4_mgmt_address[0]} {v4_mgmt_address[1]}")
+        self.wait_write(f"ipv6 address {self.mgmt_address_ipv6}")
+        self.wait_write("no shutdown")
+        self.wait_write("exit")
+        
+        self.wait_write(f"ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 {self.mgmt_gw_ipv4}")
+        self.wait_write(f"ipv6 route vrf clab-mgmt ::/0 {self.mgmt_gw_ipv6}")
+
+        self.wait_write("crypto key generate rsa modulus 2048")
+        self.wait_write("ip ssh version 2")
+
+        self.wait_write("netconf ssh")
+        self.wait_write("netconf max-sessions 16")
+        self.wait_write("snmp-server community public rw")
+
+        self.wait_write("no banner exec")
+        self.wait_write("no banner login")
+        self.wait_write("no banner incoming")
+
+    def _load_startup_config(self):
+        if not os.path.exists(STARTUP_CONFIG_FILE):
+            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} not found")
+            return
+
+        self.logger.trace(f"Loading startup config file {STARTUP_CONFIG_FILE}")
+        with open(STARTUP_CONFIG_FILE) as file:
+            for line in (line.rstrip() for line in file):
+                self.wait_write(line)
+
+    def _save_config(self):
+        self.logger.info("Saving configuration")
+
+        self.wait_write("end")
+        self.wait_write("write memory")
+
+
+class VIOS(vrnetlab.VR):
+    def __init__(self, hostname: str, username: str, password: str, conn_mode: str):
+        super(VIOS, self).__init__(username, password)
+        self.vms = [VIOS_vm(hostname, username, password, conn_mode)]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument(
+        "--trace",
+        action="store_true",
+        help="Enable trace level logging",
+        default=os.getenv("TRACE", "false").lower() == "true",
+    )
+    parser.add_argument(
+        "--username", help="Username", default=os.getenv("USERNAME", "admin")
+    )
+    parser.add_argument(
+        "--password", help="Password", default=os.getenv("PASSWORD", "admin")
+    )
+    parser.add_argument(
+        "--hostname", help="Router hostname", default=os.getenv("HOSTNAME", "viosl2")
+    )
+    parser.add_argument(
+        "--connection-mode",
+        help="Connection mode to use in the datapath",
+        default=os.getenv("CONNECTION_MODE", "tc"),
+    )
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    vr = VIOS(
+        hostname=args.hostname,
+        username=args.username,
+        password=args.password,
+        conn_mode=args.connection_mode,
+    )
+    vr.start()


### PR DESCRIPTION
All necessary changes needed to make the vios files work for vIOSL2.

## Changes compared to code for vios router support

Added new directory `viosl2` (was quicker than changing the vios code and making it work for vios and viosl2 ;-)).

### Makefile
- Adapt NAME to `vIOSL2`
- Adapt comments and version regex for viosl2 image file

### Dockerfile
Added `procps` to base bookworm image for troubleshooting purposes.

### launch.py
- Increase memory for IOSvL2 image from 512 to 768
- Change expected prompt from `Router>` to `Switch>`
- Adapt initial configuration for L2 switches

### README.md
All changes needed to describe viosl2 instead of vios.

## Testing
Successful tests with image `vios_l2-adventerprisek9-m.ssa.high_iron_20200929.qcow2` (CML reference platform). Tested with example topology file shown in `README.md` and also with a 10 node network with core, distribution and access switches incl. access vlans, transport vlans, trunk ports, OSPF and HSRP (incl. interface tracking, which is not available in IOL L2).