### PR TITLE
Added Cisco SD-WAN controller support

### DIFF
--- a/cisco/c8000v/Makefile
+++ b/cisco/c8000v/Makefile
@@ -3,15 +3,32 @@ NAME=c8000v
 IMAGE_FORMAT=qcow2
 IMAGE_GLOB=*.qcow2
 
-# match versions like:
-# c8000v-17.11.01a.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[a-z]\?\)\([^0-9].*\|$$\)/\1/')
+# Extract version from filename (e.g. c8000v-17.11.01a.qcow2)
+# If not in filename, extract from qcow2 metadata
+VERSION=$(shell V=$$(echo $(IMAGE) | sed -n 's/.*[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[a-z]\?\).*/\1/p'); \
+	[ -n "$$V" ] && echo "$$V" || strings $(IMAGE) | awk -F= '/RELVER/{print $$2; exit}')
 
 -include ../../makefile-sanity.include
 -include ../../makefile.include
 -include ../../makefile-install.include
 
+# Pass MODE to docker build
+docker-build: MODE?=autonomous
 docker-build: docker-build-common
-	docker run --cidfile cidfile --privileged $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION) --trace --install
-	docker commit --change='ENTRYPOINT ["/launch.py"]' $$(cat cidfile) $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION)
-	docker rm -f $$(cat cidfile)
+	(cd docker; docker build --build-arg MODE=$(MODE) -t $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION) .)
+	$(MAKE) docker-clean-build
+
+# Override default to build both autonomous and controller mode variants
+docker-image:
+	for IMAGE in $(IMAGES); do \
+		echo "Building autonomous mode variant for $$IMAGE"; \
+		$(MAKE) IMAGE=$$IMAGE MODE=autonomous docker-build; \
+		$(MAKE) IMAGE=$$IMAGE docker-clean-build; \
+		echo "Building controller mode variant for $$IMAGE"; \
+		VER=$$($(MAKE) -s IMAGE=$$IMAGE print-version); \
+		$(MAKE) IMAGE=$$IMAGE VERSION=controller-$$VER MODE=controller docker-build; \
+		$(MAKE) IMAGE=$$IMAGE docker-clean-build; \
+	done
+
+print-version:
+	@echo $(VERSION)

--- a/cisco/c8000v/README.md
+++ b/cisco/c8000v/README.md
@@ -3,18 +3,13 @@
 This is the vrnetlab docker image for Cisco Catalyst 8000V Edge Software, or
 'c8000v' for short.
 
-The Catalyst 8000v platform is a successor to the CSR 1000v. As such, this
-platform directory 'c8000v' started off as a copy of the 'csr' directory. With
-time we imagine the two platforms will diverge. One such change is already
-planned to support using the Catalyst 8000v in one of the two modes:
+The Catalyst 8000v platform is a successor to the CSR 1000v and supports two
+operating modes:
 
-- regular,
-- SD-WAN Controller mode (managed by Viptela).
+- **Autonomous mode** - Standard IOS-XE routing platform
+- **Controller mode** - SD-WAN managed mode (Viptela)
 
-Right now the SD-WAN flavor is still split off because to enable the Controller
-mode you have to effectively boot the router into a completely different mode.
-In the near future these modifications will be merged back into the 'c8000v'
-platform that will produce both the regular and sd-wan images.
+The build process automatically produces both variants from a single qcow2 image.
 
 On installation of Catalyst 8000v the user is presented with the choice of
 output, which can be over serial console, a video console or through automatic
@@ -33,20 +28,30 @@ which essentially just assembles the required files, then run it with
 we shut down the VM and commit this new state into the final docker image. This
 is unorthodox but works and saves us a lot of time.
 
+**Note:** This installation process is not performed for controller mode,
+as serial-enabled qcow2 images already have the correct console configuration.
+
 ## Building the docker image
 
 Put the .qcow2 file in this directory and run `make docker-image` and you should
-be good to go. The resulting image is called `vr-c8000v`. You can tag it with
-something else if you want, like `my-repo.example.com/vr-c8000v` and then push
-it to your repo. The tag is the same as the version of the Catalyst 8000v image,
-so if you have c8000v-universalk9.16.04.01.qcow2 your final docker image will be
-called `vr-c8000v:16.04.01`
+be good to go. The build process automatically produces both autonomous and controller
+mode variant images from a single qcow2 file.
+
+**Note:** Controller mode requires a serial-enabled image (e.g.,
+`c8000v-universalk9_16G_serial.17.12.05a.qcow2`).
+
+The resulting images are called `vr-c8000v:VERSION` and `vr-c8000v:controller-VERSION`.
+You can tag them with something else if you want, like `my-repo.example.com/vr-c8000v`
+and then push to your repo. The tag is the same as the version of the Catalyst 8000v
+image, so if you have c8000v-universalk9.16.04.01.qcow2 your final docker images will be
+called `vr-c8000v:16.04.01` and `vr-c8000v:controller-16.04.01`
 
 It's been tested to boot and respond to SSH with:
 
 - 16.03.01a (c8000v-universalk9.16.03.01a.qcow2)
 - 16.04.01 (c8000v-universalk9.16.04.01.qcow2)
 - 17.11.01a (c8000v-universalk9_16G_serial.17.11.01a.qcow2)
+- 17.16.01a (c8000v_universalk9_8g_seria.qcow2) - Autonomous and controller modes tested
 
 ## Usage
 

--- a/cisco/c8000v/docker/Dockerfile
+++ b/cisco/c8000v/docker/Dockerfile
@@ -6,6 +6,9 @@ ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
+ARG MODE=autonomous
+ENV MODE=${MODE}
+
 EXPOSE 22 161/udp 830 5000 10000-10099
 HEALTHCHECK CMD ["/healthcheck.py"]
 ENTRYPOINT ["/launch.py"]

--- a/cisco/sdwan-components/Makefile
+++ b/cisco/sdwan-components/Makefile
@@ -1,0 +1,43 @@
+VENDOR=Cisco
+NAME=sdwan-components
+IMAGE_FORMAT=qcow2
+IMAGE_GLOB=*.qcow2
+
+# Detect component type and version from filename
+# Examples:
+# viptela_vmanage_20_16_1_gen.qcow2 -> manager, 20.16.1
+# viptela_vsmart_20_16_1_gen.qcow2 -> controller, 20.16.1
+# viptela_vbond_20_16_1_gen.qcow2 -> validator, 20.16.1
+COMPONENT=$(shell echo $(IMAGE) | sed -n 's/.*[-_]v*\(manage\|smart\|bond\)[-_].*/\1/p' | sed -e 's/manage/manager/' -e 's/smart/controller/' -e 's/bond/validator/')
+VERSION=$(shell echo $(IMAGE) | sed -n 's/.*\(manage\|smart\|bond\)[-_]\([0-9][0-9._]*[0-9]\).*/\2/p' | sed -e 's/_/./g')
+
+
+-include ../../makefile-sanity.include
+-include ../../makefile.include
+
+# Override docker-build to include component type in image tag
+docker-build: docker-build-common docker-clean-build
+
+docker-build-common: docker-clean-build docker-pre-build
+	@if [ -z "$$IMAGE" ]; then echo "ERROR: No IMAGE specified"; exit 1; fi
+	@if [ "$(IMAGE)" = "$(VERSION)" ]; then echo "ERROR: Incorrect version string ($(IMAGE)). The regexp for extracting version information is likely incorrect, check the regexp in the Makefile or open an issue at https://github.com/hellt/vrnetlab/issues/new including the image file name you are using."; exit 1; fi
+	@echo "Building docker image using $(IMAGE) as $(REGISTRY)$(IMG_VENDOR)_sdwan-$(COMPONENT):$(VERSION)"
+	@if [ -d ../common ]; then \
+		cp ../common/* docker/; \
+	elif [ -d ../../common ]; then \
+		cp ../../common/* docker/; \
+	else \
+		echo "ERROR: Cannot find common directory"; exit 1; \
+	fi
+	@[ -f ./vswitch.xml ] && cp vswitch.xml docker/ || true
+	$(MAKE) IMAGE=$$IMAGE docker-build-image-copy
+	(cd docker; docker build --build-arg http_proxy=$(http_proxy) --build-arg HTTP_PROXY=$(HTTP_PROXY) --build-arg https_proxy=$(https_proxy) --build-arg HTTPS_PROXY=$(HTTPS_PROXY) --build-arg IMAGE=$(IMAGE) --build-arg VERSION=$(VERSION) --label "vrnetlab-version=$(VRNETLAB_VERION)" -t $(REGISTRY)$(IMG_VENDOR)_sdwan-$(COMPONENT):$(VERSION) .)
+
+build:
+	@echo "Building all SD-WAN component images..."
+	@for img in *.qcow2; do \
+		if [ -f "$$img" ]; then \
+			echo "Building $$img"; \
+			$(MAKE) docker-image IMAGE=$$img; \
+		fi \
+	done

--- a/cisco/sdwan-components/README.md
+++ b/cisco/sdwan-components/README.md
@@ -1,0 +1,91 @@
+# Cisco SD-WAN Components
+
+vrnetlab Docker images for Cisco SD-WAN controller components: vManage, vSmart, and vBond.
+
+## Building
+
+Download qcow2 images from Cisco and place them in this directory. Component type is auto-detected from filename:
+- `*vmanage*.qcow2` → manager
+- `*vsmart*.qcow2` → controller
+- `*vbond*.qcow2` → validator
+
+Build all components:
+```bash
+make
+```
+
+Or build individually:
+```bash
+make docker-image IMAGE=viptela_vmanage_20_16_1.qcow2
+```
+
+Generates images:
+- `vrnetlab/cisco_sdwan-manager:20.16.1`
+- `vrnetlab/cisco_sdwan-controller:20.16.1`
+- `vrnetlab/cisco_sdwan-validator:20.16.1`
+
+## Requirements
+
+| Component | RAM | Disk |
+|-----------|-----|------|
+| vManage | 16 GB | 30 GB + 50 GB data disk |
+| vSmart | 4 GB | 30 GB |
+| vBond | 2 GB | 30 GB |
+
+Default: 5 NICs (eth0-eth4)
+- **eth0**: VPN 512 (management) - configured with vrnetlab management IP
+- **eth1+**: VPN 0 (transport)
+
+## Configuration
+
+### Default
+- Username: `admin`
+- Password: `admin`
+- Hostname: `sdwan-manager`, `sdwan-controller`, or `sdwan-validator`
+
+### Custom Config
+
+**Full cloud-init** at `/config/cloud-init.yaml`:
+```bash
+docker run -d --privileged \
+  -v /path/to/cloud-init.yaml:/config/cloud-init.yaml \
+  vrnetlab/cisco_sdwan-manager:20.16.1
+```
+
+**zCloud XML only** at `/config/zcloud.xml`:
+```bash
+docker run -d --privileged \
+  -v /path/to/zcloud.xml:/config/zcloud.xml \
+  vrnetlab/cisco_sdwan-manager:20.16.1
+```
+
+### Runtime Parameters
+
+```bash
+docker run -d --privileged vrnetlab/cisco_sdwan-manager:20.16.1 \
+  --hostname my-vmanage \
+  --username admin \
+  --password MyPass123 \
+  --nics 8
+```
+
+## Troubleshooting
+
+View logs:
+```bash
+docker logs <container-name>
+```
+
+Serial console:
+```bash
+docker exec -it <container-name> telnet localhost 5000
+```
+
+SSH access:
+```bash
+docker exec -it <container-name> ssh admin@localhost
+```
+
+## Tested Versions
+
+- Cisco SD-WAN 20.16.1

--- a/cisco/sdwan-components/docker/Dockerfile
+++ b/cisco/sdwan-components/docker/Dockerfile
@@ -1,0 +1,42 @@
+FROM public.ecr.aws/docker/library/debian:bookworm-slim AS builder
+
+ARG DISK_SIZE=30G
+
+RUN apt-get update -qy && \
+   apt-get install -y --no-install-recommends qemu-utils && \
+   rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY $IMAGE* /
+RUN qemu-img resize /$IMAGE $DISK_SIZE
+
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG DISK_SIZE=30G
+
+RUN apt-get update -qy \
+   && apt-get install -y --no-install-recommends\
+   bridge-utils \
+   iproute2 \
+   socat \
+   qemu-kvm \
+   tcpdump \
+   ssh \
+   inetutils-ping \
+   dnsutils \
+   iptables \
+   nftables \
+   telnet \
+   cloud-utils \
+   sshpass \
+   && rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY --from=builder $IMAGE* /
+COPY *.py /
+COPY templates/ /templates/
+
+EXPOSE 22 5000 10000-10099
+HEALTHCHECK CMD ["/healthcheck.py"]
+ENTRYPOINT ["/launch.py"]

--- a/cisco/sdwan-components/docker/launch.py
+++ b/cisco/sdwan-components/docker/launch.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+
+import datetime
+import logging
+import os
+import re
+import signal
+import subprocess
+import sys
+
+import vrnetlab
+
+CLOUD_INIT_CONFIG_FILE = "/config/cloud-init.yaml"
+ZCLOUD_XML_FILE = "/config/zcloud.xml"
+
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+
+
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+
+
+logging.Logger.trace = trace
+
+
+class Sdwan_component_vm(vrnetlab.VM):
+    def __init__(
+        self,
+        hostname,
+        username,
+        password,
+        nics,
+        conn_mode,
+        component_type,
+    ):
+        for e in os.listdir("/"):
+            if re.search(".qcow2$", e):
+                disk_image = "/" + e
+                # Detect component type from filename if not specified
+                if not component_type:
+                    e_lower = e.lower()
+                    if "manage" in e_lower:
+                        component_type = "manager"
+                    elif "smart" in e_lower:
+                        component_type = "controller"
+                    elif "bond" in e_lower:
+                        component_type = "validator"
+
+        # Set RAM based on component type
+        ram_map = {
+            "manager": 16384,
+            "controller": 4096,
+            "validator": 2048,
+        }
+        ram = ram_map.get(component_type, 4096)
+
+        super(Sdwan_component_vm, self).__init__(
+            username, password, disk_image=disk_image, ram=ram
+        )
+
+        self.conn_mode = conn_mode
+        self.component_type = component_type
+        self.nic_type = "virtio-net-pci"
+
+        # Set hostname to sdwan-<component-type> if not specified
+        self.hostname = hostname if hostname else f"sdwan-{component_type}"
+
+        # Store number of NICs for later use
+        self.num_nics = nics
+
+        self.image_name = "cloud_init.iso"
+        self.create_boot_image()
+
+        self.qemu_args.extend(["-cdrom", "/" + self.image_name])
+
+        # Add data disk for vManage only (virtio since nvme not supported in this QEMU)
+        if self.component_type == "manager":
+            self.add_disk("50G", driveif="virtio")
+
+        if "ADD_DISK" in os.environ:
+            disk_size = os.getenv("ADD_DISK")
+
+            self.add_disk(disk_size)
+
+    def load_template(self, template_name):
+        """Load and render a template file"""
+        template_path = f"/templates/{template_name}"
+        with open(template_path, "r") as f:
+            template = f.read()
+
+        # Extract IP and prefix from CIDR notation (e.g., "10.0.0.15/24")
+        ip_with_prefix = self.mgmt_address_ipv4
+        variables = {
+            "hostname": self.hostname,
+            "username": self.username,
+            "password": self.password,
+            "mgmt_ip": ip_with_prefix.split('/')[0],
+            "mgmt_prefix": ip_with_prefix.split('/')[1],
+            "mgmt_gw": self.mgmt_gw_ipv4
+        }
+
+        for key, value in variables.items():
+            template = template.replace(f"{{{{ {key} }}}}", str(value))
+
+        return template
+
+    def gen_cloud_config(self, custom_zcloud=None):
+        """Generate cloud-init configuration based on component type
+
+        Args:
+            custom_zcloud: Optional custom zcloud.xml content. If None, uses template.
+        """
+        # Map component types to their personalities and template names
+        component_map = {
+            "manager": {"personality": "vmanage", "template": "manager-zcloud.xml.j2"},
+            "controller": {"personality": "vsmart", "template": "controller-zcloud.xml.j2"},
+            "validator": {"personality": "vbond", "template": "validator-zcloud.xml.j2"}
+        }
+
+        config = component_map.get(self.component_type, component_map["manager"])
+
+        # Use custom zcloud if provided, otherwise load from template
+        if custom_zcloud:
+            zcloud_xml = custom_zcloud
+        else:
+            zcloud_xml = self.load_template(config["template"])
+
+        # Build cloud-init config
+        cloud_config = "#cloud-config\n"
+
+        # Add disk setup only for manager
+        if self.component_type == "manager":
+            cloud_config += """disk_setup:
+  /dev/vda:
+    table_type: mbr
+    layout: false
+    overwrite: false
+fs_setup:
+- device: /dev/vda
+  label: data
+  partition: none
+  filesystem: ext4
+  overwrite: false
+mounts:
+- [ /dev/vda, /opt/data ]
+"""
+
+        cloud_config += "write_files:\n"
+
+        # Add persona file only for manager
+        if self.component_type == "manager":
+            cloud_config += """- path: /opt/web-app/etc/persona
+  owner: vmanage:vmanage-admin
+  permissions: '0644'
+  content: '{"persona":"COMPUTE_AND_DATA"}'
+"""
+
+        # Add common files
+        cloud_config += f"""- path: /etc/default/personality
+  content: "{config['personality']}\\n"
+- path: /etc/default/inited
+  content: "1\\n"
+- path: /usr/share/viptela/symantec-root-ca.crt
+- path: /etc/confd/init/zcloud.xml
+  content: |
+{chr(10).join('    ' + line for line in zcloud_xml.split(chr(10)))}
+"""
+
+        return cloud_config
+
+    def create_boot_image(self):
+        """Creates a cloud-init iso image with a bootstrap configuration"""
+        cloud_config = self._load_user_config() or self._generate_default_config()
+
+        with open("/bootstrap_config.yaml", "w") as cfg_file:
+            cfg_file.write(cloud_config)
+
+        subprocess.Popen(["cloud-localds", "-v", "/" + self.image_name, "/bootstrap_config.yaml"])
+
+    def _load_user_config(self):
+        """Load user-provided configuration if present"""
+        if os.path.exists(CLOUD_INIT_CONFIG_FILE):
+            self.logger.info("Found full cloud-init configuration at %s", CLOUD_INIT_CONFIG_FILE)
+            with open(CLOUD_INIT_CONFIG_FILE, "r") as f:
+                return f.read()
+
+        if os.path.exists(ZCLOUD_XML_FILE):
+            self.logger.info("Found zcloud.xml configuration at %s", ZCLOUD_XML_FILE)
+            with open(ZCLOUD_XML_FILE, "r") as f:
+                return self.gen_cloud_config(custom_zcloud=f.read())
+
+        return None
+
+    def _generate_default_config(self):
+        """Generate default cloud-init configuration"""
+        self.logger.info("Generating default configuration for %s", self.component_type)
+        return self.gen_cloud_config()
+
+    def bootstrap_spin(self):
+        """This function should be called periodically to do work."""
+
+        if self.spins > 6000:
+            # too many spins with no result ->  give up
+            self.logger.debug("Too many spins -> give up")
+            self.stop()
+            self.start()
+            return
+
+        (ridx, match, res) = self.tn.expect([b"System Ready"], 1)
+        if match:  # got a match!
+            if ridx == 0:  # System Ready
+                self.logger.debug("System Ready detected")
+                self.wait_write("", wait=None)
+
+                self.running = True
+                # close telnet connection
+                self.tn.close()
+                # startup time?
+                startup_time = datetime.datetime.now() - self.start_time
+                self.logger.info("Startup complete in: %s", startup_time)
+                return
+
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        if res != b"":
+            self.logger.trace("OUTPUT: %s" % res.decode())
+            # reset spins if we saw some output
+            self.spins = 0
+
+        self.spins += 1
+
+        return
+
+    def gen_nics(self):
+        """Generate QEMU args for data plane NICs as tap interfaces"""
+        res = []
+        # Generate data plane NICs (p01-pXX) as tap interfaces
+        # Management NIC (p00) is handled by parent class
+        for i in range(1, self.num_nics):
+            res.extend(["-device", f"{self.nic_type},netdev=p{i:02d},mac={vrnetlab.gen_mac(i)}"])
+            res.extend(["-netdev", f"tap,ifname=p{i:02d},id=p{i:02d},script=no,downscript=no"])
+        return res
+
+    def add_disk(self, disk_size, driveif="ide"):
+        additional_disk = f"disk_{disk_size}.qcow2"
+
+        if not os.path.exists(additional_disk):
+            self.logger.debug(f"Creating additional disk image {additional_disk}")
+            vrnetlab.run_command(
+                ["qemu-img", "create", "-f", "qcow2", additional_disk, disk_size]
+            )
+
+        self.qemu_args.extend(
+            [
+                "-drive",
+                f"if={driveif},file={additional_disk}",
+            ]
+        )
+
+
+class Sdwan_component(vrnetlab.VR):
+    def __init__(self, hostname, username, password, nics, conn_mode, component_type):
+        super(Sdwan_component, self).__init__(username, password)
+        self.vms = [Sdwan_component_vm(hostname, username, password, nics, conn_mode, component_type)]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument(
+        "--trace", action="store_true", help="enable trace level logging"
+    )
+    parser.add_argument("--username", default="admin", help="Username")
+    parser.add_argument("--password", default="admin", help="Password")
+    parser.add_argument("--hostname", default=None, help="VM Hostname (default: sdwan-<component-type>)")
+    parser.add_argument("--nics", type=int, default=5, help="Number of NICS")
+    parser.add_argument(
+        "--component-type",
+        choices=["manager", "controller", "validator"],
+        help="SD-WAN component type (auto-detected from image if not specified)",
+    )
+    parser.add_argument(
+        "--connection-mode",
+        default="vrxcon",
+        help="Connection mode to use in the datapath",
+    )
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    vr = Sdwan_component(
+        args.hostname,
+        args.username,
+        args.password,
+        args.nics,
+        args.connection_mode,
+        args.component_type,
+    )
+    vr.start()

--- a/cisco/sdwan-components/docker/templates/controller-zcloud.xml.j2
+++ b/cisco/sdwan-components/docker/templates/controller-zcloud.xml.j2
@@ -1,0 +1,59 @@
+<config xmlns="http://tail-f.com/ns/config/1.0">
+  <system xmlns="http://viptela.com/system">
+    <personality>vsmart</personality>
+    <device-model>vsmart</device-model>
+    <host-name>{{ hostname }}</host-name>
+    <aaa>
+      <user>
+        <name>{{ username }}</name>
+        <password>{{ password }}</password>
+        <group>netadmin</group>
+      </user>
+    </aaa>
+  </system>
+  <vpn xmlns="http://viptela.com/vpn">
+    <vpn-instance>
+      <vpn-id>512</vpn-id>
+      <interface>
+        <if-name>eth0</if-name>
+         <ip>
+          <address>{{ mgmt_ip }}/{{ mgmt_prefix }}</address>
+         </ip>
+         <shutdown>false</shutdown>
+      </interface>
+      <ip>
+        <route>
+          <prefix>0.0.0.0/0</prefix>
+          <next-hop>
+            <address>{{ mgmt_gw }}</address>
+          </next-hop>
+        </route>
+      </ip>
+    </vpn-instance>
+  </vpn>
+  <vpn xmlns="http://viptela.com/vpn">
+    <vpn-instance>
+      <vpn-id>0</vpn-id>
+      <interface>
+        <if-name>eth1</if-name>
+         <ip>
+          <dhcp-client>true</dhcp-client>
+         </ip>
+         <shutdown>false</shutdown>
+         <tunnel-interface>
+          <encapsulation>
+            <encap>ipsec</encap>
+          </encapsulation>
+          <color>
+            <value>default</value>
+          </color>
+          <allow-service>
+            <sshd>true</sshd>
+            <netconf>true</netconf>
+          </allow-service>
+        </tunnel-interface>
+        <shutdown>false</shutdown>
+      </interface>
+    </vpn-instance>
+  </vpn>
+</config>

--- a/cisco/sdwan-components/docker/templates/manager-zcloud.xml.j2
+++ b/cisco/sdwan-components/docker/templates/manager-zcloud.xml.j2
@@ -1,0 +1,59 @@
+<config xmlns="http://tail-f.com/ns/config/1.0">
+  <system xmlns="http://viptela.com/system">
+    <personality>vmanage</personality>
+    <device-model>vmanage</device-model>
+    <host-name>{{ hostname }}</host-name>
+    <aaa>
+      <user>
+        <name>{{ username }}</name>
+        <password>{{ password }}</password>
+        <group>netadmin</group>
+      </user>
+    </aaa>
+  </system>
+  <vpn xmlns="http://viptela.com/vpn">
+    <vpn-instance>
+      <vpn-id>512</vpn-id>
+      <interface>
+        <if-name>eth0</if-name>
+         <ip>
+          <address>{{ mgmt_ip }}/{{ mgmt_prefix }}</address>
+         </ip>
+         <shutdown>false</shutdown>
+      </interface>
+      <ip>
+        <route>
+          <prefix>0.0.0.0/0</prefix>
+          <next-hop>
+            <address>{{ mgmt_gw }}</address>
+          </next-hop>
+        </route>
+      </ip>
+    </vpn-instance>
+  </vpn>
+  <vpn xmlns="http://viptela.com/vpn">
+    <vpn-instance>
+      <vpn-id>0</vpn-id>
+      <interface>
+        <if-name>eth1</if-name>
+         <ip>
+          <dhcp-client>true</dhcp-client>
+         </ip>
+         <shutdown>false</shutdown>
+         <tunnel-interface>
+          <encapsulation>
+            <encap>ipsec</encap>
+          </encapsulation>
+          <color>
+            <value>default</value>
+          </color>
+          <allow-service>
+            <sshd>true</sshd>
+            <netconf>true</netconf>
+          </allow-service>
+        </tunnel-interface>
+        <shutdown>false</shutdown>
+      </interface>
+    </vpn-instance>
+  </vpn>
+</config>

--- a/cisco/sdwan-components/docker/templates/validator-zcloud.xml.j2
+++ b/cisco/sdwan-components/docker/templates/validator-zcloud.xml.j2
@@ -1,0 +1,57 @@
+<config xmlns="http://tail-f.com/ns/config/1.0">
+  <system xmlns="http://viptela.com/system">
+    <host-name>{{ hostname }}</host-name>
+    <aaa>
+      <user>
+        <name>{{ username }}</name>
+        <password>{{ password }}</password>
+        <group>netadmin</group>
+      </user>
+    </aaa>
+  </system>
+  <vpn xmlns="http://viptela.com/vpn">
+    <vpn-instance>
+      <vpn-id>512</vpn-id>
+      <interface>
+        <if-name>eth0</if-name>
+         <ip>
+          <address>{{ mgmt_ip }}/{{ mgmt_prefix }}</address>
+         </ip>
+         <shutdown>false</shutdown>
+      </interface>
+      <ip>
+        <route>
+          <prefix>0.0.0.0/0</prefix>
+          <next-hop>
+            <address>{{ mgmt_gw }}</address>
+          </next-hop>
+        </route>
+      </ip>
+    </vpn-instance>
+  </vpn>
+  <vpn xmlns="http://viptela.com/vpn">
+    <vpn-instance>
+      <vpn-id>0</vpn-id>
+      <interface>
+        <if-name>ge0/0</if-name>
+         <ip>
+          <dhcp-client>true</dhcp-client>
+         </ip>
+         <shutdown>false</shutdown>
+         <tunnel-interface>
+          <encapsulation>
+            <encap>ipsec</encap>
+          </encapsulation>
+          <color>
+            <value>default</value>
+          </color>
+          <allow-service>
+            <sshd>true</sshd>
+            <netconf>true</netconf>
+          </allow-service>
+        </tunnel-interface>
+        <shutdown>false</shutdown>
+      </interface>
+    </vpn-instance>
+  </vpn>
+</config>


### PR DESCRIPTION
 # Add Cisco SD-WAN Components Support

  Adds vrnetlab support for Cisco SD-WAN controller components: vManage, vSmart, and vBond.

  ## Features

  - Auto-detects component type from qcow2 filename (`*vmanage*`, `*vsmart*`, `*vbond*`)
  - Cloud-init based bootstrapping with template support
  - Configures VPN 512 (management) and VPN 0 (transport) interfaces
  - Component-specific resource allocation (vManage: 16GB RAM, vSmart: 4GB, vBond: 2GB)
  - Custom configuration via `/config/cloud-init.yaml` or `/config/zcloud.xml`
  - Default credentials: admin/admin
  - Serial console and SSH access

  ## Testing

  Tested with Cisco SD-WAN 20.16.1:
  - All components boot successfully
  - Network interfaces correctly configured (eth0 for management, eth1+ for transport)
  - Serial console login working
  - SSH access working