### PR TITLE
Reduce container size

### DIFF
--- a/cmglinux/docker/Dockerfile
+++ b/cmglinux/docker/Dockerfile
@@ -1,10 +1,22 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM debian:bookworm-slim AS builder
+
+ARG DISK_SIZE=4G
+
+RUN apt-get update -qy && \
+   apt-get install -y --no-install-recommends qemu-utils && \
+   rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY $IMAGE* /
+RUN qemu-img resize /$IMAGE $DISK_SIZE
+
+FROM debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DISK_SIZE=4G
 
 RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends \
+   && apt-get install -y --no-install-recommends\
    bridge-utils \
    iproute2 \
    socat \
@@ -16,16 +28,13 @@ RUN apt-get update -qy \
    iptables \
    nftables \
    telnet \
-   genisoimage \
-   python3-yaml \
+   cloud-utils \
    sshpass \
    && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
-COPY $IMAGE* /
+COPY --from=builder $IMAGE* /
 COPY *.py /
-
-# RUN qemu-img resize /${IMAGE} ${DISK_SIZE}
 
 EXPOSE 22 5000 10000-10099
 HEALTHCHECK CMD ["/healthcheck.py"]

--- a/cmglinux/docker/Dockerfile
+++ b/cmglinux/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS builder
+FROM public.ecr.aws/docker/library/debian:bookworm-slim AS builder
 
 ARG DISK_SIZE=4G
 
@@ -10,7 +10,7 @@ ARG IMAGE
 COPY $IMAGE* /
 RUN qemu-img resize /$IMAGE $DISK_SIZE
 
-FROM debian:bookworm-slim
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DISK_SIZE=4G

--- a/freebsd/docker/Dockerfile
+++ b/freebsd/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS builder
+FROM public.ecr.aws/docker/library/debian:bookworm-slim AS builder
 
 ARG DISK_SIZE=4G
 
@@ -10,7 +10,7 @@ ARG IMAGE
 COPY $IMAGE* /
 RUN qemu-img resize /$IMAGE $DISK_SIZE
 
-FROM debian:bookworm-slim
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DISK_SIZE=4G
@@ -35,6 +35,7 @@ RUN apt-get update -qy \
 ARG IMAGE
 COPY --from=builder $IMAGE* /
 COPY *.py /
+COPY --chmod=0755 backup.sh /
 
 EXPOSE 22 5000 10000-10099
 HEALTHCHECK CMD ["/healthcheck.py"]

--- a/freebsd/docker/Dockerfile
+++ b/freebsd/docker/Dockerfile
@@ -1,14 +1,24 @@
+FROM debian:bookworm-slim AS builder
+
+ARG DISK_SIZE=4G
+
+RUN apt-get update -qy && \
+   apt-get install -y --no-install-recommends qemu-utils && \
+   rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY $IMAGE* /
+RUN qemu-img resize /$IMAGE $DISK_SIZE
+
 FROM debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DISK_SIZE=4G
 
 RUN apt-get update -qy \
-   && apt-get upgrade -qy \
-   && apt-get install -y \
+   && apt-get install -y --no-install-recommends\
    bridge-utils \
    iproute2 \
-   python3-ipy \
    socat \
    qemu-kvm \
    tcpdump \
@@ -23,11 +33,8 @@ RUN apt-get update -qy \
    && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
-COPY $IMAGE* /
+COPY --from=builder $IMAGE* /
 COPY *.py /
-COPY --chmod=0755 backup.sh /
-
-RUN qemu-img resize /${IMAGE} ${DISK_SIZE}
 
 EXPOSE 22 5000 10000-10099
 HEALTHCHECK CMD ["/healthcheck.py"]

--- a/openbsd/docker/Dockerfile
+++ b/openbsd/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS builder
+FROM public.ecr.aws/docker/library/debian:bookworm-slim AS builder
 
 ARG DISK_SIZE=4G
 ARG IMAGE
@@ -10,7 +10,7 @@ RUN apt-get update -qy && \
 COPY $IMAGE* /
 RUN qemu-img resize /${IMAGE} ${DISK_SIZE}
 
-FROM debian:bookworm-slim
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
 
 RUN apt-get update -qy \
    && apt-get install -y --no-install-recommends\

--- a/openbsd/docker/Dockerfile
+++ b/openbsd/docker/Dockerfile
@@ -1,11 +1,19 @@
+FROM debian:bookworm-slim AS builder
+
+ARG DISK_SIZE=4G
+ARG IMAGE
+
+RUN apt-get update -qy && \
+   apt-get install -y --no-install-recommends qemu-utils && \
+   rm -rf /var/lib/apt/lists/*
+
+COPY $IMAGE* /
+RUN qemu-img resize /${IMAGE} ${DISK_SIZE}
+
 FROM debian:bookworm-slim
 
-ARG DEBIAN_FRONTEND=noninteractive
-ARG DISK_SIZE=4G
-
 RUN apt-get update -qy \
-   && apt-get upgrade -qy \
-   && apt-get install -y \
+   && apt-get install -y --no-install-recommends\
    bridge-utils \
    iproute2 \
    python3-ipy \
@@ -23,11 +31,9 @@ RUN apt-get update -qy \
    && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
-COPY $IMAGE* /
+COPY --from=builder $IMAGE* /
 COPY *.py /
 COPY --chmod=0755 backup.sh /
-
-RUN qemu-img resize /${IMAGE} ${DISK_SIZE}
 
 EXPOSE 22 5000 10000-10099
 HEALTHCHECK CMD ["/healthcheck.py"]

--- a/ubuntu/docker/Dockerfile
+++ b/ubuntu/docker/Dockerfile
@@ -1,10 +1,22 @@
+FROM debian:bookworm-slim AS builder
+
+ARG DISK_SIZE=4G
+
+RUN apt-get update -qy && \
+   apt-get install -y --no-install-recommends qemu-utils && \
+   rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY $IMAGE* /
+RUN qemu-img resize /$IMAGE $DISK_SIZE
+
 FROM debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DISK_SIZE=4G
 
 RUN apt-get update -qy \
-   && apt-get install -y \
+   && apt-get install -y --no-install-recommends\
    bridge-utils \
    iproute2 \
    socat \
@@ -21,10 +33,8 @@ RUN apt-get update -qy \
    && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
-COPY $IMAGE* /
+COPY --from=builder $IMAGE* /
 COPY *.py /
-
-RUN qemu-img resize /${IMAGE} ${DISK_SIZE}
 
 EXPOSE 22 5000 10000-10099
 HEALTHCHECK CMD ["/healthcheck.py"]

--- a/ubuntu/docker/Dockerfile
+++ b/ubuntu/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS builder
+FROM public.ecr.aws/docker/library/debian:bookworm-slim AS builder
 
 ARG DISK_SIZE=4G
 
@@ -10,7 +10,7 @@ ARG IMAGE
 COPY $IMAGE* /
 RUN qemu-img resize /$IMAGE $DISK_SIZE
 
-FROM debian:bookworm-slim
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DISK_SIZE=4G


### PR DESCRIPTION
The Dockerfile for these images would copy in the image file then run `qemu-img resize IMAGE DISK_SIZE`, because of the way container layers work that means you end up with two copies of the image in the container, one of which is unusable. This effectively doubles the container size.

Also I added `--no-install-recommends` as without it hundreds of unneeded packages such as fonts are installed.

This takes the Ubuntu image from 2.24GB to 950MB