### PR TITLE
change self.num_nics from 13 to max of 96

### DIFF
--- a/vjunosrouter/docker/launch.py
+++ b/vjunosrouter/docker/launch.py
@@ -96,7 +96,7 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
         self.qemu_args.extend(["-no-user-config", "-nodefaults", "-boot", "strict=on"])
         self.nic_type = "virtio-net-pci"
         # 1 management port + 12 front ports to match vJunosEvolved
-        self.num_nics = 13
+        self.num_nics = 96
         self.smbios = ["type=1,product=VM-VMX,family=lab"]
         self.conn_mode = conn_mode
 


### PR DESCRIPTION
For the vjunos-juniperrouters I need to be able to configure more than just 13 interfaces. The max the vjunos-juniperrouters can support is 96. So I increased to 96 locally, rebuilt my docker image and now I can turn up more interfaces. I am doing this pull request to help others out from running into the same issue. Also this is the other config you need on the virutal device to support up to 96 interfaces:

chassis {
fpc 0 {
    pic 0 {
        number-of-ports 96;