### PR TITLE
model-driven config detection fix for nokia_sros <=22

### DIFF
--- a/nokia/sros/docker/launch.py
+++ b/nokia/sros/docker/launch.py
@@ -1288,6 +1288,10 @@ class SROS_vm(vrnetlab.VM):
                         self.logger.debug("Detected classic startup configuration")
                         classic_cfg = True
                         break
+                    if "configure {" == l_clean:
+                        self.logger.debug("Detected model-driven startup configuration")
+                        classic_cfg = False
+                        break
 
         if classic_cfg:
             sros_scrapli_dev["variant"] = "classic"


### PR DESCRIPTION
This patch allows detection of model-driven startup configuration for nokia_sros releases <=22