### PR TITLE
docs(n9kv): clarify README with correct qcow2 filename convention and image tagging

### DIFF
--- a/n9kv/README.md
+++ b/n9kv/README.md
@@ -5,11 +5,25 @@ This is the vrnetlab docker image for Cisco Nexus 9000v virtual switch.
 
 ## Building the docker image
 
-Put the .qcow2 file in this directory and run make docker-image and you should be good to go. The resulting image is 
-called vr-n9kv. You can tag it with something else if you want, like my-repo.example.com/vr-n9kv and then push it to 
-your repo. The tag is the same as the version of the NXOS image, so if you have nxosv.9.2.4.qcow2 your final docker 
-image will be called vr-n9kv:9.2.4
+1. Place your Cisco Nexus 9000v qcow2 image in this directory. **The filename must follow the format:**
+   
+   ```
+   n9kv-<version>.qcow2
+   ```
+   
+   For example: `n9kv-9300-10.5.2.qcow2`
 
+2. Run `make docker-image`.
+
+The resulting Docker image will be named:
+
+```
+vrnetlab/cisco_n9kv:<version>
+```
+
+For the example above, the image will be `vrnetlab/cisco_n9kv:9300-10.5.2`.
+
+You can retag the image as needed (e.g., `my-repo.example.com/vr-n9kv:9300-10.5.2`) and push it to your own repository.
 
 ## System requirements
 


### PR DESCRIPTION
- Updated build instructions to specify required image filename format (n9kv-<version>.qcow2)
- Corrected Docker image tag examples to match Makefile logic
- Improved clarity for users building and tagging the image