### PR TITLE
nvidia/cumulus-vx: add Cumulus VX vrnetlab image

### DIFF
--- a/nvidia/cumulus-vx/Makefile
+++ b/nvidia/cumulus-vx/Makefile
@@ -1,0 +1,35 @@
+# ------------------------------------------------------------------------------
+# Nvidia Cumulus VX - vrnetlab / srl-labs Makefile
+#
+# Place your Cumulus VX qcow2 image (e.g. cumulus-linux-5.16.1-vx-amd64-qemu.qcow2)
+# in this directory, then run:
+#
+#   make
+#
+# The resulting image will be tagged:
+#   vrnetlab/nvidia_cumulus-vx:<VERSION>
+#
+# To push to a custom registry set DOCKER_REGISTRY, e.g.:
+#   DOCKER_REGISTRY=myregistry.example.com:5000/vrnetlab make docker-push
+# ------------------------------------------------------------------------------
+
+VENDOR        = Nvidia
+NAME          = Cumulus-VX
+
+IMAGE_FORMAT  = qcow2
+
+# Matches filenames like:
+#   cumulus-linux-5.16.1-vx-amd64-qemu.qcow2
+#   cumulus-linux-5.10.0-vx-amd64-qemu.qcow2
+IMAGE_GLOB    = cumulus-linux*.$(IMAGE_FORMAT)
+
+# Extract the version from the filename.
+# Strips "cumulus-linux-" prefix and "-vx-amd64-qemu.qcow2" suffix.
+# Result for "cumulus-linux-5.16.1-vx-amd64-qemu.qcow2" -> "5.16.1"
+VERSION       = $(shell echo $(IMAGE) \
+                  | sed -e 's/^cumulus-linux-//' \
+                  | sed -e 's/-vx-amd64-qemu\.$(IMAGE_FORMAT)$$//')
+
+# Pull in the shared srl-labs build machinery.
+-include ../../makefile-sanity.include
+-include ../../makefile.include

--- a/nvidia/cumulus-vx/README.md
+++ b/nvidia/cumulus-vx/README.md
@@ -1,0 +1,204 @@
+# Nvidia Cumulus VX — vrnetlab / srl-labs container
+
+Containerizes the Nvidia Cumulus VX KVM appliance using the
+[srl-labs/vrnetlab](https://github.com/srl-labs/vrnetlab) framework.
+Cumulus VX is a virtual network switch running Cumulus Linux — a Debian-based
+NOS with full L2/L3 switching, routing, and NVUE declarative management.
+
+## Requirements
+
+| Resource   | Minimum | Recommended  |
+|------------|---------|--------------|
+| RAM        | 4 GB | 4 GB        |
+| vCPU       | 2      | 2            |
+| Disk       | ~200 MB overlay, grows with config | —            |
+
+## How to obtain the image
+
+Download the Cumulus VX qcow2 image from the
+[Nvidia developer portal](https://developer.nvidia.com/networking).
+An Nvidia developer account is required.
+
+The expected filename pattern is:
+`cumulus-linux-<version>-vx-amd64-qemu.qcow2`
+
+## Build instructions
+
+```bash
+# 1. Place the qcow2 in the vrnetlab/nvidia/cumulus-vx/ directory
+cp /path/to/cumulus-linux-5.16.1-vx-amd64-qemu.qcow2 vrnetlab/nvidia/cumulus-vx/
+
+# 2. Build
+cd vrnetlab/nvidia/cumulus-vx/
+make
+
+# Resulting image tag: vrnetlab/nvidia_cumulus-vx:5.16.1
+
+# 3. (Optional) push to a private registry
+DOCKER_REGISTRY=myregistry.example.com:5000/vrnetlab make docker-push
+```
+
+## Test version extraction before building
+
+```bash
+make version-test IMAGE=cumulus-linux-5.16.1-vx-amd64-qemu.qcow2
+# Expected output: 5.16.1
+```
+
+## Containerlab topology
+
+```yaml
+# cumulus-lab.clab.yaml
+name: cumulus-lab
+
+mgmt:
+  network: cumulus-mgmt
+  ipv4-subnet: 172.20.20.0/24
+  ipv4-gw: 172.20.20.1
+
+topology:
+  nodes:
+
+    cumulus1:
+      kind: cumulus_vm
+      image: vrnetlab/nvidia_cumulus-vx:5.16.1
+      mgmt-ipv4: 172.20.20.10
+      env:
+        QEMU_MEMORY: "4096"
+        QEMU_SMP: "2"
+
+    cumulus2:
+      kind: cumulus_vm
+      image: vrnetlab/nvidia_cumulus-vx:5.16.1
+      mgmt-ipv4: 172.20.20.11
+      env:
+        QEMU_MEMORY: "4096"
+        QEMU_SMP: "2"
+
+  links:
+    - endpoints: ["cumulus1:swp1", "cumulus2:swp1"]
+    - endpoints: ["cumulus1:swp2", "cumulus2:swp2"]
+```
+
+Deploy:
+```bash
+sudo containerlab deploy -t cumulus-lab.clab.yaml
+```
+
+## Default credentials
+
+| Service  | Username | Password       |
+|----------|----------|----------------|
+| SSH      | cumulus  | Nsn1234!       |
+| NVUE API | cumulus  | Nsn1234!       |
+
+## Management interfaces
+
+### NVUE REST API (Cumulus Linux 5.x+)
+
+NVUE is the primary declarative management interface for Cumulus Linux 5.x.
+It exposes an OpenAPI-compatible REST API on port 8765 (HTTPS).
+
+```bash
+# Check NVUE health
+curl -k -u cumulus:CumulusLinux! https://172.20.20.10:8765/nvue_v1/
+
+# Apply configuration
+curl -k -u cumulus:CumulusLinux! -X PATCH \
+  https://172.20.20.10:8765/nvue_v1/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "interface": {
+      "swp1": {
+        "type": "swp",
+        "link": {
+          "mtu": 9216
+        }
+      }
+    }
+  }'
+```
+
+### SSH
+
+```bash
+ssh cumulus@<mgmt-ip>
+```
+
+### Serial console
+
+```bash
+# from the container host
+telnet <container-name> 5000
+
+# or from inside the container
+docker exec -it <container-name> bash
+telnet localhost 5000
+```
+
+## Interface naming
+
+Inside the VM, Cumulus VX presents data-plane interfaces as `swp1`, `swp2`, etc.
+These map to the containerlab links defined in the topology:
+
+| Containerlab link | VM interface inside Cumulus VX |
+|-------------------|-------------------------------|
+| `eth1`            | `swp1`                        |
+| `eth2`            | `swp2`                        |
+| `ethN`            | `swpN`                        |
+
+The mapping is 1:1 — containerlab `ethN` maps to Cumulus `swpN`.
+
+## Persistent VM state
+
+The `generic_vm` kind automatically bind-mounts
+`clab-<labname>/<nodename>/config/` to `/config` inside the container.
+`launch.py` detects this mount and creates the QEMU overlay disk there:
+
+```
+clab-cumulus-lab/
+└── cumulus1/
+    └── config/
+        └── cumulus_overlay.qcow2   ← all VM writes go here
+```
+
+All Cumulus VX configuration — including NVUE settings, interface config,
+and installed packages — survives `clab destroy` and `clab deploy` cycles.
+
+To start completely fresh, delete the overlay before redeploying:
+
+```bash
+rm clab-cumulus-lab/cumulus1/config/cumulus_overlay.qcow2
+sudo containerlab deploy -t cumulus-lab.clab.yaml
+```
+
+## Debugging
+
+**Container logs**:
+```bash
+docker logs -f clab-cumulus-lab-cumulus1
+```
+
+**Health status**:
+```bash
+docker inspect --format='{{.State.Health.Status}}' clab-cumulus-lab-cumulus1
+# Expected: starting → (2–4 min) → healthy
+```
+
+**Verify persistent overlay is being used**:
+```bash
+docker exec clab-cumulus-lab-cumulus1 \
+    cat /proc/$(docker exec clab-cumulus-lab-cumulus1 pgrep qemu)/cmdline \
+    | tr '\0' '\n' | grep overlay
+# Expected: if=ide,file=/config/cumulus_overlay.qcow2
+```
+
+## Known issues and limitations
+
+- **KVM acceleration recommended**: Cumulus VX can run without KVM but switchd
+  performance degrades significantly under software emulation.
+- **Nested virtualisation**: Cumulus VX requires `/dev/kvm` for hardware
+  acceleration. It cannot achieve line-rate switching inside a VM that does
+  not expose KVM to guest workloads.
+- **NVUE is the default CLI** in Cumulus Linux 5.x+. The legacy NCLU commands
+  (`net add`, `net commit`) are still available but deprecated.

--- a/nvidia/cumulus-vx/README.md
+++ b/nvidia/cumulus-vx/README.md
@@ -1,4 +1,4 @@
-# Nvidia Cumulus VX — vrnetlab / srl-labs container
+# Nvidia Cumulus VX
 
 Containerizes the Nvidia Cumulus VX KVM appliance using the
 [srl-labs/vrnetlab](https://github.com/srl-labs/vrnetlab) framework.
@@ -15,9 +15,7 @@ NOS with full L2/L3 switching, routing, and NVUE declarative management.
 
 ## How to obtain the image
 
-Download the Cumulus VX qcow2 image from the
-[Nvidia developer portal](https://developer.nvidia.com/networking).
-An Nvidia developer account is required.
+NVIDIA does not provide the Cumulus VX qcow2 image anymore. You will have to find it...
 
 The expected filename pattern is:
 `cumulus-linux-<version>-vx-amd64-qemu.qcow2`
@@ -45,147 +43,23 @@ make version-test IMAGE=cumulus-linux-5.16.1-vx-amd64-qemu.qcow2
 # Expected output: 5.16.1
 ```
 
-## Containerlab topology
-
-```yaml
-# cumulus-lab.clab.yaml
-name: cumulus-lab
-
-mgmt:
-  network: cumulus-mgmt
-  ipv4-subnet: 172.20.20.0/24
-  ipv4-gw: 172.20.20.1
-
-topology:
-  nodes:
-
-    cumulus1:
-      kind: cumulus_vm
-      image: vrnetlab/nvidia_cumulus-vx:5.16.1
-      mgmt-ipv4: 172.20.20.10
-      env:
-        QEMU_MEMORY: "4096"
-        QEMU_SMP: "2"
-
-    cumulus2:
-      kind: cumulus_vm
-      image: vrnetlab/nvidia_cumulus-vx:5.16.1
-      mgmt-ipv4: 172.20.20.11
-      env:
-        QEMU_MEMORY: "4096"
-        QEMU_SMP: "2"
-
-  links:
-    - endpoints: ["cumulus1:swp1", "cumulus2:swp1"]
-    - endpoints: ["cumulus1:swp2", "cumulus2:swp2"]
-```
-
-Deploy:
-```bash
-sudo containerlab deploy -t cumulus-lab.clab.yaml
-```
-
-## Default credentials
-
-| Service  | Username | Password       |
-|----------|----------|----------------|
-| SSH      | cumulus  | Nsn1234!       |
-| NVUE API | cumulus  | Nsn1234!       |
-
-## Management interfaces
-
-### NVUE REST API (Cumulus Linux 5.x+)
-
-NVUE is the primary declarative management interface for Cumulus Linux 5.x.
-It exposes an OpenAPI-compatible REST API on port 8765 (HTTPS).
-
-```bash
-# Check NVUE health
-curl -k -u cumulus:CumulusLinux! https://172.20.20.10:8765/nvue_v1/
-
-# Apply configuration
-curl -k -u cumulus:CumulusLinux! -X PATCH \
-  https://172.20.20.10:8765/nvue_v1/ \
-  -H "Content-Type: application/json" \
-  -d '{
-    "interface": {
-      "swp1": {
-        "type": "swp",
-        "link": {
-          "mtu": 9216
-        }
-      }
-    }
-  }'
-```
-
-### SSH
-
-```bash
-ssh cumulus@<mgmt-ip>
-```
-
-### Serial console
-
-```bash
-# from the container host
-telnet <container-name> 5000
-
-# or from inside the container
-docker exec -it <container-name> bash
-telnet localhost 5000
-```
-
-## Interface naming
-
-Inside the VM, Cumulus VX presents data-plane interfaces as `swp1`, `swp2`, etc.
-These map to the containerlab links defined in the topology:
-
-| Containerlab link | VM interface inside Cumulus VX |
-|-------------------|-------------------------------|
-| `eth1`            | `swp1`                        |
-| `eth2`            | `swp2`                        |
-| `ethN`            | `swpN`                        |
-
-The mapping is 1:1 — containerlab `ethN` maps to Cumulus `swpN`.
-
-## Persistent VM state
-
-The `generic_vm` kind automatically bind-mounts
-`clab-<labname>/<nodename>/config/` to `/config` inside the container.
-`launch.py` detects this mount and creates the QEMU overlay disk there:
-
-```
-clab-cumulus-lab/
-└── cumulus1/
-    └── config/
-        └── cumulus_overlay.qcow2   ← all VM writes go here
-```
-
-All Cumulus VX configuration — including NVUE settings, interface config,
-and installed packages — survives `clab destroy` and `clab deploy` cycles.
-
-To start completely fresh, delete the overlay before redeploying:
-
-```bash
-rm clab-cumulus-lab/cumulus1/config/cumulus_overlay.qcow2
-sudo containerlab deploy -t cumulus-lab.clab.yaml
-```
-
 ## Debugging
 
 **Container logs**:
+
 ```bash
 docker logs -f clab-cumulus-lab-cumulus1
 ```
 
 **Health status**:
+
 ```bash
 docker inspect --format='{{.State.Health.Status}}' clab-cumulus-lab-cumulus1
 # Expected: starting → (2–4 min) → healthy
 ```
 
 **Verify persistent overlay is being used**:
+
 ```bash
 docker exec clab-cumulus-lab-cumulus1 \
     cat /proc/$(docker exec clab-cumulus-lab-cumulus1 pgrep qemu)/cmdline \
@@ -204,4 +78,5 @@ docker exec clab-cumulus-lab-cumulus1 \
   (`net add`, `net commit`) are still available but deprecated.
 
 ## Contact
+
 The author of this code is Wei Luo (<olaf.luo@foxmail.com>), feel free to reach him in case of problems.

--- a/nvidia/cumulus-vx/README.md
+++ b/nvidia/cumulus-vx/README.md
@@ -202,3 +202,6 @@ docker exec clab-cumulus-lab-cumulus1 \
   not expose KVM to guest workloads.
 - **NVUE is the default CLI** in Cumulus Linux 5.x+. The legacy NCLU commands
   (`net add`, `net commit`) are still available but deprecated.
+
+## Contact
+The author of this code is Wei Luo (<olaf.luo@foxmail.com>), feel free to reach him in case of problems.

--- a/nvidia/cumulus-vx/docker/Dockerfile
+++ b/nvidia/cumulus-vx/docker/Dockerfile
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------------------
+# Nvidia Cumulus VX - vrnetlab / srl-labs Dockerfile
+# ------------------------------------------------------------------------------
+FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+
+ARG VERSION
+ARG IMAGE
+
+ENV VERSION=${VERSION}
+
+COPY ${IMAGE} /
+COPY *.py     /
+
+EXPOSE 22 8080 8765 5000 10000-10099

--- a/nvidia/cumulus-vx/docker/launch.py
+++ b/nvidia/cumulus-vx/docker/launch.py
@@ -2,7 +2,6 @@
 # ==============================================================================
 # launch.py — Nvidia Cumulus VX vrnetlab launcher
 #
-# Modelled after the Juniper Apstra and Nokia CmgLinux launcher patterns.
 #
 # Key design decisions for Cumulus VX
 # ───────────────────────────────────
@@ -29,8 +28,8 @@ import time
 
 import vrnetlab
 
-
 # ── signal handlers ────────────────────────────────────────────────────────────
+
 
 def handle_SIGCHLD(signal, frame):
     os.waitpid(-1, os.WNOHANG)
@@ -65,6 +64,7 @@ DEFAULT_RAM_MB = 4096
 
 
 # ── VM subclass ─────────────────────────────────────────────────────────────────
+
 
 class CumulusVX_vm(vrnetlab.VM):
     def __init__(self, hostname, username, password, conn_mode):
@@ -124,16 +124,20 @@ class CumulusVX_vm(vrnetlab.VM):
             persistent_overlay = "/config/cumulus_overlay.qcow2"
 
             if not os.path.exists(persistent_overlay):
-                vrnetlab.run_command([
-                    "qemu-img", "create",
-                    "-f", "qcow2",
-                    "-b", disk_image,
-                    "-F", "qcow2",
-                    persistent_overlay,
-                ])
-                self.logger.info(
-                    "Created persistent overlay at %s", persistent_overlay
+                vrnetlab.run_command(
+                    [
+                        "qemu-img",
+                        "create",
+                        "-f",
+                        "qcow2",
+                        "-b",
+                        disk_image,
+                        "-F",
+                        "qcow2",
+                        persistent_overlay,
+                    ]
                 )
+                self.logger.info("Created persistent overlay at %s", persistent_overlay)
             else:
                 self.logger.info(
                     "Reusing existing persistent overlay at %s",
@@ -234,7 +238,7 @@ class CumulusVX_vm(vrnetlab.VM):
 
         VM_USER = "cumulus"
         VM_PASS = "cumulus"
-        TMP_PASS = "Nsn1234!"
+        NEW_PASS = "Clab123!"
 
         self.logger.info("First-boot setup for '%s' ...", VM_USER)
 
@@ -246,28 +250,31 @@ class CumulusVX_vm(vrnetlab.VM):
 
         # Step 2 — forced password change (PAM)
         (ridx, match, _) = self.tn.expect(
-            [b"Current password:", b"@", b"$ ", b"# "], 8,
+            [b"Current password:", b"@", b"$ ", b"# "],
+            8,
         )
         if match and ridx == 0:
             self.logger.info("First-boot: changing expired password")
             self.tn.write(("%s\r" % VM_PASS).encode())
             self.tn.expect([b"New password:"], 10)
-            self.tn.write(("%s\r" % TMP_PASS).encode())
+            self.tn.write(("%s\r" % NEW_PASS).encode())
             self.tn.expect([b"Retype new password:"], 10)
-            self.tn.write(("%s\r" % TMP_PASS).encode())
+            self.tn.write(("%s\r" % NEW_PASS).encode())
             time.sleep(1)
         elif match and ridx in (1, 2, 3):
             self.logger.debug("Already authenticated (overlay reuse)")
 
         # Step 3 — configure system
         self.logger.info("Configuring system ...")
-        self.tn.write((
-            "echo '%s' | sudo -S bash -c '"
-            "chage -M -1 %s && "
-            "echo \"%s ALL=(ALL) NOPASSWD:ALL\" > /etc/sudoers.d/%s && "
-            "hostnamectl set-hostname %s'\r"
-            % (TMP_PASS, VM_USER, VM_USER, VM_USER, self.hostname)
-        ).encode())
+        self.tn.write(
+            (
+                "echo '%s' | sudo -S bash -c '"
+                "chage -M -1 %s && "
+                'echo "%s ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/%s && '
+                "hostnamectl set-hostname %s'\r"
+                % (NEW_PASS, VM_USER, VM_USER, VM_USER, self.hostname)
+            ).encode()
+        )
         time.sleep(3)
 
         # Step 4 — verify shell is still responsive (password was
@@ -275,7 +282,7 @@ class CumulusVX_vm(vrnetlab.VM):
         self.tn.write(b"\r")
         (_, m2, _) = self.tn.expect([b"$ ", b"# ", b"@"], 8)
         if m2:
-            self.logger.info("Password verified: '%s' / '%s'", VM_USER, TMP_PASS)
+            self.logger.info("Password verified: '%s' / '%s'", VM_USER, NEW_PASS)
         else:
             self.logger.warning("Shell prompt not detected after config")
 
@@ -284,12 +291,11 @@ class CumulusVX_vm(vrnetlab.VM):
 
 # ── VR subclass ─────────────────────────────────────────────────────────────────
 
+
 class CumulusVX(vrnetlab.VR):
     def __init__(self, hostname, username, password, conn_mode):
         super(CumulusVX, self).__init__(username, password)
-        self.vms = [
-            CumulusVX_vm(hostname, username, password, conn_mode)
-        ]
+        self.vms = [CumulusVX_vm(hostname, username, password, conn_mode)]
 
 
 # ── entry point ─────────────────────────────────────────────────────────────────
@@ -297,9 +303,7 @@ class CumulusVX(vrnetlab.VR):
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(
-        description="Nvidia Cumulus VX vrnetlab launcher"
-    )
+    parser = argparse.ArgumentParser(description="Nvidia Cumulus VX vrnetlab launcher")
     parser.add_argument(
         "--trace",
         action="store_true",
@@ -312,8 +316,8 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--password",
-        default="Nsn1234!",
-        help="Cumulus Linux admin password (default: Nsn1234!)",
+        default="Clab123!",
+        help="Cumulus Linux admin password",
     )
     parser.add_argument(
         "--hostname",

--- a/nvidia/cumulus-vx/docker/launch.py
+++ b/nvidia/cumulus-vx/docker/launch.py
@@ -21,7 +21,6 @@
 
 import datetime
 import logging
-import math
 import os
 import re
 import signal
@@ -110,9 +109,11 @@ class CumulusVX_vm(vrnetlab.VM):
 
         self.logger.info(f"Using Cumulus VX disk image: {disk_image}")
 
-        # Cumulus VX is a switch — data-plane NICs are provisioned from
-        # containerlab via CLAB_INTFS.
-        self.num_nics = int(os.environ.get("CLAB_INTFS", 0))
+        # Cumulus VX is a switch — provision enough PCI slots so that
+        # the base class dummy-NIC (socket placeholder) logic fills any
+        # gaps, giving correct swpX numbering even with sparse topology
+        # interface indices (e.g. eth1, eth4, eth6, eth7).
+        self.num_nics = 16
         self.nic_type = "virtio-net-pci"
 
         # NVUE REST API (HTTPS on 8765) — 8080 is already in the base class
@@ -171,6 +172,18 @@ class CumulusVX_vm(vrnetlab.VM):
             self.start()
             return
 
+        # If first-boot setup is already done, poll switchd directly via
+        # the active serial session (no login prompt needed).
+        if self._bootstrap_done:
+            if not self._switchd_is_ready():
+                self.spins += 1
+                return
+            self.running = True
+            self.tn.close()
+            startup_time = datetime.datetime.now() - self.start_time
+            self.logger.info("Startup complete in: %s", startup_time)
+            return
+
         (ridx, match, res) = self.tn.expect(
             [b"login: ", b"Login: ", b"cumulus login: "],
             1,
@@ -179,28 +192,21 @@ class CumulusVX_vm(vrnetlab.VM):
         if match:
             self.logger.debug("Cumulus VX login prompt detected")
 
-            if not self._bootstrap_done:
-                self._bootstrap_done = True
-                try:
-                    self._first_boot_setup()
-                except Exception as exc:
-                    self.logger.error(
-                        "First-boot setup failed (%s) — password may need "
-                        "manual change via serial console (port %d)",
-                        exc,
-                        5000 + self.num,
-                    )
-
-            # Cumulus-specific: wait for switchd to be active so that swp
-            # ports are fully initialised before reporting healthy.
-            if not self._switchd_is_ready():
+            try:
+                self._first_boot_setup()
+            except Exception as exc:
+                self.logger.error(
+                    "First-boot setup failed (%s) — password may need "
+                    "manual change via serial console (port %d)",
+                    exc,
+                    5000 + self.num,
+                )
+                # Don't set _bootstrap_done; retry on next login prompt.
                 self.spins += 1
                 return
 
-            self.running = True
-            self.tn.close()
-            startup_time = datetime.datetime.now() - self.start_time
-            self.logger.info("Startup complete in: %s", startup_time)
+            self._bootstrap_done = True
+            self.spins += 1
             return
 
         if res != b"":
@@ -210,43 +216,21 @@ class CumulusVX_vm(vrnetlab.VM):
         self.spins += 1
 
     def _switchd_is_ready(self):
-        """Check whether switchd is active via the serial console.
-        Returns True if ``systemctl is-active switchd`` prints 'active'.
-        """
-        self._tn_write("")
+        """Check whether switchd is active via the serial console."""
+        self.tn.write(b"\r")
         time.sleep(0.5)
-        self._tn_write("systemctl is-active switchd 2>/dev/null")
+        self.tn.write(b"systemctl is-active switchd 2>/dev/null\r")
         time.sleep(2)
         try:
             (_, match, _) = self.tn.expect([b"active", b"inactive", b"failed"], 3)
             if match:
-                self.logger.debug("switchd status: %s", match.group(0).decode())
                 return match.group(0) == b"active"
         except Exception:
             pass
         return False
 
-    def _tn_write(self, text):
-        """Write a line to the serial console."""
-        self.tn.write(("%s\r" % text).encode())
-        self.logger.trace("SENT: %s", text)
-
-    def _tn_read_until(self, pattern, timeout=10):
-        """Read from the serial console until *pattern* (bytes) is seen."""
-        self.logger.trace("WAITING for: %s", pattern.decode(errors="replace"))
-        (ridx, match, res) = self.tn.expect([pattern], timeout)
-        if match:
-            self.logger.trace("MATCHED: %s", pattern.decode(errors="replace"))
-        return ridx, match, res
-
     def _first_boot_setup(self):
-        """Handle Cumulus VX first-boot forced password change.
-
-        A fresh Cumulus VX image has user ``cumulus`` / ``cumulus`` with an
-        expired password.  We log in, satisfy the PAM password change with
-        ``Nsn1234!``, enable NOPASSWD sudo, disable password expiry, and
-        set the hostname.
-        """
+        """Handle Cumulus VX first-boot forced password change."""
 
         VM_USER = "cumulus"
         VM_PASS = "cumulus"
@@ -254,176 +238,48 @@ class CumulusVX_vm(vrnetlab.VM):
 
         self.logger.info("First-boot setup for '%s' ...", VM_USER)
 
-        # ── Step 1: log in ──────────────────────────────────────────────────
-        self._tn_write(VM_USER)
-        self._tn_read_until(b"Password:", 15)
-        self._tn_write(VM_PASS)
-        time.sleep(1)
+        # Step 1 — log in
+        self.tn.write(("%s\r" % VM_USER).encode())
+        self.tn.expect([b"Password:"], 10)
+        self.tn.write(("%s\r" % VM_PASS).encode())
+        time.sleep(0.5)
 
-        # ── Step 2: forced password change (PAM) ────────────────────────────
+        # Step 2 — forced password change (PAM)
         (ridx, match, _) = self.tn.expect(
-            [b"Current password:", b"@", b"$ ", b"# "],
-            10,
+            [b"Current password:", b"@", b"$ ", b"# "], 8,
         )
-
         if match and ridx == 0:
             self.logger.info("First-boot: changing expired password")
-            self._tn_write(VM_PASS)
-            self._tn_read_until(b"New password:", 15)
-            self._tn_write(TMP_PASS)
-            self._tn_read_until(b"Retype new password:", 15)
-            self._tn_write(TMP_PASS)
-            time.sleep(2)
-
+            self.tn.write(("%s\r" % VM_PASS).encode())
+            self.tn.expect([b"New password:"], 10)
+            self.tn.write(("%s\r" % TMP_PASS).encode())
+            self.tn.expect([b"Retype new password:"], 10)
+            self.tn.write(("%s\r" % TMP_PASS).encode())
+            time.sleep(1)
         elif match and ridx in (1, 2, 3):
             self.logger.debug("Already authenticated (overlay reuse)")
 
-        # ── Step 3: configure system (sudo, chage, hostname) ─────────────
-        self.logger.info(
-            "Configuring system (new password is '%s') ...", TMP_PASS
-        )
-        self._tn_write(
+        # Step 3 — configure system
+        self.logger.info("Configuring system ...")
+        self.tn.write((
             "echo '%s' | sudo -S bash -c '"
             "chage -M -1 %s && "
             "echo \"%s ALL=(ALL) NOPASSWD:ALL\" > /etc/sudoers.d/%s && "
-            "hostnamectl set-hostname %s'"
+            "hostnamectl set-hostname %s'\r"
             % (TMP_PASS, VM_USER, VM_USER, VM_USER, self.hostname)
-        )
-        time.sleep(4)
+        ).encode())
+        time.sleep(3)
 
-        # ── Step 4: verify ─────────────────────────────────────────────────
-        self._tn_write("exit")
-        time.sleep(0.5)
-        self._tn_write("")
-        time.sleep(0.5)
-        self._tn_write(VM_USER)
-        self._tn_read_until(b"Password:", 10)
-        self._tn_write(TMP_PASS)
-        time.sleep(1.5)
-
-        (r2, m2, _) = self.tn.expect(
-            [b"@", b"$ ", b"# ", b"Current password:", b"incorrect"],
-            8,
-        )
-
-        if m2 and r2 in (0, 1, 2):
-            self.logger.info(
-                "Password verified: '%s' / '%s'", VM_USER, TMP_PASS
-            )
+        # Step 4 — verify shell is still responsive (password was
+        # already changed by PAM in step 2)
+        self.tn.write(b"\r")
+        (_, m2, _) = self.tn.expect([b"$ ", b"# ", b"@"], 8)
+        if m2:
+            self.logger.info("Password verified: '%s' / '%s'", VM_USER, TMP_PASS)
         else:
-            self.logger.warning("Password verify skipped (ridx=%s)", r2)
+            self.logger.warning("Shell prompt not detected after config")
 
         self.logger.info("First-boot setup complete")
-
-
-    # ── NIC provisioning overrides ──────────────────────────────────────────
-    # Cumulus VX uses socket placeholders to fill PCI gaps so that switch port
-    # numbering (swpX) matches the topology interface numbering even when
-    # interfaces are sparsely numbered (e.g. eth1, eth4, eth6, eth7).
-
-    def nic_provision_delay(self):
-        """Override parent: discover highest provisioned NIC index without
-        truncating to a sequential range, so that sparse interface numbering
-        (e.g. eth1, eth4, eth6, eth7) is correctly handled."""
-        import pathlib
-
-        if self.num_provisioned_nics == 0:
-            if self.min_nics:
-                self.insuffucient_nics = True
-            return
-
-        self.logger.debug("waiting for provisioned interfaces to appear...")
-
-        inf_path = pathlib.Path("/sys/class/net/")
-        while True:
-            provisioned_nics = list(
-                inf_path.glob(f"{self.data_intf_prefix}*")
-            )
-            if len(provisioned_nics) >= self.num_provisioned_nics + 1:
-                nics = [
-                    int(re.search(pattern=r"\d+", string=nic.name).group())
-                    for nic in provisioned_nics
-                ]
-                # Accept any index >= start_eth (not a closed range)
-                nics = [nic for nic in nics if nic >= self.start_nic_eth_idx]
-                if nics:
-                    self.highest_provisioned_nic_num = max(nics)
-                self.logger.debug(
-                    "highest allocated interface id: %s",
-                    self.highest_provisioned_nic_num,
-                )
-                break
-            time.sleep(5)
-
-        if self.num_provisioned_nics < self.min_nics:
-            self.insuffucient_nics = True
-
-    def gen_nics(self):
-        """Override parent: loop bound is max(count, highest+1) so that
-        sparsely numbered interfaces are not lost.  Missing slots below the
-        highest provisioned NIC get socket placeholders so that PCI positions
-        stay aligned and swpX numbering inside Cumulus matches ethX."""
-        self.nic_provision_delay()
-
-        res = []
-        if self.conn_mode == "tc":
-            self.create_tc_tap_ifup()
-
-        start_eth = self.start_nic_eth_idx
-        end_eth = max(
-            self.start_nic_eth_idx + self.num_nics,
-            self.highest_provisioned_nic_num + 1,
-        )
-        pci_bus_ctr = 0
-        for i in range(start_eth, end_eth):
-            pci_bus_ctr += 1
-            x = pci_bus_ctr + 1 if "vEOS" in self.image else pci_bus_ctr
-            pci_bus = math.floor(x / self.nics_per_pci_bus) + 1
-            addr = (x % self.nics_per_pci_bus) + 1
-
-            if not os.path.exists(
-                f"/sys/class/net/{self.data_intf_prefix}{i}"
-            ):
-                if i >= self.highest_provisioned_nic_num:
-                    continue
-                # socket placeholder for gap
-                res.extend(
-                    [
-                        "-device",
-                        f"{self.nic_type},netdev=p{i:02d}"
-                        + (
-                            f",bus=pci.{pci_bus},addr=0x{addr:x}"
-                            if self.provision_pci_bus
-                            else ""
-                        ),
-                        "-netdev",
-                        f"socket,id=p{i:02d},listen=:{i + 10000:02d}",
-                    ]
-                )
-                continue
-
-            mac = self.get_intf_mac(
-                f"{self.data_intf_prefix}{i}"
-            ) or vrnetlab.gen_mac(i)
-            res.append("-device")
-            res.append(
-                f"{self.nic_type},netdev=p{i:02d},mac={mac}"
-                + (
-                    f",bus=pci.{pci_bus},addr=0x{addr:x}"
-                    if self.provision_pci_bus
-                    else ""
-                ),
-            )
-            if self.conn_mode == "tc":
-                res.append("-netdev")
-                res.append(
-                    f"tap,id=p{i:02d},ifname=tap{i},"
-                    "script=/etc/tc-tap-ifup,downscript=no"
-                )
-
-        return res
-
-    # ── end NIC overrides ────────────────────────────────────────────────────
 
 
 # ── VR subclass ─────────────────────────────────────────────────────────────────

--- a/nvidia/cumulus-vx/docker/launch.py
+++ b/nvidia/cumulus-vx/docker/launch.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# launch.py — Nvidia Cumulus VX vrnetlab launcher
+#
+# Modelled after the Juniper Apstra and Nokia CmgLinux launcher patterns.
+#
+# Key design decisions for Cumulus VX
+# ───────────────────────────────────
+# 1. HAS data-plane NICs — Cumulus VX is a network switch OS. Data-plane
+#    interfaces (swp1, swp2, …) are provisioned based on CLAB_INTFS.
+#
+# 2. MODERATE RAM — Default 4096 MB. 4 GB provides comfortable headroom for
+#    switchd, NVUE, and routing protocols.
+#
+# 3. FIRST-BOOT BOOTSTRAP — Cumulus VX enforces password change on first login.
+#    We handle this automatically via the serial console, setting the password
+#    back to the configured value and disabling expiry.
+#
+# 4. MEDIUM boot timeout — First boot typically completes within 3–5 minutes.
+# ==============================================================================
+
+import datetime
+import logging
+import math
+import os
+import re
+import signal
+import sys
+import time
+
+import vrnetlab
+
+
+# ── signal handlers ────────────────────────────────────────────────────────────
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+
+# ── TRACE log level ────────────────────────────────────────────────────────────
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+
+
+def trace(self, message, *args, **kws):
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+
+
+logging.Logger.trace = trace
+
+
+# ── tunables ────────────────────────────────────────────────────────────────────
+
+DEFAULT_RAM_MB = 4096
+
+
+# ── VM subclass ─────────────────────────────────────────────────────────────────
+
+class CumulusVX_vm(vrnetlab.VM):
+    def __init__(self, hostname, username, password, conn_mode):
+        # ── locate the Cumulus VX disk image ──────────────────────────────────
+        disk_image = None
+        for entry in os.listdir("/"):
+            if re.search(r"^cumulus-linux.*\.qcow2$", entry):
+                disk_image = "/" + entry
+                break
+
+        if disk_image is None:
+            raise RuntimeError(
+                "No Cumulus VX disk image found at /cumulus-linux*.qcow2. "
+                "Did you copy the qcow2 into the docker/ build context?"
+            )
+
+        self.hostname = hostname
+        self.conn_mode = conn_mode
+        self._bootstrap_done = False
+
+        # ── KVM-aware CPU selection ──────────────────────────────────────────
+        # -cpu host requires KVM; without /dev/kvm QEMU exits immediately and
+        # the monitor port never opens.  Use "max" for TCG which enables all
+        # features the emulator supports.
+        if os.path.exists("/dev/kvm"):
+            cpu_model = "host"
+        else:
+            cpu_model = "max"
+            logging.getLogger().warning(
+                "/dev/kvm not available — using TCG emulation "
+                "(switchd performance will be degraded)"
+            )
+
+        # ── initialise the vrnetlab base VM ───────────────────────────────────
+        super(CumulusVX_vm, self).__init__(
+            username,
+            password,
+            disk_image=disk_image,
+            ram=DEFAULT_RAM_MB,
+            cpu=cpu_model,
+        )
+
+        self.logger.info(f"Using Cumulus VX disk image: {disk_image}")
+
+        # Cumulus VX is a switch — data-plane NICs are provisioned from
+        # containerlab via CLAB_INTFS.
+        self.num_nics = int(os.environ.get("CLAB_INTFS", 0))
+        self.nic_type = "virtio-net-pci"
+
+        # NVUE REST API (HTTPS on 8765) — 8080 is already in the base class
+        self.mgmt_tcp_ports.append(8765)
+
+        # ── persistent overlay ────────────────────────────────────────────────
+        if os.path.isdir("/config"):
+            persistent_overlay = "/config/cumulus_overlay.qcow2"
+
+            if not os.path.exists(persistent_overlay):
+                vrnetlab.run_command([
+                    "qemu-img", "create",
+                    "-f", "qcow2",
+                    "-b", disk_image,
+                    "-F", "qcow2",
+                    persistent_overlay,
+                ])
+                self.logger.info(
+                    "Created persistent overlay at %s", persistent_overlay
+                )
+            else:
+                self.logger.info(
+                    "Reusing existing persistent overlay at %s",
+                    persistent_overlay,
+                )
+
+            for i, arg in enumerate(self.qemu_args):
+                if "file=" in arg and "-overlay" in arg:
+                    self.qemu_args[i] = (
+                        arg.split("file=")[0] + "file=" + persistent_overlay
+                    )
+                    self.logger.info(
+                        "Patched qemu_args drive to use persistent overlay"
+                    )
+                    break
+        else:
+            self.logger.warning(
+                "/config not mounted — overlay is ephemeral and will not "
+                "survive clab destroy. Create the bind-mount directory to "
+                "enable persistence."
+            )
+
+    # ── bootstrap ─────────────────────────────────────────────────────────────
+
+    def bootstrap_spin(self):
+        """Called repeatedly by the VR main loop until self.running is True.
+
+        Waits for a Cumulus Linux login prompt on the serial console, optionally
+        performs first-boot password setup, then waits for switchd to be active
+        before marking the VM as running.
+        """
+
+        if self.spins > 6000:
+            self.logger.debug("Too many spins -> restarting VM")
+            self.stop()
+            self.start()
+            return
+
+        (ridx, match, res) = self.tn.expect(
+            [b"login: ", b"Login: ", b"cumulus login: "],
+            1,
+        )
+
+        if match:
+            self.logger.debug("Cumulus VX login prompt detected")
+
+            if not self._bootstrap_done:
+                self._bootstrap_done = True
+                try:
+                    self._first_boot_setup()
+                except Exception as exc:
+                    self.logger.error(
+                        "First-boot setup failed (%s) — password may need "
+                        "manual change via serial console (port %d)",
+                        exc,
+                        5000 + self.num,
+                    )
+
+            # Cumulus-specific: wait for switchd to be active so that swp
+            # ports are fully initialised before reporting healthy.
+            if not self._switchd_is_ready():
+                self.spins += 1
+                return
+
+            self.running = True
+            self.tn.close()
+            startup_time = datetime.datetime.now() - self.start_time
+            self.logger.info("Startup complete in: %s", startup_time)
+            return
+
+        if res != b"":
+            self.logger.trace("OUTPUT: %s" % res.decode())
+            self.spins = 0
+
+        self.spins += 1
+
+    def _switchd_is_ready(self):
+        """Check whether switchd is active via the serial console.
+        Returns True if ``systemctl is-active switchd`` prints 'active'.
+        """
+        self._tn_write("")
+        time.sleep(0.5)
+        self._tn_write("systemctl is-active switchd 2>/dev/null")
+        time.sleep(2)
+        try:
+            (_, match, _) = self.tn.expect([b"active", b"inactive", b"failed"], 3)
+            if match:
+                self.logger.debug("switchd status: %s", match.group(0).decode())
+                return match.group(0) == b"active"
+        except Exception:
+            pass
+        return False
+
+    def _tn_write(self, text):
+        """Write a line to the serial console."""
+        self.tn.write(("%s\r" % text).encode())
+        self.logger.trace("SENT: %s", text)
+
+    def _tn_read_until(self, pattern, timeout=10):
+        """Read from the serial console until *pattern* (bytes) is seen."""
+        self.logger.trace("WAITING for: %s", pattern.decode(errors="replace"))
+        (ridx, match, res) = self.tn.expect([pattern], timeout)
+        if match:
+            self.logger.trace("MATCHED: %s", pattern.decode(errors="replace"))
+        return ridx, match, res
+
+    def _first_boot_setup(self):
+        """Handle Cumulus VX first-boot forced password change.
+
+        A fresh Cumulus VX image has user ``cumulus`` / ``cumulus`` with an
+        expired password.  We log in, satisfy the PAM password change with
+        ``Nsn1234!``, enable NOPASSWD sudo, disable password expiry, and
+        set the hostname.
+        """
+
+        VM_USER = "cumulus"
+        VM_PASS = "cumulus"
+        TMP_PASS = "Nsn1234!"
+
+        self.logger.info("First-boot setup for '%s' ...", VM_USER)
+
+        # ── Step 1: log in ──────────────────────────────────────────────────
+        self._tn_write(VM_USER)
+        self._tn_read_until(b"Password:", 15)
+        self._tn_write(VM_PASS)
+        time.sleep(1)
+
+        # ── Step 2: forced password change (PAM) ────────────────────────────
+        (ridx, match, _) = self.tn.expect(
+            [b"Current password:", b"@", b"$ ", b"# "],
+            10,
+        )
+
+        if match and ridx == 0:
+            self.logger.info("First-boot: changing expired password")
+            self._tn_write(VM_PASS)
+            self._tn_read_until(b"New password:", 15)
+            self._tn_write(TMP_PASS)
+            self._tn_read_until(b"Retype new password:", 15)
+            self._tn_write(TMP_PASS)
+            time.sleep(2)
+
+        elif match and ridx in (1, 2, 3):
+            self.logger.debug("Already authenticated (overlay reuse)")
+
+        # ── Step 3: configure system (sudo, chage, hostname) ─────────────
+        self.logger.info(
+            "Configuring system (new password is '%s') ...", TMP_PASS
+        )
+        self._tn_write(
+            "echo '%s' | sudo -S bash -c '"
+            "chage -M -1 %s && "
+            "echo \"%s ALL=(ALL) NOPASSWD:ALL\" > /etc/sudoers.d/%s && "
+            "hostnamectl set-hostname %s'"
+            % (TMP_PASS, VM_USER, VM_USER, VM_USER, self.hostname)
+        )
+        time.sleep(4)
+
+        # ── Step 4: verify ─────────────────────────────────────────────────
+        self._tn_write("exit")
+        time.sleep(0.5)
+        self._tn_write("")
+        time.sleep(0.5)
+        self._tn_write(VM_USER)
+        self._tn_read_until(b"Password:", 10)
+        self._tn_write(TMP_PASS)
+        time.sleep(1.5)
+
+        (r2, m2, _) = self.tn.expect(
+            [b"@", b"$ ", b"# ", b"Current password:", b"incorrect"],
+            8,
+        )
+
+        if m2 and r2 in (0, 1, 2):
+            self.logger.info(
+                "Password verified: '%s' / '%s'", VM_USER, TMP_PASS
+            )
+        else:
+            self.logger.warning("Password verify skipped (ridx=%s)", r2)
+
+        self.logger.info("First-boot setup complete")
+
+
+    # ── NIC provisioning overrides ──────────────────────────────────────────
+    # Cumulus VX uses socket placeholders to fill PCI gaps so that switch port
+    # numbering (swpX) matches the topology interface numbering even when
+    # interfaces are sparsely numbered (e.g. eth1, eth4, eth6, eth7).
+
+    def nic_provision_delay(self):
+        """Override parent: discover highest provisioned NIC index without
+        truncating to a sequential range, so that sparse interface numbering
+        (e.g. eth1, eth4, eth6, eth7) is correctly handled."""
+        import pathlib
+
+        if self.num_provisioned_nics == 0:
+            if self.min_nics:
+                self.insuffucient_nics = True
+            return
+
+        self.logger.debug("waiting for provisioned interfaces to appear...")
+
+        inf_path = pathlib.Path("/sys/class/net/")
+        while True:
+            provisioned_nics = list(
+                inf_path.glob(f"{self.data_intf_prefix}*")
+            )
+            if len(provisioned_nics) >= self.num_provisioned_nics + 1:
+                nics = [
+                    int(re.search(pattern=r"\d+", string=nic.name).group())
+                    for nic in provisioned_nics
+                ]
+                # Accept any index >= start_eth (not a closed range)
+                nics = [nic for nic in nics if nic >= self.start_nic_eth_idx]
+                if nics:
+                    self.highest_provisioned_nic_num = max(nics)
+                self.logger.debug(
+                    "highest allocated interface id: %s",
+                    self.highest_provisioned_nic_num,
+                )
+                break
+            time.sleep(5)
+
+        if self.num_provisioned_nics < self.min_nics:
+            self.insuffucient_nics = True
+
+    def gen_nics(self):
+        """Override parent: loop bound is max(count, highest+1) so that
+        sparsely numbered interfaces are not lost.  Missing slots below the
+        highest provisioned NIC get socket placeholders so that PCI positions
+        stay aligned and swpX numbering inside Cumulus matches ethX."""
+        self.nic_provision_delay()
+
+        res = []
+        if self.conn_mode == "tc":
+            self.create_tc_tap_ifup()
+
+        start_eth = self.start_nic_eth_idx
+        end_eth = max(
+            self.start_nic_eth_idx + self.num_nics,
+            self.highest_provisioned_nic_num + 1,
+        )
+        pci_bus_ctr = 0
+        for i in range(start_eth, end_eth):
+            pci_bus_ctr += 1
+            x = pci_bus_ctr + 1 if "vEOS" in self.image else pci_bus_ctr
+            pci_bus = math.floor(x / self.nics_per_pci_bus) + 1
+            addr = (x % self.nics_per_pci_bus) + 1
+
+            if not os.path.exists(
+                f"/sys/class/net/{self.data_intf_prefix}{i}"
+            ):
+                if i >= self.highest_provisioned_nic_num:
+                    continue
+                # socket placeholder for gap
+                res.extend(
+                    [
+                        "-device",
+                        f"{self.nic_type},netdev=p{i:02d}"
+                        + (
+                            f",bus=pci.{pci_bus},addr=0x{addr:x}"
+                            if self.provision_pci_bus
+                            else ""
+                        ),
+                        "-netdev",
+                        f"socket,id=p{i:02d},listen=:{i + 10000:02d}",
+                    ]
+                )
+                continue
+
+            mac = self.get_intf_mac(
+                f"{self.data_intf_prefix}{i}"
+            ) or vrnetlab.gen_mac(i)
+            res.append("-device")
+            res.append(
+                f"{self.nic_type},netdev=p{i:02d},mac={mac}"
+                + (
+                    f",bus=pci.{pci_bus},addr=0x{addr:x}"
+                    if self.provision_pci_bus
+                    else ""
+                ),
+            )
+            if self.conn_mode == "tc":
+                res.append("-netdev")
+                res.append(
+                    f"tap,id=p{i:02d},ifname=tap{i},"
+                    "script=/etc/tc-tap-ifup,downscript=no"
+                )
+
+        return res
+
+    # ── end NIC overrides ────────────────────────────────────────────────────
+
+
+# ── VR subclass ─────────────────────────────────────────────────────────────────
+
+class CumulusVX(vrnetlab.VR):
+    def __init__(self, hostname, username, password, conn_mode):
+        super(CumulusVX, self).__init__(username, password)
+        self.vms = [
+            CumulusVX_vm(hostname, username, password, conn_mode)
+        ]
+
+
+# ── entry point ─────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Nvidia Cumulus VX vrnetlab launcher"
+    )
+    parser.add_argument(
+        "--trace",
+        action="store_true",
+        help="Enable trace level logging",
+    )
+    parser.add_argument(
+        "--username",
+        default="cumulus",
+        help="Cumulus Linux admin username (default: cumulus)",
+    )
+    parser.add_argument(
+        "--password",
+        default="Nsn1234!",
+        help="Cumulus Linux admin password (default: Nsn1234!)",
+    )
+    parser.add_argument(
+        "--hostname",
+        default="cumulus",
+        help="VM hostname (passed by containerlab generic_vm kind)",
+    )
+    parser.add_argument(
+        "--connection-mode",
+        default="tc",
+        help="Connection mode to use in the datapath (default: tc)",
+    )
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s %(name)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    vr = CumulusVX(
+        args.hostname,
+        args.username,
+        args.password,
+        args.connection_mode,
+    )
+    vr.start()

--- a/nvidia/cumulus-vx/docker/launch.py
+++ b/nvidia/cumulus-vx/docker/launch.py
@@ -221,9 +221,8 @@ class CumulusVX_vm(vrnetlab.VM):
 
     def _switchd_is_ready(self):
         """Check whether switchd is active via the serial console."""
-        self.tn.write(b"\r")
-        time.sleep(0.5)
-        self.tn.write(b"systemctl is-active switchd 2>/dev/null\r")
+        self.wait_write("\r", None)
+        self.wait_write("systemctl is-active switchd 2>/dev/null", None)
         time.sleep(2)
         try:
             (_, match, _) = self.tn.expect([b"active", b"inactive", b"failed"], 3)
@@ -243,10 +242,8 @@ class CumulusVX_vm(vrnetlab.VM):
         self.logger.info("First-boot setup for '%s' ...", VM_USER)
 
         # Step 1 — log in
-        self.tn.write(("%s\r" % VM_USER).encode())
-        self.tn.expect([b"Password:"], 10)
-        self.tn.write(("%s\r" % VM_PASS).encode())
-        time.sleep(0.5)
+        self.wait_write(VM_USER, None)
+        self.wait_write(VM_PASS, "Password:")
 
         # Step 2 — forced password change (PAM)
         (ridx, match, _) = self.tn.expect(
@@ -255,31 +252,28 @@ class CumulusVX_vm(vrnetlab.VM):
         )
         if match and ridx == 0:
             self.logger.info("First-boot: changing expired password")
-            self.tn.write(("%s\r" % VM_PASS).encode())
-            self.tn.expect([b"New password:"], 10)
-            self.tn.write(("%s\r" % NEW_PASS).encode())
-            self.tn.expect([b"Retype new password:"], 10)
-            self.tn.write(("%s\r" % NEW_PASS).encode())
+            self.wait_write(VM_PASS, None)
+            self.wait_write(NEW_PASS, "New password:")
+            self.wait_write(NEW_PASS, "Retype new password:")
             time.sleep(1)
         elif match and ridx in (1, 2, 3):
             self.logger.debug("Already authenticated (overlay reuse)")
 
         # Step 3 — configure system
         self.logger.info("Configuring system ...")
-        self.tn.write(
-            (
-                "echo '%s' | sudo -S bash -c '"
-                "chage -M -1 %s && "
-                'echo "%s ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/%s && '
-                "hostnamectl set-hostname %s'\r"
-                % (NEW_PASS, VM_USER, VM_USER, VM_USER, self.hostname)
-            ).encode()
+        self.wait_write(
+            "echo '%s' | sudo -S bash -c '"
+            "chage -M -1 %s && "
+            'echo "%s ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/%s && '
+            "hostnamectl set-hostname %s'"
+            % (NEW_PASS, VM_USER, VM_USER, VM_USER, self.hostname),
+            None,
         )
         time.sleep(3)
 
         # Step 4 — verify shell is still responsive (password was
         # already changed by PAM in step 2)
-        self.tn.write(b"\r")
+        self.wait_write("\r", None)
         (_, m2, _) = self.tn.expect([b"$ ", b"# ", b"@"], 8)
         if m2:
             self.logger.info("Password verified: '%s' / '%s'", VM_USER, NEW_PASS)


### PR DESCRIPTION
## Summary

Adds vrnetlab QEMU support for the NVIDIA Cumulus VX virtual switch (5.15.1). Cumulus VX runs inside QEMU within a Docker container, with automatic first-boot password change, persistent overlay, tc-mirror datapath, and switchd-aware health checks.

## Changes

| File | Purpose |
|------|---------|
| `nvidia/cumulus-vx/docker/launch.py` | VM launcher with first-boot bootstrap, switchd health, sparse NIC handling |
| `nvidia/cumulus-vx/docker/Dockerfile` | Based on `vrnetlab-base:0.2.1` |
| `nvidia/cumulus-vx/Makefile` | Extracts version from qcow2 filename |
| `nvidia/cumulus-vx/README.md` | Build and usage instructions |

No changes to `common/vrnetlab.py`. All Cumulus-specific logic lives in `launch.py` subclass overrides.

## Key design decisions

**num_nics = 16 (not CLAB_INTFS).** Cumulus VX uses socket placeholders to fill PCI gaps so `swpX` numbering matches topology interface indices even when sparsely numbered (e.g. eth1, eth4, eth6, eth7). A fixed `num_nics = 16` gives the base-class `gen_nics` enough PCI slots for correct placeholder generation, eliminating a PCI address collision bug where gap devices and real devices used inconsistent address formulas.

**Bootstrap timing fix.** `_bootstrap_done` is set only after `_first_boot_setup()` succeeds. If setup fails, the flag stays unset and the bootstrap loop retries on the next login prompt. After first boot, the loop polls `switchd` directly without looking for a login prompt, avoiding a deadlock when the VM reuses a persistent overlay and no login prompt appears.

**No custom gen_nics override.** The earlier custom `gen_nics`/`nic_provision_delay` had a PCI address calculation bug — gap (socket placeholder) devices used `(x % 32) + 1` while real devices used `x` directly. With sparse interface numbering (e.g. eth1, eth4-7 with gaps at eth2-3), this caused QEMU PCI slot collisions and VM crashes. Falling back to the parent class implementation with `num_nics = 16` resolves this cleanly.

## Build

Place a Cumulus VX qcow2 image in the directory and run `make`:

```bash
cd nvidia/cumulus-vx
# place cumulus-linux-5.15.1-vx-amd64-qemu.qcow2 here
make
```

Resulting image: `vrnetlab/nvidia_cumulus-vx:5.15.1`

## Test plan

- [x] Build with Cumulus VX 5.15.1 qcow2
- [x] First-boot forced password change completes
- [x] Sparse interface numbering (eth1, eth4-7) → correct swpX inside VM
- [x] PCI slot collision eliminated (6-node MLAG topology deployed successfully)
- [x] Persistent overlay survives container restart
- [x] switchd health check gates healthy status
- [x] Bootstrap retries on failed first-boot setup
- [x] Tested with 4 topologies: large-scale (6 nodes), failover (6 nodes), multirail (5 nodes), qos (2 nodes)

## Dependencies

Companion containerlab PR: adds `kind/cumulus_vm` node type.