### PR TITLE
Add Transparent Management to SONiC

### DIFF
--- a/sonic/docker/launch.py
+++ b/sonic/docker/launch.py
@@ -103,7 +103,6 @@ class SONiC_vm(vrnetlab.VM):
         """Do the actual bootstrap config"""
         self.logger.info("applying bootstrap configuration")
         self.wait_write("sudo -i", "$")
-<<<<<<< HEAD
         # Set IPv4 Management Address if present:
         if self.mgmt_address_ipv4 and "." in self.mgmt_address_ipv4:
             self.wait_write(
@@ -129,25 +128,6 @@ class SONiC_vm(vrnetlab.VM):
                 f"while ! /usr/sbin/ip link show eth0 | grep -q \"state UP\"; do sleep 1; done;/usr/sbin/ip -6 route add default via {self.mgmt_gw_ipv6} dev eth0",
                 "#"
             )
-=======
-        # Set IPv4 Management Address:
-        self.wait_write(
-            f"sudo /usr/sbin/ip address add {self.mgmt_address_ipv4} dev eth0", "#"
-        )
-        # Set IPv4 Management Gateway:
-        self.wait_write(
-            f"sudo /usr/sbin/ip route add default via {self.mgmt_gw_ipv4} dev eth0", "#"
-        )
-        # IPv6 is untested - it has reported problems under Enterprise SONiC
-        # Set IPv6 Management Address:
-        self.wait_write(
-            f"sudo /usr/sbin/ip -6 address add {self.mgmt_address_ipv6} dev eth0", "#"
-        )
-        # Set IPv6 Management Gateway:
-        self.wait_write(
-            f"sudo /usr/sbin/ip -6 route add default via {self.mgmt_gw_ipv6} dev eth0", "#"
-        )
->>>>>>> 50afc41 (Add transparent mgmt passthrough w/ IPv4/IPv6 static address & gateway)
         self.wait_write("passwd -q %s" % (self.username))
         self.wait_write(self.password, "New password:")
         self.wait_write(self.password, "password:")


### PR DESCRIPTION
Tested through a Docker MACVLAN interface (IPv4 only tested):

Server Network:
```
containerlab-dev:~/containerlab-topologies/sonic-test$ ip a
2: ens18: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether bc:24:11:56:3d:b7 brd ff:ff:ff:ff:ff:ff
    altname enp0s18
    altname enxbc2411563db7
    inet 10.100.0.119/24 brd 10.100.0.255 scope global dynamic noprefixroute ens18
       valid_lft 56051sec preferred_lft 45251sec
    inet6 fe80::71a2:73a3:acf9:ea3d/64 scope link
       valid_lft forever preferred_lft forever
```

Docker MACVLAN Network:

```
containerlab-dev:~/containerlab-topologies/sonic-test$ docker network create -d macvlan -o parent=ens18 \
  --subnet 10.100.0.0/24 \
  --gateway 10.100.0.1 \
  --ip-range 10.100.0.16/28 \
  ens18-lan_macvlan
```

Topology YAML:
```
name: sonic-lite
mgmt:
  network: ens18-lan_macvlan
topology:
  defaults:
    env:
      CLAB_MGMT_PASSTHROUGH: "true"
  nodes:
    soniclite:
      kind: sonic-vm
      image: vrnetlab/sonic_sonic-vs:202405a
      mgmt-ipv4: 10.100.0.18
```
<img width="1256" height="391" alt="541750954-72df0a14-5482-41f9-9800-0deb58fb64e6" src="https://github.com/user-attachments/assets/a31823d2-67f0-4189-8fcb-5cfe40aef015" />

```
C:\>ipconfig
...
Wireless LAN adapter Wi-Fi:

   Connection-specific DNS Suffix  . : 
   IPv4 Address. . . . . . . . . . . : 10.100.0.52
   Subnet Mask . . . . . . . . . . . : 255.255.255.0
   Default Gateway . . . . . . . . . : 10.100.0.1
...

ssh admin@10.100.0.18
Debian GNU/Linux 12 \n \l

admin@10.100.0.18's password:
Linux sonic 6.1.0-22-2-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.94-1 (2024-06-21) x86_64

Last login: Wed Jan 28 17:04:40 2026 from 10.100.0.52
admin@sonic:~$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/16 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 0c:00:6f:7b:1f:00 brd ff:ff:ff:ff:ff:ff
    inet 10.100.0.18/24 scope global eth0
       valid_lft forever preferred_lft forever
    inet 10.100.0.122/24 brd 10.100.0.255 scope global secondary dynamic eth0
       valid_lft 85586sec preferred_lft 85586sec
    inet6 fe80::e00:6fff:fe7b:1f00/64 scope link
       valid_lft forever preferred_lft forever
```

```
admin@sonic:~$ ping 10.100.0.1
PING 10.100.0.1 (10.100.0.1) 56(84) bytes of data.
64 bytes from 10.100.0.1: icmp_seq=1 ttl=64 time=2.00 ms
64 bytes from 10.100.0.1: icmp_seq=2 ttl=64 time=0.524 ms
^C
--- 10.100.0.1 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1002ms
```

```
admin@sonic:~$ ip route
default via 10.100.0.1 dev eth0 metric 1000
```