### PR TITLE
Disable IPv6 on container tap interfaces

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -443,6 +443,9 @@ class VM:
         ip link set $TAP_IF up
         ip link set $TAP_IF mtu 65000
 
+        # disable IPv6 to avoid sending periodic traffic like router solicitations from the vrnetlab container
+        ip -6 addr flush $TAP_IF
+
         # create tc eth<->tap redirect rules
         tc qdisc add dev {INTF_PREFIX}$INDEX clsact
         tc filter add dev {INTF_PREFIX}$INDEX ingress flower action mirred egress redirect dev tap$INDEX
@@ -463,6 +466,9 @@ class VM:
 
         ip link set tap0 up
         ip link set tap0 mtu 65000
+
+        # disable IPv6 to avoid sending periodic traffic like router solicitations from the vrnetlab container
+        ip -6 addr flush $TAP_IF
 
         # create tc eth<->tap redirect rules
 


### PR DESCRIPTION
Remove IPv6 from the tap interfaces to avoid sending things like router solicitations into the lab.

This is a alternative approach to doing this via sysctls as suggested here: https://github.com/srl-labs/vrnetlab/issues/392