### PR TITLE
Update vrnetlab.py to support IPv6 connections via chardev

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -312,10 +312,10 @@ class VM:
             "none",
             "-machine",
             "pc",
-            "-monitor",
-            f"tcp:0.0.0.0:40{self.num:02d},server,nowait",
-            "-serial",
-            f"telnet:0.0.0.0:50{self.num:02d},server,nowait",
+            f"-chardev socket,id=monitor0,host=::,port=40{self.num:02d},server=on,wait=off",
+            "-monitor chardev:monitor0",
+            f"-chardev socket,id=serial0,host=::,port=50{self.num:02d},server=on,wait=off,telnet=on",
+            "-serial chardev:serial0",
             "-m",  # memory
             str(self.ram),
             "-cpu",  # cpu type


### PR DESCRIPTION
Updated monitor and serial to use chardev sockets rather than legacy tcp and telnet mechanisms. This allows connections using both IPv4 and IPv6 rather than the IPv4 connections supported by tcp and telnet. It also makes management connections faster as the IPv6 connection will just connect rather than failing and requiring a follow-up IPv4 connection.