### PR TITLE
bring back python3 shebang to unbreak healthcheck.py

### DIFF
--- a/common/healthcheck.py
+++ b/common/healthcheck.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 
 try:


### PR DESCRIPTION
The healthcheck.py wasn't executable anymore. Fix that.