### PR TITLE
Fix bootstrap_spin() function in launch scripts for Junos

### DIFF
--- a/juniper/vjunosevolved/docker/launch.py
+++ b/juniper/vjunosevolved/docker/launch.py
@@ -167,19 +167,20 @@ class VJUNOSEVOLVED_vm(vrnetlab.VM):
 
                 # Login
                 self.wait_write("\r", None)
-                self.wait_write("admin", wait=f"{self.hostname} login:")
-                self.wait_write(self.password, wait="Password:")
-                self.wait_write("\r", None)
-                self.logger.info("Login completed")
 
-                # close telnet connection
-                self.tn.close()
-                # startup time?
-                startup_time = datetime.datetime.now() - self.start_time
-                self.logger.info("Startup complete in: %s" % startup_time)
-                # mark as running
-                self.running = True
-                return
+                _, loginMatch, _ = self.tn.expect([f"{self.hostname} login:".encode("utf-8")])
+                if loginMatch:
+
+                    self.logger.info("Login prompt found")
+
+                    # close telnet connection
+                    self.tn.close()
+                    # startup time?
+                    startup_time = datetime.datetime.now() - self.start_time
+                    self.logger.info("Startup complete in: %s" % startup_time)
+                    # mark as running
+                    self.running = True
+                    return
 
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time

--- a/juniper/vjunosrouter/docker/launch.py
+++ b/juniper/vjunosrouter/docker/launch.py
@@ -138,19 +138,20 @@ class VJUNOSROUTER_vm(vrnetlab.VM):
 
                 # Login
                 self.wait_write("\r", None)
-                self.wait_write("admin", wait="login:")
-                self.wait_write(self.password, wait="Password:")
-                self.wait_write("\r", None)
-                self.logger.info("Login completed")
 
-                # close telnet connection
-                self.tn.close()
-                # startup time?
-                startup_time = datetime.datetime.now() - self.start_time
-                self.logger.info("Startup complete in: %s" % startup_time)
-                # mark as running
-                self.running = True
-                return
+                _, loginMatch, _ = self.tn.expect([b"login:"], 1)
+                if loginMatch:
+
+                    self.logger.info("Login prompt found")
+
+                    # close telnet connection
+                    self.tn.close()
+                    # startup time?
+                    startup_time = datetime.datetime.now() - self.start_time
+                    self.logger.info("Startup complete in: %s" % startup_time)
+                    # mark as running
+                    self.running = True
+                    return
 
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time

--- a/juniper/vjunosswitch/docker/launch.py
+++ b/juniper/vjunosswitch/docker/launch.py
@@ -138,19 +138,20 @@ class VJUNOSSWITCH_vm(vrnetlab.VM):
 
                 # Login
                 self.wait_write("\r", None)
-                self.wait_write("admin", wait="login:")
-                self.wait_write(self.password, wait="Password:")
-                self.wait_write("\r", None)
-                self.logger.info("Login completed")
 
-                # close telnet connection
-                self.tn.close()
-                # startup time?
-                startup_time = datetime.datetime.now() - self.start_time
-                self.logger.info("Startup complete in: %s" % startup_time)
-                # mark as running
-                self.running = True
-                return
+                _, loginMatch, _ = self.tn.expect([b"login:"], 1)
+                if loginMatch:
+
+                    self.logger.info("Login prompt found")
+
+                    # close telnet connection
+                    self.tn.close()
+                    # startup time?
+                    startup_time = datetime.datetime.now() - self.start_time
+                    self.logger.info("Startup complete in: %s" % startup_time)
+                    # mark as running
+                    self.running = True
+                    return
 
         # no match, if we saw some output from the router it's probably
         # booting, so let's give it some more time


### PR DESCRIPTION
Referenced as a [comment](https://github.com/srl-labs/vrnetlab/issues/385#issuecomment-3955048612) in issue #385. Fixes the issue with failed healthchecks on Junos VM-based nodes due to asynchronous logging.

PR to change launch.py files for the following nodes:
* vJunosRouter
* vJunosSwitch
* vJunosEvolved

The core logic of the health check contained in the `bootstrap_spin()` function has been modified. Rather than attempting to fully complete the login process to validate that the node is fully booted, the launch/healthcheck script now assumes that the `login:` prompt is a sufficient indicator that the node is healthy and ready to be accessed. This has been tested on all three of the aforementioned node types and consistently works. There are three considerations here:

1. The original script never actually checked to see whether the login process completed successfully or not. It only checked to see whether the login and password prompts appeared at all. There was no mechanism for the healthcheck to fail if, for example, the password was incorrect. On top of this, the original script never actually did anything after logging in. As far as I can tell, no functionality has been lost as a result of not completing the login process during the healthcheck.
2. Since the startup config is fully merged/created prior to the virtual device being booted, it's safe to assume that seeing the `login:` prompt means that the user is able to log in and access the device.
3. The logic behind declaring the node as ready/healthy when the login prompt appears is aligned with the behavior of the recommended node templates for Junos on other network emulation platforms, such as Cisco Modeling Labs (CML).

**NOTE:** As far as I'm aware, the original script for vJunosEvolved wasn't affected by this issue. It takes long enough to fully boot, such that there isn't any extraneous debug text that is asynchronously logged to the console. However, I also made an equivalent change to the launch script for the vJunosEvolved node to ensure consistency in the healthcheck logic across all of the Junos VMs.