### PR TITLE
Add Transparent Management support to OcNOS & Improve eth0 IPv4/IPv6

### DIFF
--- a/ipinfusion/ocnos/docker/launch.py
+++ b/ipinfusion/ocnos/docker/launch.py
@@ -109,13 +109,37 @@ class OCNOS_vm(vrnetlab.VM):
         self.wait_write(cmd="configure terminal", wait="#")
         self.wait_write(cmd="interface eth0", wait="(config)#")
         self.wait_write(cmd="ip vrf forwarding management", wait="(config-if)#")
-        self.wait_write(cmd="commit", wait="(config-if)#")
-        self.wait_write(cmd="ip address dhcp", wait="(config-if)#")
-        self.wait_write(cmd="commit", wait="(config-if)#")
+        # Set IPv4 Management Address if present:
+        if self.mgmt_address_ipv4 and "." in self.mgmt_address_ipv4:
+            self.wait_write(
+                cmd=f"ip address {self.mgmt_address_ipv4}", wait="(config-if)#"
+            )
+        else:
+            self.wait_write(
+                cmd="ip address dhcp", wait="(config-if)#"
+            )
+        # Note: IPv6 has not been fully tested
+        # Set IPv6 Management Address if present:
+        if self.mgmt_address_ipv6 and ":" in self.mgmt_address_ipv6:
+            self.wait_write(
+                cmd=f"ipv6 address {self.mgmt_address_ipv6}", wait="(config-if)#"
+            )
+        else:
+            self.wait_write(
+                cmd="ipv6 address dhcp", wait="(config-if)#"
+            )
         self.wait_write(cmd="exit", wait="(config-if)#")
-        self.wait_write(
-            cmd="ip route vrf management 0.0.0.0/0 10.0.0.2 eth0", wait="(config)#"
-        )
+        # Set IPv4 Management Gateway if present:
+        if self.mgmt_gw_ipv4 and "." in self.mgmt_gw_ipv4:
+            self.wait_write(
+                cmd=f"ip route vrf management 0.0.0.0/0 {self.mgmt_gw_ipv4} eth0", wait="(config)#"
+            )
+        # Note: IPv6 has not been fully tested
+        # Set IPv6 Management Gateway if present:
+        if self.mgmt_gw_ipv6 and ":" in self.mgmt_gw_ipv6:
+            self.wait_write(
+                cmd=f"ipv6 route vrf management ::/0 {self.mgmt_gw_ipv6} eth0", wait="(config)#"
+            )
         self.wait_write(cmd="commit", wait="(config)#")
 
     def bootstrap_config(self):


### PR DESCRIPTION
Confirmed support for Transparent Management in OcNOS & Improved the IPv4/IPv6 eth0 Address configuration method.

Validated with IPv4 MACVLAN - Docker Assigned IP, External DHCP Assigned IP & Static IP

```
IPv4 MACVLAN Configuration:
        docker network create -d macvlan
        -o parent=ens18
        --subnet 10.100.0.0/24
        --gateway 10.100.0.1
        --ip-range 10.100.0.16/28
        ens18-lan_macvlan
```

Docker Assigned Address & Passthrough:
```
Topology File		
=============
name: ocnos
mgmt:
  network: ens18-lan_macvlan
topology:
  defaults:
    env:
      CLAB_MGMT_PASSTHROUGH: "true"
  nodes:
    ocnos:
      kind: ipinfusion_ocnos
      image: vrnetlab/ipinfusion_ocnos:6.6.1-140
=============

Result (Truncated):
OcNOS(config-if)#'
2026-02-09 20:28:27,756: vrnetlab       DEBUG writing to serial console: 'ip address 10.100.0.16/24'
2026-02-09 20:28:27,756: vrnetlab       INFO waiting for '(config-if)#' on serial console
2026-02-09 20:28:27,800: vrnetlab       INFO read from serial console: 'ip address 10.100.0.16/24
OcNOS(config-if)#'
2026-02-09 20:28:27,800: vrnetlab       DEBUG writing to serial console: 'ipv6 address dhcp'
2026-02-09 20:28:27,800: vrnetlab       INFO waiting for '(config-if)#' on serial console
2026-02-09 20:28:27,844: vrnetlab       INFO read from serial console: 'ipv6 address dhcp
OcNOS(config-if)#'
2026-02-09 20:28:27,844: vrnetlab       DEBUG writing to serial console: 'exit'
2026-02-09 20:28:27,844: vrnetlab       INFO waiting for '(config)#' on serial console
2026-02-09 20:28:27,888: vrnetlab       INFO read from serial console: 'exit
OcNOS(config)#'
2026-02-09 20:28:27,888: vrnetlab       DEBUG writing to serial console: 'ip route vrf management 0.0.0.0/0 10.100.0.1 eth0'
2026-02-09 20:28:27,888: vrnetlab       INFO waiting for '(config)#' on serial console
2026-02-09 20:28:27,936: vrnetlab       INFO read from serial console: 'ip route vrf management 0.0.0.0/0 10.100.0.1 eth0
OcNOS(config)#'
2026-02-09 20:28:27,936: vrnetlab       DEBUG writing to serial console: 'commit'
2026-02-09 20:28:27,936: vrnetlab       INFO waiting for '(config)#' on serial console
2026-02-09 20:28:28,818: vrnetlab       INFO read from serial console: 'commit
OcNOS(config)#'

ocnos>show run (Truncated)
!
! Software version: DEMO_VM-OcNOS-SP-PLUS-x86-6.6.1.140-MR 07/01/2025 15:34:25
!
! Last configuration change at 20:28:30 UTC Mon Feb 09 2026 by ocnos
!
ip vrf management
!
interface eth0
 ip vrf forwarding management
 ip address 10.100.0.16/24
 ipv6 address dhcp
!
 exit
!
ip route vrf management 0.0.0.0/0 10.100.0.1 eth0
!
!
end

ocnos>
```

External DHCP Transparent Passthrough Management Example:

```
Topology File
=============
name: ocnos
mgmt:
  network: ens18-lan_macvlan
topology:
  defaults:
    env:
      CLAB_MGMT_PASSTHROUGH: "true"
	  CLAB_MGMT_DHCP: "true"
  nodes:
    ocnos:
      kind: ipinfusion_ocnos
      image: vrnetlab/ipinfusion_ocnos:6.6.1-140
=============

Result (Truncated):
OcNOS(config-if)#'
2026-02-09 20:34:46,320: vrnetlab       DEBUG writing to serial console: 'ip address dhcp'
2026-02-09 20:34:46,320: vrnetlab       INFO waiting for '(config-if)#' on serial console
2026-02-09 20:34:46,364: vrnetlab       INFO read from serial console: 'ip address dhcp
OcNOS(config-if)#'
2026-02-09 20:34:46,364: vrnetlab       DEBUG writing to serial console: 'ipv6 address dhcp'
2026-02-09 20:34:46,364: vrnetlab       INFO waiting for '(config-if)#' on serial console
2026-02-09 20:34:46,408: vrnetlab       INFO read from serial console: 'ipv6 address dhcp
OcNOS(config-if)#'
2026-02-09 20:34:46,408: vrnetlab       DEBUG writing to serial console: 'exit'
2026-02-09 20:34:46,408: vrnetlab       INFO waiting for '(config)#' on serial console
2026-02-09 20:34:46,452: vrnetlab       INFO read from serial console: 'exit
OcNOS(config)#'
2026-02-09 20:34:46,452: vrnetlab       DEBUG writing to serial console: 'commit'
2026-02-09 20:34:46,452: vrnetlab       INFO waiting for '(config)#' on serial console
2026-02-09 20:34:47,280: vrnetlab       INFO read from serial console: 'commit

ocnos>show run (Truncated)
!
! Software version: DEMO_VM-OcNOS-SP-PLUS-x86-6.6.1.140-MR 07/01/2025 15:34:25
!
! Last configuration change at 20:34:48 UTC Mon Feb 09 2026 by ocnos
!
ip vrf management
!
interface eth0
 ip vrf forwarding management
 ip address dhcp
 ipv6 address dhcp
!
 exit
!
!
end

ocnos>show ip interface eth0 brief

'*' - address is assigned by dhcp client

Interface            IP-Address      Admin-Status          Link-Status
eth0                *10.100.0.145    up                    up

ocnos>ping 8.8.8.8 vrf management
Press CTRL+C to exit
PING 8.8.8.8 (8.8.8.8) 100(128) bytes of data.
108 bytes from 8.8.8.8: icmp_seq=1 ttl=119 time=13.4 ms
108 bytes from 8.8.8.8: icmp_seq=2 ttl=119 time=17.1 ms
```

Static IP Example:

```
Topology File
=============
name: ocnos
mgmt:
  network: ens18-lan_macvlan
topology:
  defaults:
    env:
      CLAB_MGMT_PASSTHROUGH: "true"
  nodes:
    ocnos:
      kind: ipinfusion_ocnos
      image: vrnetlab/ipinfusion_ocnos:6.6.1-140
	  mgmt-ipv4: 10.100.0.18
=============

Result (Truncated):
OcNOS(config-if)#'
2026-02-09 20:45:15,604: vrnetlab       DEBUG writing to serial console: 'ip address 10.100.0.18/24'
2026-02-09 20:45:15,604: vrnetlab       INFO waiting for '(config-if)#' on serial console
2026-02-09 20:45:15,648: vrnetlab       INFO read from serial console: 'ip address 10.100.0.18/24
OcNOS(config-if)#'
2026-02-09 20:45:15,648: vrnetlab       DEBUG writing to serial console: 'ipv6 address dhcp'
2026-02-09 20:45:15,648: vrnetlab       INFO waiting for '(config-if)#' on serial console
2026-02-09 20:45:15,692: vrnetlab       INFO read from serial console: 'ipv6 address dhcp
OcNOS(config-if)#'
2026-02-09 20:45:15,692: vrnetlab       DEBUG writing to serial console: 'exit'
2026-02-09 20:45:15,692: vrnetlab       INFO waiting for '(config)#' on serial console
2026-02-09 20:45:15,736: vrnetlab       INFO read from serial console: 'exit
OcNOS(config)#'
2026-02-09 20:45:15,736: vrnetlab       DEBUG writing to serial console: 'ip route vrf management 0.0.0.0/0 10.100.0.1 eth0'
2026-02-09 20:45:15,736: vrnetlab       INFO waiting for '(config)#' on serial console
2026-02-09 20:45:15,784: vrnetlab       INFO read from serial console: 'ip route vrf management 0.0.0.0/0 10.100.0.1 eth0
OcNOS(config)#'
2026-02-09 20:45:15,784: vrnetlab       DEBUG writing to serial console: 'commit'
2026-02-09 20:45:15,784: vrnetlab       INFO waiting for '(config)#' on serial console
2026-02-09 20:45:16,609: vrnetlab       INFO read from serial console: 'commit

ocnos>show run (Truncated)
!
! Software version: DEMO_VM-OcNOS-SP-PLUS-x86-6.6.1.140-MR 07/01/2025 15:34:25
!
! Last configuration change at 20:45:18 UTC Mon Feb 09 2026 by ocnos
!
ip vrf management
!
interface eth0
 ip vrf forwarding management
 ip address 10.100.0.18/24
 ipv6 address dhcp
!
 exit
!
ip route vrf management 0.0.0.0/0 10.100.0.1 eth0
!
!
end

ocnos>show ip interface eth0 brief

'*' - address is assigned by dhcp client

Interface            IP-Address      Admin-Status          Link-Status
eth0                 10.100.0.18     up                    up
```