### PR TITLE
change/sonic replace instead of merge

### DIFF
--- a/sonic/docker/backup.sh
+++ b/sonic/docker/backup.sh
@@ -95,7 +95,7 @@ restore() {
         echo "Copying startup config file to the VM..."
 
         if wait_for_ssh; then
-            $SCP_CMD $BACKUP_FILE $HOST:$TMP_FILE && $SSH_CMD $HOST "sudo config load -y $TMP_FILE && sudo config save -y"
+            $SCP_CMD $BACKUP_FILE $HOST:$TMP_FILE && $SSH_CMD $HOST "sudo config replace -y $TMP_FILE && sudo config save -y"
         else
             echo "Failed to establish SSH connection. Config copy operation aborted."
         fi


### PR DESCRIPTION
Changed config load to config replace in `sonic/docker/backup.sh` to ensure user-provided startup configurations completely replace the default config instead of merging with it. This provides deterministic, predictable device configurations when deploying SONIC containers with custom config_db.json files.