### PR TITLE
vJunos-EVO: remove error in init file that prevents loading it

### DIFF
--- a/vjunosevolved/docker/init.conf
+++ b/vjunosevolved/docker/init.conf
@@ -1,5 +1,3 @@
-delete: chassis auto-image-upgrade;
-
 system {
     host-name {HOSTNAME};
     root-authentication {

--- a/vjunosevolved/docker/init.conf
+++ b/vjunosevolved/docker/init.conf
@@ -1,3 +1,5 @@
+delete: chassis auto-image-upgrade;
+
 system {
     host-name {HOSTNAME};
     root-authentication {
@@ -27,7 +29,7 @@ interfaces {
             family inet {
                 address {MGMT_IP_IPV4};
             }
-            family inet {
+            family inet6 {
                 address {MGMT_IP_IPV6};
             }
         }


### PR DESCRIPTION
plus remove config for ZTP as per console log message:

```
2024-12-31 09:11:40 INFO: ZTP: remove "chassis auto-image-upgrade" from config to abort ZTP
```