### PR TITLE
OcNOS - Increase max nics to 62

### DIFF
--- a/ocnos/docker/launch.py
+++ b/ocnos/docker/launch.py
@@ -57,7 +57,7 @@ class OCNOS_vm(vrnetlab.VM):
         )
         self.hostname = hostname
         self.conn_mode = conn_mode
-        self.num_nics = 8
+        self.num_nics = 62
         self.nic_type = "virtio-net-pci"
 
     def bootstrap_spin(self):


### PR DESCRIPTION
According to https://containerlab.dev/manual/kinds/ipinfusion-ocnos/ the virtualisation should support up to 144 interfaces.

The best I was able to manage was 62 (eth0 mgmt to eth62) before it refused to boot. It appears that this limit relates to the QEMU Machine/PCI limit

To go beyond 62 (I would like to get to at least 64!) I think we need to identify alternative QMEU options to increase the number of PCI buses created - but that's a challenge for another time.

This change increases the maximum number of 62, and I have included a test artefact validating both creation and also packet flow of eth1 and eth62 between two OcNOS instances
[CONTLAB-OCNOS-MAXPORTS.txt](https://github.com/user-attachments/files/20805739/CONTLAB-OCNOS-MAXPORTS.txt)
