### PR TITLE
PAN-OS: Handle version number suffix

### DIFF
--- a/pan/Makefile
+++ b/pan/Makefile
@@ -6,7 +6,7 @@ IMAGE_GLOB=*.qcow2
 # match versions like:
 # PA-VNM-KVM-7.0.1.qcow2
 # PA-VM-KVM-10.0.6.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/PA-\(VNM\|VM\)-KVM-\(.*\).qcow2/\2/')
+VERSION=$(shell echo $(IMAGE) | sed -re 's/PA-(VM|VNM)-KVM-(.*)\.qcow2/\2/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include

--- a/pan/Makefile
+++ b/pan/Makefile
@@ -6,7 +6,7 @@ IMAGE_GLOB=*.qcow2
 # match versions like:
 # PA-VNM-KVM-7.0.1.qcow2
 # PA-VM-KVM-10.0.6.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.*-\([0-9]\{1,2\}\.[0-9]\{1,2\}.[0-9]\{1,2\}\)\.qcow2$$/\1/')
+VERSION=$(shell echo $(IMAGE) | sed -e 's/PA-\(VNM\|VM\)-KVM-\(.*\).qcow2/\2/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include


### PR DESCRIPTION
Fixes #332. Simplified the regex so it works with both no suffix and suffix version numbers.
```
Building docker image using PA-VM-KVM-10.2.10-h12.qcow2 as vrnetlab/paloalto_pa-vm:10.2.10-h12
...
Building docker image using PA-VM-KVM-10.2.10.qcow2 as vrnetlab/paloalto_pa-vm:10.1.11
```