### PR TITLE
Fixed commit pattern for vMX

### DIFF
--- a/juniper/vmx/docker/launch.py
+++ b/juniper/vmx/docker/launch.py
@@ -47,7 +47,7 @@ class VMX_vcp(vrnetlab.VM):
 
     # [edit]
     # <prompt>#
-    COMMIT_PATTERN = r"commit complete[\s\S]*\[edit\][\s\S]*#"
+    COMMIT_PATTERN = r"(?s)commit complete.*\[edit\].*#"
 
     def __init__(
         self,


### PR DESCRIPTION
For larger startup config sometime exit happens before commit is completed. By making sure we see 'commit complete' before we exit, we can make sure that commit happened for sure.

## Commit output
```
commit complete

[edit]
<prompt>#
```

## Commit pattern
```python
r"(?s)commit complete.*\[edit\].*#"
```
where `(?s)` enables multiline flag and rest is self explanatory. 