### PR TITLE
DHCP and static MAC support for management interface 

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -377,15 +377,15 @@ class VM:
             f.write(ifup_script)
         os.chmod("/etc/tc-tap-mgmt-ifup", 0o777)
 
-    def get_mgmt_mac(self):
+    def get_mgmt_mac(self, last_octet=0):
         """Get the MAC address for the management interface from the envvar
-           CLAB_MGMT_MAC or generate a random one using gen_mac(0).
+           `CLAB_MGMT_MAC` or generate a random one using `gen_mac(last_octet)`.
         """
         mgmt_mac_override = os.environ.get("CLAB_MGMT_MAC", "")
         if mgmt_mac_override:
             return mgmt_mac_override
         else:
-            return gen_mac(0)
+            return gen_mac(last_octet)
 
     def gen_mgmt(self):
         """Generate qemu args for the mgmt interface(s)
@@ -414,11 +414,7 @@ class VM:
 
         res = []
         res.append("-device")
-        self.mgmt_mac = (
-            "c0:00:01:00:ca:fe"
-            if getattr(self, "_static_mgmt_mac", False)
-            else self.get_mgmt_mac()
-        )
+        self.mgmt_mac = self.get_mgmt_mac()
 
         res.append(self.nic_type + f",netdev=p00,mac={self.mgmt_mac}")
         res.append("-netdev")

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -377,6 +377,16 @@ class VM:
             f.write(ifup_script)
         os.chmod("/etc/tc-tap-mgmt-ifup", 0o777)
 
+    def get_mgmt_mac(self):
+        """Get the MAC address for the management interface from the envvar
+           CLAB_MGMT_MAC or generate a random one using gen_mac(0).
+        """
+        mgmt_mac_override = os.environ.get("CLAB_MGMT_MAC", "")
+        if mgmt_mac_override:
+            return mgmt_mac_override
+        else:
+            return gen_mac(0)
+
     def gen_mgmt(self):
         """Generate qemu args for the mgmt interface(s)
 
@@ -407,7 +417,7 @@ class VM:
         self.mgmt_mac = (
             "c0:00:01:00:ca:fe"
             if getattr(self, "_static_mgmt_mac", False)
-            else gen_mac(0)
+            else self.get_mgmt_mac()
         )
 
         res.append(self.nic_type + f",netdev=p00,mac={self.mgmt_mac}")

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -116,16 +116,18 @@ class VM:
         # which **does not** match the eth0 interface of a container.
         # In pass-through mode the VM container uses the same IP as the container's eth0 interface and transparently forwards traffic between the two interfaces.
         # See https://github.com/hellt/vrnetlab/issues/286
-        self.mgmt_passthrough = mgmt_passthrough
-        mgmt_passthrough_override = os.environ.get("CLAB_MGMT_PASSTHROUGH", "")
-        if mgmt_passthrough_override:
-            self.mgmt_passthrough = mgmt_passthrough_override.lower() == "true"
+        self.mgmt_passthrough = (
+            os.environ.get("CLAB_MGMT_PASSTHROUGH", "").lower() == "true"
+            if os.environ.get("CLAB_MGMT_PASSTHROUGH")
+            else mgmt_passthrough
+        )
 
         # Check if CLAB_MGMT_DHCP environment variable is set
-        self.mgmt_dhcp = mgmt_dhcp
-        mgmt_dhcp_override = os.environ.get("CLAB_MGMT_DHCP", "")
-        if mgmt_dhcp_override:
-            self.mgmt_dhcp = mgmt_dhcp_override.lower() == "true"
+        self.mgmt_dhcp = (
+            os.environ.get("CLAB_MGMT_DHCP", "").lower() == "true"
+            if os.environ.get("CLAB_MGMT_DHCP")
+            else mgmt_dhcp
+        )
 
         # Populate management IP and gateway
         # If CLAB_MGMT_DHCP environment variable is set, we assume that a DHCP client
@@ -377,15 +379,11 @@ class VM:
             f.write(ifup_script)
         os.chmod("/etc/tc-tap-mgmt-ifup", 0o777)
 
-    def get_mgmt_mac(self, last_octet=0):
+    def get_mgmt_mac(self, last_octet=0) -> str:
         """Get the MAC address for the management interface from the envvar
-           `CLAB_MGMT_MAC` or generate a random one using `gen_mac(last_octet)`.
+        `CLAB_MGMT_MAC` or generate a random one using `gen_mac(last_octet)`.
         """
-        mgmt_mac_override = os.environ.get("CLAB_MGMT_MAC", "")
-        if mgmt_mac_override:
-            return mgmt_mac_override
-        else:
-            return gen_mac(last_octet)
+        return os.environ.get("CLAB_MGMT_MAC") or gen_mac(last_octet)
 
     def gen_mgmt(self):
         """Generate qemu args for the mgmt interface(s)
@@ -546,7 +544,7 @@ class VM:
 
         for i in range(0, nics):
             # dummy interface naming
-            interface_name = f"dummy{str(i+self.num_provisioned_nics)}"
+            interface_name = f"dummy{str(i + self.num_provisioned_nics)}"
 
             # PCI bus counter is to ensure pci bus index starts from 1
             # and continuing in sequence regardles the eth index
@@ -846,24 +844,31 @@ class VR:
                 else:
                     self.update_health(1, "starting")
 
-            #file-based signalling backdoor to trigger a system reset (via qemu-monitor) on all or specific VMs.
-            #if file is empty: reset whole VR (all VMs)
-            #if file is non-empty: reset only specified VMs (comma separated list)
-            if os.path.exists('/reset'):
-                with open('/reset','rt') as f:
-                    fcontent=f.read().strip()
-                vm_num_list=fcontent.split(',')
+            # file-based signalling backdoor to trigger a system reset (via qemu-monitor) on all or specific VMs.
+            # if file is empty: reset whole VR (all VMs)
+            # if file is non-empty: reset only specified VMs (comma separated list)
+            if os.path.exists("/reset"):
+                with open("/reset", "rt") as f:
+                    fcontent = f.read().strip()
+                vm_num_list = fcontent.split(",")
                 for vm in self.vms:
                     if (str(vm.num) in vm_num_list) or not fcontent:
                         try:
                             vm.qm.write("system_reset\r".encode())
-                            self.logger.debug(f"Sent qemu-monitor system_reset to VM num {vm.num} ")
+                            self.logger.debug(
+                                f"Sent qemu-monitor system_reset to VM num {vm.num} "
+                            )
                         except Exception as e:
-                            self.logger.debug(f"Failed to send qemu-monitor system_reset to VM num {vm.num} ({e})")
+                            self.logger.debug(
+                                f"Failed to send qemu-monitor system_reset to VM num {vm.num} ({e})"
+                            )
                 try:
-                    os.remove('/reset')
+                    os.remove("/reset")
                 except Exception as e:
-                    self.logger.debug(f"Failed to cleanup /reset file({e}). qemu-monitor system_reset will likely be triggered again on VMs")
+                    self.logger.debug(
+                        f"Failed to cleanup /reset file({e}). qemu-monitor system_reset will likely be triggered again on VMs"
+                    )
+
 
 class QemuBroken(Exception):
     """Our Qemu instance is somehow broken"""

--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -213,6 +213,10 @@ class CSR_vm(vrnetlab.VM):
         self.wait_write("end")
         self.wait_write("copy running-config startup-config")
 
+    # Override management MAC with specific static MAC address
+    def get_mgmt_mac(self):
+        return "c0:00:01:00:ca:fe"
+
 
 class CSR(vrnetlab.VR):
     def __init__(self, hostname, username, password, nics, conn_mode):

--- a/dell_sonic/docker/launch.py
+++ b/dell_sonic/docker/launch.py
@@ -103,14 +103,17 @@ class Dell_Sonic_VM(vrnetlab.VM):
         """Do the actual bootstrap config"""
         self.logger.info("applying bootstrap configuration")
         self.wait_write("sudo -i", "$")
-        # set ipv4/6 address to the management interface
-        self.wait_write(
-            f"sudo /usr/sbin/ip address add {self.mgmt_address_ipv4} dev eth0", "#"
-        )
-        # note, v6 address is not being applied for whatever reason
-        self.wait_write(
-            f"sudo /usr/sbin/ip -6 address add {self.mgmt_address_ipv6} dev eth0", "#"
-        )
+
+        # set ipv4/6 address of the management interface if it is not managed by dhcp
+        if not self.mgmt_address_ipv4 == "dhcp":
+            self.wait_write(
+                f"sudo /usr/sbin/ip address add {self.mgmt_address_ipv4} dev eth0", "#"
+            )
+        if not self.mgmt_address_ipv4 == "dhcp":
+            # note, v6 address is not being applied for whatever reason
+            self.wait_write(
+                f"sudo /usr/sbin/ip -6 address add {self.mgmt_address_ipv6} dev eth0", "#"
+            )
         self.wait_write("passwd -q %s" % (self.username))
         self.wait_write(self.password, "New password:")
         self.wait_write(self.password, "password:")

--- a/routeros/docker/launch.py
+++ b/routeros/docker/launch.py
@@ -84,7 +84,7 @@ class ROS_vm(vrnetlab.VM):
         res.append("-device")
 
         res.append(
-            self.nic_type + ",netdev=br-mgmt,mac=%(mac)s" % {"mac": vrnetlab.gen_mac(0)}
+            self.nic_type + ",netdev=br-mgmt,mac=%(mac)s" % {"mac": self.get_mgmt_mac()}
         )
         res.append("-netdev")
         res.append("bridge,br=br-mgmt,id=br-mgmt" % {"i": 0})

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -1329,8 +1329,7 @@ class SROS_integrated(SROS_vm):
 
         res = []
 
-        mac = vrnetlab.gen_mac(0)
-        self.mgmt_mac = mac
+        self.mgmt_mac = self.get_mgmt_mac()
 
         if self.mgmt_passthrough:
             res.append("-device")
@@ -1435,8 +1434,7 @@ class SROS_cp(SROS_vm):
         """
         res = []
 
-        mac = vrnetlab.gen_mac(0)
-        self.mgmt_mac = mac
+        self.mgmt_mac = self.get_mgmt_mac()
 
         if self.mgmt_passthrough:
             res.append("-device")


### PR DESCRIPTION
This small series of commits is adding DHCP and static MAC support for the management interface.
Primary focus was to be able to test the Zero Touch Provisioning feature available on SONiC which relies on DHCP in its first stage.

Basic Containerlab Example:
```
name: sonic-ztp
prefix: ""

mgmt:
  network: mgmt
  ipv4-subnet: 172.80.80.0/24

topology:
  defaults:
    kind: dell_sonic
    env:
      CLAB_MGMT_DHCP: "true"
      CLAB_MGMT_PASSTHROUGH: "true"

  kinds:
    dell_sonic:
      image: vrnetlab/dell_sonic:4.4.0

  nodes:
    sonic01:
      env:
        CLAB_MGMT_MAC: "0c:00:01:01:01:01"
    sonic02:
      env:
        CLAB_MGMT_MAC: "0c:00:01:01:01:02"
    ztpserver:
      kind: linux
      image: alpine-s6-ztpserver:latest
      mgmt-ipv4: 172.80.80.10
      binds:
        - config/ztpserver/dnsmasq.conf:/etc/dnsmasq.conf
```
This topology defines a custom management network and enables the management passthrough and dhcp feature for the default nodes, which are `dell_sonic` nodes. The SONiC nodes `sonic01` and `sonic02` have a dedicated MAC address assigned.
The `ztpserver` node is a simple docker container which provides DHCP (dnsmasq) and HTTP(S) (nginx) services.
This simple example lab will be published separately but the topology file should give a good clue how to use the added features.

Credits: Many thanks to @vista- for his very valuable suggestions and help polishing the implementation!