### PR TITLE
vjunos: Add AMD SVM enable step to Makefile

### DIFF
--- a/juniper/vjunosrouter/Makefile
+++ b/juniper/vjunosrouter/Makefile
@@ -19,13 +19,13 @@ all: enable-amd-svm-on-images
 IMAGES=$(shell ls $(IMAGE_GLOB) 2>/dev/null)
 
 enable-amd-svm-on-images:
-	docker pull vistagg/vjunos-amd-enabler:latest
+	docker pull ghcr.io/birbnetworks/vjunos-amd-enable:latest
 	for IMAGE in $(IMAGES); do \
 		echo "Enabling AMD SVM flags on $$IMAGE"; \
 		docker run --rm \
 			--cap-add SYS_ADMIN \
 			--device /dev/kvm \
 			-v "$$(pwd)/$$IMAGE:/vJunos.qcow2:rw" \
-			vistagg/vjunos-amd-enabler; \
+			ghcr.io/birbnetworks/vjunos-amd-enable:latest; \
 	done
-	docker rmi vistagg/vjunos-amd-enabler:latest || true
+	docker rmi ghcr.io/birbnetworks/vjunos-amd-enable:latest || true

--- a/juniper/vjunosrouter/Makefile
+++ b/juniper/vjunosrouter/Makefile
@@ -8,5 +8,24 @@ IMAGE_GLOB=*.qcow2
 # ...
 VERSION=$(shell echo $(IMAGE) | sed -e 's/vJunos-router-//i' | sed -e 's/.qcow2//i')
 
+.PHONY: enable-amd-svm-on-images all
+
+all: enable-amd-svm-on-images
+    $(MAKE) docker-image
+
 -include ../../makefile-sanity.include
 -include ../../makefile.include
+
+IMAGES=$(shell ls $(IMAGE_GLOB) 2>/dev/null)
+
+enable-amd-svm-on-images:
+    docker pull vistagg/vjunos-amd-enabler:latest
+    for IMAGE in $(IMAGES); do \
+        echo "Enabling AMD SVM flags on $$IMAGE"; \
+        docker run --rm \
+            --cap-add SYS_ADMIN \
+            --device /dev/kvm \
+            -v "$$(pwd)/$$IMAGE:/vJunos.qcow2:rw" \
+            vistagg/vjunos-amd-enabler; \
+        done
+        docker rmi vistagg/vjunos-amd-enabler:latest || true

--- a/juniper/vjunosrouter/Makefile
+++ b/juniper/vjunosrouter/Makefile
@@ -11,7 +11,7 @@ VERSION=$(shell echo $(IMAGE) | sed -e 's/vJunos-router-//i' | sed -e 's/.qcow2/
 .PHONY: enable-amd-svm-on-images all
 
 all: enable-amd-svm-on-images
-    $(MAKE) docker-image
+	$(MAKE) docker-image
 
 -include ../../makefile-sanity.include
 -include ../../makefile.include
@@ -19,13 +19,13 @@ all: enable-amd-svm-on-images
 IMAGES=$(shell ls $(IMAGE_GLOB) 2>/dev/null)
 
 enable-amd-svm-on-images:
-    docker pull vistagg/vjunos-amd-enabler:latest
-    for IMAGE in $(IMAGES); do \
-        echo "Enabling AMD SVM flags on $$IMAGE"; \
-        docker run --rm \
-            --cap-add SYS_ADMIN \
-            --device /dev/kvm \
-            -v "$$(pwd)/$$IMAGE:/vJunos.qcow2:rw" \
-            vistagg/vjunos-amd-enabler; \
-        done
-        docker rmi vistagg/vjunos-amd-enabler:latest || true
+	docker pull vistagg/vjunos-amd-enabler:latest
+	for IMAGE in $(IMAGES); do \
+		echo "Enabling AMD SVM flags on $$IMAGE"; \
+		docker run --rm \
+			--cap-add SYS_ADMIN \
+			--device /dev/kvm \
+			-v "$$(pwd)/$$IMAGE:/vJunos.qcow2:rw" \
+			vistagg/vjunos-amd-enabler; \
+	done
+	docker rmi vistagg/vjunos-amd-enabler:latest || true

--- a/juniper/vjunosswitch/Makefile
+++ b/juniper/vjunosswitch/Makefile
@@ -11,5 +11,24 @@ IMAGE_GLOB=*.qcow2
 
 VERSION=$(shell echo $(IMAGE) | sed -e 's/vjunos-switch-//i' | sed -e 's/.qcow2//i')
 
+.PHONY: enable-amd-svm-on-images all
+
+all: enable-amd-svm-on-images
+    $(MAKE) docker-image
+
 -include ../../makefile-sanity.include
 -include ../../makefile.include
+
+IMAGES=$(shell ls $(IMAGE_GLOB) 2>/dev/null)
+
+enable-amd-svm-on-images:
+    docker pull vistagg/vjunos-amd-enabler:latest
+    for IMAGE in $(IMAGES); do \
+        echo "Enabling AMD SVM flags on $$IMAGE"; \
+        docker run --rm \
+            --cap-add SYS_ADMIN \
+            --device /dev/kvm \
+            -v "$$(pwd)/$$IMAGE:/vJunos.qcow2:rw" \
+            vistagg/vjunos-amd-enabler; \
+        done
+        docker rmi vistagg/vjunos-amd-enabler:latest || true

--- a/juniper/vjunosswitch/Makefile
+++ b/juniper/vjunosswitch/Makefile
@@ -22,13 +22,13 @@ all: enable-amd-svm-on-images
 IMAGES=$(shell ls $(IMAGE_GLOB) 2>/dev/null)
 
 enable-amd-svm-on-images:
-	docker pull vistagg/vjunos-amd-enabler:latest
+	docker pull ghcr.io/birbnetworks/vjunos-amd-enable:latest
 	for IMAGE in $(IMAGES); do \
 		echo "Enabling AMD SVM flags on $$IMAGE"; \
 		docker run --rm \
 			--cap-add SYS_ADMIN \
 			--device /dev/kvm \
 			-v "$$(pwd)/$$IMAGE:/vJunos.qcow2:rw" \
-			vistagg/vjunos-amd-enabler; \
+			ghcr.io/birbnetworks/vjunos-amd-enable:latest; \
 	done
-	docker rmi vistagg/vjunos-amd-enabler:latest || true
+	docker rmi ghcr.io/birbnetworks/vjunos-amd-enable:latest || true

--- a/juniper/vjunosswitch/Makefile
+++ b/juniper/vjunosswitch/Makefile
@@ -14,7 +14,7 @@ VERSION=$(shell echo $(IMAGE) | sed -e 's/vjunos-switch-//i' | sed -e 's/.qcow2/
 .PHONY: enable-amd-svm-on-images all
 
 all: enable-amd-svm-on-images
-    $(MAKE) docker-image
+	$(MAKE) docker-image
 
 -include ../../makefile-sanity.include
 -include ../../makefile.include
@@ -22,13 +22,13 @@ all: enable-amd-svm-on-images
 IMAGES=$(shell ls $(IMAGE_GLOB) 2>/dev/null)
 
 enable-amd-svm-on-images:
-    docker pull vistagg/vjunos-amd-enabler:latest
-    for IMAGE in $(IMAGES); do \
-        echo "Enabling AMD SVM flags on $$IMAGE"; \
-        docker run --rm \
-            --cap-add SYS_ADMIN \
-            --device /dev/kvm \
-            -v "$$(pwd)/$$IMAGE:/vJunos.qcow2:rw" \
-            vistagg/vjunos-amd-enabler; \
-        done
-        docker rmi vistagg/vjunos-amd-enabler:latest || true
+	docker pull vistagg/vjunos-amd-enabler:latest
+	for IMAGE in $(IMAGES); do \
+		echo "Enabling AMD SVM flags on $$IMAGE"; \
+		docker run --rm \
+			--cap-add SYS_ADMIN \
+			--device /dev/kvm \
+			-v "$$(pwd)/$$IMAGE:/vJunos.qcow2:rw" \
+			vistagg/vjunos-amd-enabler; \
+	done
+	docker rmi vistagg/vjunos-amd-enabler:latest || true


### PR DESCRIPTION
This patches out the vmx CPU flag check in the Junos control plane VM startup script to also accept AMD's SVM flag. 