### PR TITLE
Add support for vJunosEvolved 24.2 and up

### DIFF
--- a/vjunosevolved/README.md
+++ b/vjunosevolved/README.md
@@ -4,6 +4,8 @@ This is the vrnetlab docker image for Juniper's vJunosEvolved.
 
 > Available with [containerlab](https://containerlab.dev) as juniper_vjunosevolved.
 
+There are two variants of vJunosEvolved: the default variant, modelling a Juniper BT chipset, and starting with JunosEvo 24.2, a BX variant, modelling a chassis with two Juniper BX chipsets in it.
+
 ## Building the docker image
 
 Download the vJunosEvolved .qcow2 image from  <https://www.juniper.net/us/en/dm/vjunos-labs.html>

--- a/vjunosevolved/docker/Dockerfile
+++ b/vjunosevolved/docker/Dockerfile
@@ -1,23 +1,5 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
 LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
- && apt-get install --no-install-recommends -y \
-    dosfstools \
-    bridge-utils \
-    iproute2 \
-    python3 \
-    python3-passlib \
-    socat \
-    ssh \
-    qemu-kvm \
-    qemu-utils \
-    inetutils-ping \
-    dnsutils \
-    telnet \
- && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /
@@ -30,5 +12,3 @@ COPY make-config.sh /
 COPY *.py /
 
 EXPOSE 22 161/udp 830 5000 10000-10099 57400
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/vjunosevolved/docker/launch.py
+++ b/vjunosevolved/docker/launch.py
@@ -121,12 +121,11 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         try:
             parsed_junos_version = float(junos_version)
         except ValueError as e:
-             self.logger.error(f"Could not parse Junos version from filename {disk_image}! Expecting '12.3R4' style versioning to be present.")
+             self.logger.error(f"Could not parse Junos version from filename {disk_image}! Expecting '12.3R4' style versioning to be present: {e}")
 
-        if parsed_junos_version is not None:
-            if parsed_junos_version >= 24.2:
-                # vJunosEvolved 24.2R1 and up require UEFI
-                self.qemu_args.extend(["-bios", "/usr/share/qemu/OVMF.fd"])           
+        if parsed_junos_version is not None and parsed_junos_version >= 24.2:
+            # vJunosEvolved 24.2R1 and up require UEFI
+            self.qemu_args.extend(["-bios", "/usr/share/qemu/OVMF.fd"])           
         
         self.conn_mode = conn_mode
 

--- a/vjunosevolved/docker/launch.py
+++ b/vjunosevolved/docker/launch.py
@@ -108,8 +108,26 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         self.smbios = [
             "type=0,vendor=Bochs,version=Bochs",
             "type=3,manufacturer=Bochs",
-            "type=1,manufacturer=Bochs,product=Bochs,serial=chassis_no=0:slot=0:type=1:assembly_id=0x0D20:platform=251:master=0:channelized=no",
         ]
+
+        # BT chipset
+        evo_model_smbios = "type=1,manufacturer=Bochs,product=Bochs,serial=chassis_no=0:slot=0:type=1:assembly_id=0x0D20:platform=251:master=0:channelized=no"
+        if "BX" in disk_image:
+            # BX chipset
+            evo_model_smbios = "type=1,manufacturer=Bochs,product=Bochs,serial=chassis_no=0:slot=0:type=1:assembly_id=0x0DA9:platform=272:master=0:channelized=no"
+        self.smbios.append(evo_model_smbios)
+
+        junos_version = str(re.search(r"(\d{2}\.\d{1})R\d{1}", disk_image).group(1))
+        try:
+            parsed_junos_version = float(junos_version)
+        except ValueError as e:
+             self.logger.error(f"Could not parse Junos version from filename {disk_image}! Expecting '12.3R4' style versioning to be present.")
+
+        if parsed_junos_version is not None:
+            if parsed_junos_version >= 24.2:
+                # vJunosEvolved 24.2R1 and up require UEFI
+                self.qemu_args.extend(["-bios", "/usr/share/qemu/OVMF.fd"])           
+        
         self.conn_mode = conn_mode
 
     def startup_config(self):
@@ -150,7 +168,7 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
 
                 # Login
                 self.wait_write("\r", None)
-                self.wait_write("admin", wait="login:")
+                self.wait_write("admin", wait=f"{self.hostname} login:")
                 self.wait_write(self.password, wait="Password:")
                 self.wait_write("\r", None)
                 self.logger.info("Login completed")
@@ -167,7 +185,7 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time
         if res != b"":
-            self.logger.trace("OUTPUT: %s" % res.decode())
+            self.logger.trace("OUTPUT: %s" % res.decode('utf-8', errors="ignore"))
             # reset spins if we saw some output
             self.spins = 0
 

--- a/vrnetlab-base.dockerfile
+++ b/vrnetlab-base.dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update -qy \
    git \
    dosfstools \
    genisoimage \
+   ovmf \
    && rm -rf /var/lib/apt/lists/*
 
 # copying the uv project


### PR DESCRIPTION
Juniper recently released vJunosEvolved 24.2, which now requires UEFI boot, and now comes in two variants, BT and BX chipset support.

The Dockerfile of vjunosevolved has been revamped to use the vrnetlab base image.

The `ovmf` package for UEFI BIOS has been added to the vrnetlab base image (this PR requires a new version to be published). I used a future 0.2.1 version in the vJunosEvolved Dockerfile. 