### PR TITLE
Added SD-WAN/Controller mode for C8000v

### DIFF
--- a/cisco/c8000v/Makefile
+++ b/cisco/c8000v/Makefile
@@ -3,15 +3,32 @@ NAME=c8000v
 IMAGE_FORMAT=qcow2
 IMAGE_GLOB=*.qcow2
 
-# match versions like:
-# c8000v-17.11.01a.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[a-z]\?\)\([^0-9].*\|$$\)/\1/')
+# Extract version from filename (e.g. c8000v-17.11.01a.qcow2)
+# If not in filename, extract from qcow2 metadata
+VERSION=$(shell V=$$(echo $(IMAGE) | sed -n 's/.*[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[a-z]\?\).*/\1/p'); \
+	[ -n "$$V" ] && echo "$$V" || strings $(IMAGE) | awk -F= '/RELVER/{print $$2; exit}')
 
 -include ../../makefile-sanity.include
 -include ../../makefile.include
 -include ../../makefile-install.include
 
+# Pass MODE to docker build
+docker-build: MODE?=autonomous
 docker-build: docker-build-common
-	docker run --cidfile cidfile --privileged $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION) --trace --install
-	docker commit --change='ENTRYPOINT ["/launch.py"]' $$(cat cidfile) $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION)
-	docker rm -f $$(cat cidfile)
+	(cd docker; docker build --build-arg MODE=$(MODE) -t $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION) .)
+	$(MAKE) docker-clean-build
+
+# Override default to build both autonomous and controller mode variants
+docker-image:
+	for IMAGE in $(IMAGES); do \
+		echo "Building autonomous mode variant for $$IMAGE"; \
+		$(MAKE) IMAGE=$$IMAGE MODE=autonomous docker-build; \
+		$(MAKE) IMAGE=$$IMAGE docker-clean-build; \
+		echo "Building controller mode variant for $$IMAGE"; \
+		VER=$$($(MAKE) -s IMAGE=$$IMAGE print-version); \
+		$(MAKE) IMAGE=$$IMAGE VERSION=controller-$$VER MODE=controller docker-build; \
+		$(MAKE) IMAGE=$$IMAGE docker-clean-build; \
+	done
+
+print-version:
+	@echo $(VERSION)

--- a/cisco/c8000v/README.md
+++ b/cisco/c8000v/README.md
@@ -3,18 +3,13 @@
 This is the vrnetlab docker image for Cisco Catalyst 8000V Edge Software, or
 'c8000v' for short.
 
-The Catalyst 8000v platform is a successor to the CSR 1000v. As such, this
-platform directory 'c8000v' started off as a copy of the 'csr' directory. With
-time we imagine the two platforms will diverge. One such change is already
-planned to support using the Catalyst 8000v in one of the two modes:
+The Catalyst 8000v platform is a successor to the CSR 1000v and supports two
+operating modes:
 
-- regular,
-- SD-WAN Controller mode (managed by Viptela).
+- **Autonomous mode** - Standard IOS-XE routing platform
+- **Controller mode** - SD-WAN managed mode (Viptela)
 
-Right now the SD-WAN flavor is still split off because to enable the Controller
-mode you have to effectively boot the router into a completely different mode.
-In the near future these modifications will be merged back into the 'c8000v'
-platform that will produce both the regular and sd-wan images.
+The build process automatically produces both variants from a single qcow2 image.
 
 On installation of Catalyst 8000v the user is presented with the choice of
 output, which can be over serial console, a video console or through automatic
@@ -33,20 +28,30 @@ which essentially just assembles the required files, then run it with
 we shut down the VM and commit this new state into the final docker image. This
 is unorthodox but works and saves us a lot of time.
 
+**Note:** This installation process is not performed for controller mode,
+as serial-enabled qcow2 images already have the correct console configuration.
+
 ## Building the docker image
 
 Put the .qcow2 file in this directory and run `make docker-image` and you should
-be good to go. The resulting image is called `vr-c8000v`. You can tag it with
-something else if you want, like `my-repo.example.com/vr-c8000v` and then push
-it to your repo. The tag is the same as the version of the Catalyst 8000v image,
-so if you have c8000v-universalk9.16.04.01.qcow2 your final docker image will be
-called `vr-c8000v:16.04.01`
+be good to go. The build process automatically produces both autonomous and controller
+mode variant images from a single qcow2 file.
+
+**Note:** Controller mode requires a serial-enabled image (e.g.,
+`c8000v-universalk9_16G_serial.17.12.05a.qcow2`).
+
+The resulting images are called `vr-c8000v:VERSION` and `vr-c8000v:controller-VERSION`.
+You can tag them with something else if you want, like `my-repo.example.com/vr-c8000v`
+and then push to your repo. The tag is the same as the version of the Catalyst 8000v
+image, so if you have c8000v-universalk9.16.04.01.qcow2 your final docker images will be
+called `vr-c8000v:16.04.01` and `vr-c8000v:controller-16.04.01`
 
 It's been tested to boot and respond to SSH with:
 
 - 16.03.01a (c8000v-universalk9.16.03.01a.qcow2)
 - 16.04.01 (c8000v-universalk9.16.04.01.qcow2)
 - 17.11.01a (c8000v-universalk9_16G_serial.17.11.01a.qcow2)
+- 17.16.01a (c8000v_universalk9_8g_seria.qcow2) - Autonomous and controller modes tested
 
 ## Usage
 

--- a/cisco/c8000v/docker/Dockerfile
+++ b/cisco/c8000v/docker/Dockerfile
@@ -6,6 +6,9 @@ ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
+ARG MODE=autonomous
+ENV MODE=${MODE}
+
 EXPOSE 22 161/udp 830 5000 10000-10099
 HEALTHCHECK CMD ["/healthcheck.py"]
 ENTRYPOINT ["/launch.py"]


### PR DESCRIPTION
Adds dual-mode support for Cisco Catalyst 8000V with autonomous (standard IOS-XE) and
  controller (SD-WAN) variants built from a single qcow2 image.

  - Autonomous mode: Standard IOS-XE routing with clab-mgmt VRF
  - Controller mode: SD-WAN managed mode with VRF 513 and cloud-init bootstrap
  - Build process automatically produces both variants: `vr-c8000v:VERSION` and
  `vr-c8000v:controller-VERSION`
  - Controller mode requires serial output(not VGA) version of the qcow2 images

related to #396 