### PR TITLE
Add `DEBUG_SCRAPLI` env var

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -119,7 +119,11 @@ class VM:
         will write all channel i/o as DEBUG log level.
         """
         self.scrapli_logger = logging.getLogger("scrapli")
-        self.scrapli_logger.setLevel(logging.INFO)
+        
+        scrapli_log_level = logging.DEBUG if os.getenv("DEBUG_SCRAPLI", "false").lower() == "true" else logging.INFO
+        self.scrapli_logger.setLevel(scrapli_log_level)
+        
+        
 
         # configure scrapli
         if self.use_scrapli:

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -13,7 +13,7 @@ from typing import Dict
 import vrnetlab
 from scrapli import Scrapli
 
-DEBUG_SCRAPLI = True if os.getenv("DEBUG_SCRAPLI", "false").lower() == "true" else False
+LOG_SCRAPLI = True if os.getenv("LOG_SCRAPLI", "false").lower() == "true" else False
 
 
 def handle_SIGCHLD(signal, frame):
@@ -1237,7 +1237,7 @@ class SROS_vm(vrnetlab.VM):
         return cmds
 
     def log_scrapli_cmd_res(self, res: list):
-        if not DEBUG_SCRAPLI:
+        if not LOG_SCRAPLI:
             return
         for response in res:
             self.logger.debug(f"CHANNEL INPUT: {response.channel_input}")


### PR DESCRIPTION
- Changed the env var naming for the SROS `DEBUG_SCRAPLI` to `LOG_SCRAPLI`. It fits the purpose of the env var closer.

- Added a global `DEBUG_SCRAPLI` env var (in vrnetlab.py). If it's set to `"true` then Scrapli logging will be on `logging.DEBUG` which is much more verbose (shows all channel I/O).

