### PR TITLE
Implement Spirent vSTC

### DIFF
--- a/vstc/Makefile
+++ b/vstc/Makefile
@@ -3,16 +3,7 @@ NAME=vstc
 IMAGE_FORMAT=qcow2
 IMAGE_GLOB=*.qcow2
 
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[sb]\?\?\)\([^0-9].*\|$$\)/\1/')
+VERSION=$(shell echo $(IMAGE) | sed -e 's/spirent_vstc-\(.*\)\.qcow2/\1/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include
-
-docker-pre-build:
-	-cat cidfile | xargs --no-run-if-empty docker rm -f
-	-rm cidfile
-
-docker-build: docker-build-common
-	docker run --cidfile cidfile --privileged $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION) --trace --install
-	docker commit --change='ENTRYPOINT ["/launch.py"]' $$(cat cidfile) $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION)
-	docker rm -f $$(cat cidfile)

--- a/vstc/Makefile
+++ b/vstc/Makefile
@@ -1,0 +1,18 @@
+VENDOR=Spirent
+NAME=vstc
+IMAGE_FORMAT=qcow2
+IMAGE_GLOB=*.qcow2
+
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[sb]\?\?\)\([^0-9].*\|$$\)/\1/')
+
+-include ../makefile-sanity.include
+-include ../makefile.include
+
+docker-pre-build:
+	-cat cidfile | xargs --no-run-if-empty docker rm -f
+	-rm cidfile
+
+docker-build: docker-build-common
+	docker run --cidfile cidfile --privileged $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION) --trace --install
+	docker commit --change='ENTRYPOINT ["/launch.py"]' $$(cat cidfile) $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION)
+	docker rm -f $$(cat cidfile)

--- a/vstc/README.md
+++ b/vstc/README.md
@@ -18,17 +18,16 @@ Interface naming follows `ethX` naming convention, with `eth0` reserved for the 
 name: vstc_lab
 topology:
   nodes:
-		# example DUT
-		r1:
-			kind: nokia_sros
-			image: vrnetlab/nokia_sros:24.10.R1
-		# STC traffic generator
-		vstc:
-			kind: generic_vm
-			image: vrnetlab/spirent_vstc:5.55.3216
+    # example DUT
+    r1:
+      kind: nokia_sros
+      image: vrnetlab/nokia_sros:24.10.R1
+    # STC traffic generator
+    vstc:
+      kind: generic_vm
+      image: vrnetlab/spirent_vstc:5.55.3216
 
-	links:
-		- endpoints: ["vstc:eth1","r1:1/1/1"]
-		- endpoints: ["vstc:eth2","r1:1/1/2"]
+  links:
+    - endpoints: ["vstc:eth1","r1:1/1/1"]
+    - endpoints: ["vstc:eth2","r1:1/1/2"]
 ```
-    

--- a/vstc/README.md
+++ b/vstc/README.md
@@ -10,7 +10,7 @@ Please wait for the 'Startup Completed' message in the `docker logs` output befo
 
 ## Example
 
-You should use the Spirent vSTC with the `linux` kind in your topology definition.
+You should use the Spirent vSTC with the `generic_vm` kind in your topology definition.
 
 Interface naming follows `ethX` naming convention, with `eth0` reserved for the clab management network.
 
@@ -18,11 +18,13 @@ Interface naming follows `ethX` naming convention, with `eth0` reserved for the 
 name: vstc_lab
 topology:
   nodes:
+		# example DUT
 		r1:
 			kind: nokia_sros
 			image: vrnetlab/nokia_sros:24.10.R1
+		# STC traffic generator
 		vstc:
-			kind: linux
+			kind: generic_vm
 			image: vrnetlab/spirent_vstc:5.55.3216
 
 	links:

--- a/vstc/README.md
+++ b/vstc/README.md
@@ -4,4 +4,29 @@ This is the vrnetlab image for the Spirent vSTC (Virtual Spirent Test Center).
 
 Default credentials are: `admin`:`spt_admin`
 
-On bootup the node will be configured with IP addressing, and then reboot to fully apply the configuration.
+On bootup the node will be boostrapped with IP addressing config, and then rebooted to fully apply the configuration.
+
+Please wait for the 'Startup Completed' message in the `docker logs` output before attempting to connect to the node via the STC Client or SSH.
+
+## Example
+
+You should use the Spirent vSTC with the `linux` kind in your topology definition.
+
+Interface naming follows `ethX` naming convention, with `eth0` reserved for the clab management network.
+
+```yaml
+name: vstc_lab
+topology:
+  nodes:
+		r1:
+			kind: nokia_sros
+			image: vrnetlab/nokia_sros:24.10.R1
+		vstc:
+			kind: linux
+			image: vrnetlab/spirent_vstc:5.55.3216
+
+	links:
+		- endpoints: ["vstc:eth1","r1:1/1/1"]
+		- endpoints: ["vstc:eth2","r1:1/1/2"]
+```
+    

--- a/vstc/README.md
+++ b/vstc/README.md
@@ -1,1 +1,7 @@
-Spirent vSTC
+# Spirent vSTC
+
+This is the vrnetlab image for the Spirent vSTC (Virtual Spirent Test Center).
+
+Default credentials are: `admin`:`spt_admin`
+
+On bootup the node will be configured with IP addressing, and then reboot to fully apply the configuration.

--- a/vstc/README.md
+++ b/vstc/README.md
@@ -1,0 +1,1 @@
+Spirent vSTC

--- a/vstc/docker/Dockerfile
+++ b/vstc/docker/Dockerfile
@@ -5,6 +5,3 @@ ENV VERSION=${VERSION}
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
-
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/vstc/docker/Dockerfile
+++ b/vstc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
 
 ARG VERSION
 ENV VERSION=${VERSION}
@@ -6,6 +6,5 @@ ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
-EXPOSE 22 161/udp 830 5000 10000-10099
 HEALTHCHECK CMD ["/healthcheck.py"]
 ENTRYPOINT ["/launch.py"]

--- a/vstc/docker/Dockerfile
+++ b/vstc/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+
+ARG VERSION
+ENV VERSION=${VERSION}
+ARG IMAGE
+COPY $IMAGE* /
+COPY *.py /
+
+EXPOSE 22 161/udp 830 5000 10000-10099
+HEALTHCHECK CMD ["/healthcheck.py"]
+ENTRYPOINT ["/launch.py"]

--- a/vstc/docker/launch.py
+++ b/vstc/docker/launch.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+import datetime
+import logging
+import os
+import re
+import signal
+import subprocess
+import sys
+from time import sleep
+
+import vrnetlab
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+
+
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+
+
+logging.Logger.trace = trace
+
+
+class STC_vm(vrnetlab.VM):
+    def __init__(self, hostname, username, password, nics, conn_mode, install_mode=False):
+        for e in os.listdir("/"):
+            if re.search(".qcow2$", e):
+                disk_image = "/" + e
+
+        self._static_mgmt_mac = True
+
+        super(STC_vm, self).__init__(
+            username, password, disk_image=disk_image, use_scrapli=True
+        )
+
+        self.num_nics = nics
+        self.hostname = hostname
+        self.conn_mode = conn_mode
+        self.nic_type = "virtio-net-pci"
+
+    def bootstrap_spin(self):
+        """This function should be called periodically to do work."""
+
+        if self.spins > 600:
+            # too many spins with no result ->  give up
+            self.stop()
+            self.start()
+            return
+
+        self.write_to_stdout(self.scrapli_tn.channel.read())
+        # (ridx, match, res) = self.con_expect(
+        #     [b"CVAC-4-CONFIG_DONE", b"Press RETURN to get started!"]
+        # )
+        # if match:  # got a match!
+        #     if ridx == 0 and not self.install_mode:  # configuration applied
+        #         self.logger.info("CVAC Configuration has been applied.")
+        #         # close telnet connection
+        #         self.scrapli_tn.close()
+        #         # startup time?
+        #         startup_time = datetime.datetime.now() - self.start_time
+        #         self.logger.info("Startup complete in: %s", startup_time)
+        #         # mark as running
+        #         self.running = True
+        #         return
+        #     elif ridx == 1:  # IOSXEBOOT-4-FACTORY_RESET
+        #         if self.install_mode:
+        #             install_time = datetime.datetime.now() - self.start_time
+        #             self.logger.info("Install complete in: %s", install_time)
+        #             self.running = True
+        #             return
+
+        # # no match, if we saw some output from the router it's probably
+        # # booting, so let's give it some more time
+        # if res != b"":
+        #     self.write_to_stdout(res)
+        #     # reset spins if we saw some output
+        #     self.spins = 0
+
+        # self.spins += 1
+
+        return
+
+class STC(vrnetlab.VR):
+    def __init__(self, hostname, username, password, nics, conn_mode):
+        super(STC, self).__init__(username, password)
+        self.vms = [STC_vm(hostname, username, password, nics, conn_mode)]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument(
+        "--trace", action="store_true", help="enable trace level logging"
+    )
+    parser.add_argument("--username", default="admin", help="Username")
+    parser.add_argument("--password", default="spt_admin", help="Password")
+    parser.add_argument("--hostname", default="stc", help="Hostname")
+    parser.add_argument("--nics", type=int, default=31, help="Number of NICS")
+    parser.add_argument(
+        "--connection-mode",
+        default="vrxcon",
+        help="Connection mode to use in the datapath",
+    )
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    vr = STC(
+        args.hostname,
+        args.username,
+        args.password,
+        args.nics,
+        args.connection_mode,
+    )
+    vr.start()

--- a/vstc/docker/launch.py
+++ b/vstc/docker/launch.py
@@ -41,7 +41,7 @@ class STC_vm(vrnetlab.VM):
                 disk_image = "/" + e
 
         super(STC_vm, self).__init__(
-            username, password, disk_image=disk_image, use_scrapli=True, min_dp_nics=1
+            username, password, disk_image=disk_image, use_scrapli=True, min_dp_nics=1, mgmt_passthrough=True
         )
 
         self.hostname = hostname

--- a/vstc/docker/launch.py
+++ b/vstc/docker/launch.py
@@ -119,6 +119,7 @@ if __name__ == "__main__":
     parser.add_argument("--username", default="admin", help="Username")
     parser.add_argument("--password", default="spt_admin", help="Password")
     parser.add_argument("--hostname", default="stc", help="Hostname")
+    parser.add_argument("--connection-mode", default="tc", help="Ignored, does nothing")
     
     args = parser.parse_args()
 


### PR DESCRIPTION
vSTC is weird in that you have to reboot to apply config. Since there is no DHCP server to apply the passthrough address from clab, we enter the IP addressing manually. Then reboot the node.

This node has transparent mgmt passthrough force enabled, will not connect correctly with the QEMU NAT.

Unfortunately this means the node boot time is doubled, but this quick and dirty method does the trick.