### PR TITLE
Fix routeros 

### DIFF
--- a/routeros/README.md
+++ b/routeros/README.md
@@ -10,6 +10,7 @@ Tested booting and responding to SSH:
  * chr-6.39.2.vmdk   MD5:eb99636e3cdbd1ea79551170c68a9a27
  * chr-6.47.9.vmdk
  * chr-7.1beta5.vmdk
+ * chr-7.16.2.vmdk
 
 
 ## System requirements

--- a/routeros/docker/Dockerfile
+++ b/routeros/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/routeros/docker/Dockerfile
+++ b/routeros/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
 LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The typing change caused an issue when starting the container:
```
Traceback (most recent call last):
  File "/launch.py", line 11, in <module>
    import vrnetlab
  File "/vrnetlab.py", line 860, in <module>
    def cidr_to_ddn(prefix: str) -> list[str]:
TypeError: 'type' object is not subscriptable
```

Updating the ubuntu version allow to be more up to date and use newer python version.