### PR TITLE
Fix SCP command to replace config without -y option

### DIFF
--- a/sonic/docker/backup.sh
+++ b/sonic/docker/backup.sh
@@ -95,7 +95,7 @@ restore() {
         echo "Copying startup config file to the VM..."
 
         if wait_for_ssh; then
-            $SCP_CMD $BACKUP_FILE $HOST:$TMP_FILE && $SSH_CMD $HOST "sudo config replace -y $TMP_FILE && sudo config save -y"
+            $SCP_CMD $BACKUP_FILE $HOST:$TMP_FILE && $SSH_CMD $HOST "sudo config replace $TMP_FILE && sudo config save -y"
         else
             echo "Failed to establish SSH connection. Config copy operation aborted."
         fi


### PR DESCRIPTION
-y flag was left over from `config load` which accepts a `-y`. I missed removing this when changing the operation to replace from previous load.