### PR TITLE
Support running Mikrotik on Mac M3 or greater.

### DIFF
--- a/mikrotik/routeros/docker/Dockerfile
+++ b/mikrotik/routeros/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update -qy \
    python3-ipy \
    socat \
    qemu-kvm \
+   qemu-system-x86 \
    tcpdump \
    ssh \
    inetutils-ping \

--- a/mikrotik/routeros/docker/launch.py
+++ b/mikrotik/routeros/docker/launch.py
@@ -4,6 +4,7 @@ import datetime
 import ftplib
 import logging
 import os
+import platform
 import re
 import signal
 import sys
@@ -52,7 +53,11 @@ class ROS_vm(vrnetlab.VM):
         for e in os.listdir("/"):
             if re.search(".vmdk$", e):
                 disk_image = "/" + e
-        super(ROS_vm, self).__init__(username, password, disk_image=disk_image, ram=256)
+
+        # the default cpu=host only works when running clab on an amd64 machine
+        extra_args = {} if platform.machine() == "x86_64" else {"cpu": "qemu64"}
+
+        super(ROS_vm, self).__init__(username, password, disk_image=disk_image, ram=256, **extra_args)
         self.qemu_args.extend(["-boot", "n"])
         self.hostname = hostname
         self.conn_mode = conn_mode


### PR DESCRIPTION
To run this on a Mac we explicitly need to install qemu-system-x86.
Also we cannot use `cpu=host` when we don't run a native emulation.
Autodetect the platform to change this.

PS:
I've also managed to run the arm64 CHR image on my Mac, but for some reason it's actually much slower than the amd64 one. So I'm not spending anymore effort on this.