### PR TITLE
feat(huawei): add 'undo dcn' to bootstrap to clear residual  configs

### DIFF
--- a/huawei_vrp/docker/launch.py
+++ b/huawei_vrp/docker/launch.py
@@ -173,6 +173,9 @@ class VRP_vm(vrnetlab.VM):
         self.wait_write(cmd="protocol inbound ssh port 830", wait="]")
         self.wait_write(cmd="quit", wait="]")
 
+        # Reset or undo DCN configuration
+        self.wait_write(cmd="undo dcn", wait="]")
+
         self.wait_write(cmd="commit", wait="]")
         self.wait_write(cmd="return", wait="]")
         self.wait_write(cmd="save", wait=">")


### PR DESCRIPTION
Adds the 'undo dcn' command during the Huawei bootstrap process to remove potential residual configurations (e.g., DCN auto-configuration) that may come bundled with the image. This ensures a clean initial state for provisioning and avoids interface conflicts.