### PR TITLE
Handle interactive config commands on n9kv

### DIFF
--- a/n9kv/docker/launch.py
+++ b/n9kv/docker/launch.py
@@ -189,7 +189,9 @@ feature grpc
         else:
             self.logger.warning("User provided startup configuration is not found.")
 
+        con.send_config("terminal dont-ask")
         res = con.send_configs(n9kv_config.splitlines())
+        con.send_config("no terminal dont-ask")
         con.send_config("copy running-config startup-config")
 
         for response in res:

--- a/n9kv/docker/launch.py
+++ b/n9kv/docker/launch.py
@@ -189,6 +189,8 @@ feature grpc
         else:
             self.logger.warning("User provided startup configuration is not found.")
 
+        # set `terminal dont-ask` to avoid confirmation prompts
+        # during startup config deployment
         con.send_config("terminal dont-ask")
         res = con.send_configs(n9kv_config.splitlines())
         con.send_config("no terminal dont-ask")


### PR DESCRIPTION
If a command that requires user input, such as `copp profile strict`, is present in the startup config file of a n9kv instance, config deployment will freeze once it pushes that command.

Setting `terminal dont-ask` before pushing the config skips the prompts:

```
n9kv-test# terminal ?
  dont-ask          Don't prompt for confirmation, do what the command indicates
```

Tested with n9kv 10.3.1 and 10.3.8.  The command appears to be available in all NXOS versions: [here's version 6 from 2014](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/6-x/command_reference/config_612I22/b_n9k_command_ref/b_n9k_command_ref_chapter_010110.html#wp3962612674)

Fixes https://github.com/hellt/vrnetlab/issues/373