### PR TITLE
bugfix: Add timeout to FTP client connection.

### DIFF
--- a/mikrotik/routeros/docker/launch.py
+++ b/mikrotik/routeros/docker/launch.py
@@ -38,6 +38,9 @@ ROS_MGMT_ADDR = "172.31.255.30"
 PREFIX_LENGTH = "30"
 CONFIG_FILE = "/ftpboot/config.auto.rsc"
 
+# Get FTP client connect timeout from ENV if provided
+FTP_TIMEOUT = vrnetlab.getenv_uint("FTP_TIMEOUT", 30)
+
 
 def trace(self, message, *args, **kws):
     # Yes, logger takes its '*args' as 'args'.
@@ -220,7 +223,7 @@ class ROS_vm(vrnetlab.VM):
         max_attempts = 5
         for i in range(1, max_attempts + 1):
             try:
-                with ftplib.FTP(ROS_MGMT_ADDR, self.username, self.password) as session:
+                with ftplib.FTP(ROS_MGMT_ADDR, self.username, self.password, '', FTP_TIMEOUT) as session:
                     with open(CONFIG_FILE, "rb") as file:  # file to send
                         session.storbinary(
                             "STOR config.auto.rsc", file
@@ -233,7 +236,7 @@ class ROS_vm(vrnetlab.VM):
                 if i != max_attempts:
                     self.logger.info("Trying again")
                 else:
-                    self.logger.info(f"Giving up after {max_attempts}")
+                    self.logger.info(f"Giving up after {max_attempts} attempts")
 
         self.logger.info("config pushed via FTP")
 


### PR DESCRIPTION
When a custom config script causes the RouterOS side to drop the connection mid-load, the launch script hangs indefinitely.  Health checks are never run, so the container is marked unhealthy - even when the script itself completed successfully.

An example of this happening is if the script configures the management port as part of a VRF.

This pull request adds a 30-second default timeout on the ftplib.FTP() client, configurable via the `FTP_TIMEOUT` environment variable.

In cases where the RouterOS side drops the connection, the FTP push will fail after the timeout, however, it allows the launch script to continue and health checks to succeed.

```
2026-06-09 09:48:58,385: launch         INFO completed bootstrap configuration
2026-06-09 09:48:58,386: launch         INFO Pushing config via FTP
2026-06-09 09:49:29,456: launch         INFO FTP attempt #1 failed due to timed out
2026-06-09 09:49:29,457: launch         INFO Trying again
2026-06-09 09:49:29,458: launch         INFO FTP attempt #2 failed due to [Errno 111] Connection refused
2026-06-09 09:49:29,459: launch         INFO Trying again
2026-06-09 09:49:29,460: launch         INFO FTP attempt #3 failed due to [Errno 111] Connection refused
2026-06-09 09:49:29,460: launch         INFO Trying again
2026-06-09 09:49:29,462: launch         INFO FTP attempt #4 failed due to [Errno 111] Connection refused
2026-06-09 09:49:29,462: launch         INFO Trying again
2026-06-09 09:49:29,464: launch         INFO FTP attempt #5 failed due to [Errno 111] Connection refused
2026-06-09 09:49:29,464: launch         INFO Giving up after 5 attempts
2026-06-09 09:49:29,465: launch         INFO config pushed via FTP
2026-06-09 09:49:29,465: launch         INFO Startup complete in: 0:01:16.965788
```

Previously it would hang indefinitely at the `Pushing config via FTP` step.

*Note: The odd grammar in the time out failure message is just a pre-existing quirk in the way exceptions are formatted into log messages.*