### PR TITLE
vJunos and vSRX improvements: interface count, base Docker image

### DIFF
--- a/vjunosrouter/docker/Dockerfile
+++ b/vjunosrouter/docker/Dockerfile
@@ -1,22 +1,5 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
 LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
- && apt-get install --no-install-recommends -y \
-    dosfstools \
-    bridge-utils \
-    iproute2 \
-    python3 \
-    socat \
-    ssh \
-    qemu-kvm \
-    qemu-utils \
-    inetutils-ping \
-    dnsutils \
-    telnet \
- && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /
@@ -29,5 +12,3 @@ COPY make-config.sh /
 COPY *.py /
 
 EXPOSE 22 161/udp 830 5000 10000-10099 57400
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/vjunosrouter/docker/init.conf
+++ b/vjunosrouter/docker/init.conf
@@ -21,6 +21,13 @@ system {
     }
     management-instance;
 }
+chassis {
+    fpc 0 {
+        pic 0 {
+            number-of-ports 12;
+        }
+    }
+}
 interfaces {
     fxp0 {
         unit 0 {

--- a/vjunosrouter/docker/launch.py
+++ b/vjunosrouter/docker/launch.py
@@ -95,7 +95,8 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
 
         self.qemu_args.extend(["-no-user-config", "-nodefaults", "-boot", "strict=on"])
         self.nic_type = "virtio-net-pci"
-        self.num_nics = 11
+        # 1 management port + 12 front ports to match vJunosEvolved
+        self.num_nics = 13
         self.smbios = ["type=1,product=VM-VMX,family=lab"]
         self.conn_mode = conn_mode
 

--- a/vjunosswitch/docker/Dockerfile
+++ b/vjunosswitch/docker/Dockerfile
@@ -1,22 +1,5 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
 LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
- && apt-get install --no-install-recommends -y \
-    dosfstools \
-    bridge-utils \
-    iproute2 \
-    python3 \
-    socat \
-    ssh \
-    qemu-kvm \
-    qemu-utils \
-    inetutils-ping \
-    dnsutils \
-    telnet \
- && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /
@@ -29,5 +12,3 @@ COPY make-config.sh /
 COPY *.py /
 
 EXPOSE 22 161/udp 830 5000 10000-10099 57400
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/vjunosswitch/docker/init.conf
+++ b/vjunosswitch/docker/init.conf
@@ -21,6 +21,13 @@ system {
     }
     management-instance;
 }
+chassis {
+    fpc 0 {
+        pic 0 {
+            number-of-ports 56;
+        }
+    }
+}
 interfaces {
     fxp0 {
         unit 0 {

--- a/vjunosswitch/docker/launch.py
+++ b/vjunosswitch/docker/launch.py
@@ -95,7 +95,8 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
 
         self.qemu_args.extend(["-no-user-config", "-nodefaults", "-boot", "strict=on"])
         self.nic_type = "virtio-net-pci"
-        self.num_nics = 11
+        # 1 management port + 48 front ports + 8 uplink ports to match most dense 1U Juniper switch
+        self.num_nics = 57
         self.smbios = ["type=1,product=VM-VEX"]
         self.conn_mode = conn_mode
 

--- a/vsrx/docker/Dockerfile
+++ b/vsrx/docker/Dockerfile
@@ -1,18 +1,5 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
 LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
-   && apt-get install --no-install-recommends -y \
-   bridge-utils \
-   iproute2 \
-   python3 \
-   socat \
-   qemu-kvm \
-   qemu-utils \
-   genisoimage \
-   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /
@@ -22,5 +9,3 @@ COPY make-config-iso.sh /
 COPY *.py /
 
 EXPOSE 22 161/udp 830 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]


### PR DESCRIPTION
This PR changes vSRX, vJunos images to use the `srl-labs/vrnetlab-base` base Docker image when building. This should optimize the image size and speed up image builds.

Additionally, the interface counts of the vJunos images are bumped up:
- vJunos-Router to 12 revenue ports, to match vJunosEvolved
- vJunos-Switch to 56 revenue ports, matching the most dense 1U Juniper switch (48+8 ports)