### PR TITLE
Migrate from telnetlib to scrapli

### DIFF
--- a/cisco/asav/docker/launch.py
+++ b/cisco/asav/docker/launch.py
@@ -53,7 +53,6 @@ class ASAv_vm(vrnetlab.VM):
             disk_image=disk_image,
             ram=2048,
             cpu="Nehalem",
-            use_scrapli=True,
         )
         self.hostname = hostname
         self.nic_type = "e1000"

--- a/cisco/c8000v/docker/launch.py
+++ b/cisco/c8000v/docker/launch.py
@@ -54,7 +54,7 @@ class C8000v_vm(vrnetlab.VM):
             self.license = True
 
         super().__init__(
-            username, password, disk_image=disk_image, ram=4096, use_scrapli=True
+            username, password, disk_image=disk_image, ram=4096
         )
         self.install_mode = install_mode
         self.hostname = hostname

--- a/cisco/cat9kv/docker/launch.py
+++ b/cisco/cat9kv/docker/launch.py
@@ -54,7 +54,6 @@ class cat9kv_vm(vrnetlab.VM):
             smp=f"cores={vcpu},threads=1,sockets=1",
             ram=ram,
             min_dp_nics=8,
-            use_scrapli=True,
         )
         self.hostname = hostname
         self.conn_mode = conn_mode

--- a/cisco/csr1000v/docker/launch.py
+++ b/cisco/csr1000v/docker/launch.py
@@ -56,7 +56,7 @@ class CSR_vm(vrnetlab.VM):
             self.license = True
 
         super(CSR_vm, self).__init__(
-            username, password, disk_image=disk_image, use_scrapli=True
+            username, password, disk_image=disk_image
         )
 
         self.install_mode = install_mode

--- a/cisco/n9kv/docker/launch.py
+++ b/cisco/n9kv/docker/launch.py
@@ -54,7 +54,6 @@ class N9KV_vm(vrnetlab.VM):
             ram=10240,
             smp=4,
             cpu="host",
-            use_scrapli=True,
         )
         self.hostname = hostname
         self.conn_mode = conn_mode

--- a/cisco/nxos/docker/launch.py
+++ b/cisco/nxos/docker/launch.py
@@ -50,7 +50,6 @@ class NXOS_vm(vrnetlab.VM):
             disk_image=disk_image,
             ram=4096,
             smp="2",
-            use_scrapli=True,
         )
         self.credentials = [["admin", "admin"]]
         self.hostname = hostname

--- a/cisco/vios/docker/launch.py
+++ b/cisco/vios/docker/launch.py
@@ -73,7 +73,6 @@ class VIOS_vm(vrnetlab.VM):
             smp="1",
             ram=ram,
             driveif="virtio",
-            use_scrapli=True,
         )
 
         self.hostname = hostname

--- a/cisco/xrv/docker/launch.py
+++ b/cisco/xrv/docker/launch.py
@@ -45,7 +45,7 @@ class XRV_vm(vrnetlab.VM):
             if re.search(".vmdk", e):
                 disk_image = "/" + e
         super(XRV_vm, self).__init__(
-            username, password, disk_image=disk_image, ram=3072, use_scrapli=True
+            username, password, disk_image=disk_image, ram=3072
         )
         self.hostname = hostname
         self.conn_mode = conn_mode

--- a/cisco/xrv9k/docker/launch.py
+++ b/cisco/xrv9k/docker/launch.py
@@ -54,7 +54,6 @@ class XRv9k_vm(vrnetlab.VM):
             disk_image=disk_image,
             ram=ram,
             smp=f"cores={vcpu},threads=1,sockets=1",
-            use_scrapli=True,
             cpu="host,+ssse3,+sse4.1,+sse4.2,+x2apic",
         )
         

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -12,15 +12,11 @@ import shutil
 import subprocess
 import sys
 import tarfile
-import telnetlib
 import tempfile
 import time
 from pathlib import Path
 
-try:
-    from scrapli import Driver
-except ImportError:
-    pass
+from scrapli import Driver
 
 MAX_RETRIES = 60
 
@@ -83,6 +79,70 @@ def boot_delay():
         time.sleep(int(delay))
 
 
+class _Console:
+    """telnetlib-compatible wrapper around a scrapli channel (qemu serial console / monitor)."""
+
+    def __init__(self, driver):
+        self._driver = driver
+
+    def open(self):
+        self._driver.open()
+
+    def close(self):
+        self._driver.close()
+
+    def write(self, data):
+        if isinstance(data, bytes):
+            data = data.decode(errors="ignore")
+        self._driver.channel.write(data)
+
+    def _read(self):
+        data = self._driver.channel.read()
+        if data:
+            # mirror console output to stdout so it shows up in docker logs
+            sys.stdout.buffer.write(data)
+            sys.stdout.buffer.flush()
+        return data
+
+    def read_very_eager(self):
+        """Return whatever bytes are currently available (telnetlib-compatible)."""
+        return self._read()
+
+    def read_until(self, expected, timeout=None):
+        """Read until the literal expected bytes are seen, or timeout (telnetlib-compatible)."""
+        if isinstance(expected, str):
+            expected = expected.encode()
+        buf = b""
+        t_end = time.time() + timeout if timeout else None
+        while expected not in buf:
+            data = self._read()
+            buf += data
+            if not data:
+                time.sleep(0.1)
+            if t_end and time.time() > t_end:
+                break
+        return buf
+
+    def expect(self, regex_list, timeout=None):
+        """Regex-match byte patterns against the stream (telnetlib.expect-compatible).
+
+        Returns (index, match, buffer), or (-1, None, buffer) on timeout.
+        """
+        buf = b""
+        t_end = time.time() + timeout if timeout else None
+        while True:
+            data = self._read()
+            buf += data
+            if not data:
+                time.sleep(0.1)
+            for i, pat in enumerate(regex_list):
+                match = re.search(pat.decode(), buf.decode(errors="ignore"))
+                if match:
+                    return i, match, buf
+            if t_end and time.time() > t_end:
+                return -1, None, buf
+
+
 class VM:
     def __str__(self):
         return self.__class__.__name__
@@ -110,11 +170,9 @@ class VM:
         mgmt_intf="eth0",
         mgmt_dhcp=False,
         min_dp_nics=0,
-        use_scrapli=False,
         data_intf_prefix="eth",
         arch="x86_64",
     ):
-        self.use_scrapli = use_scrapli
         self.arch = arch
 
         # configure logging
@@ -129,38 +187,39 @@ class VM:
         
         scrapli_log_level = logging.DEBUG if os.getenv("DEBUG_SCRAPLI", "false").lower() == "true" else logging.INFO
         self.scrapli_logger.setLevel(scrapli_log_level)
-        
-        
 
-        # configure scrapli
-        if self.use_scrapli:
-            # init scrapli_tn -- main telnet device
-            scrapli_tn_dev = {
-                "host": "127.0.0.1",
-                "port": 5000 + num,
-                "auth_bypass": True,
-                "auth_strict_key": False,
-                "transport": "telnet",
-                "timeout_socket": 3600,
-                "timeout_transport": 3600,
-                "timeout_ops": 3600,
-            }
+        # init scrapli_tn -- main telnet device
+        scrapli_tn_dev = {
+            "host": "127.0.0.1",
+            "port": 5000 + num,
+            "auth_bypass": True,
+            "auth_strict_key": False,
+            "transport": "telnet",
+            "timeout_socket": 3600,
+            "timeout_transport": 3600,
+            "timeout_ops": 3600,
+        }
 
-            self.scrapli_tn = Driver(**scrapli_tn_dev)
+        self.scrapli_tn = Driver(**scrapli_tn_dev)
 
-            # init scrapli_qm_dev -- qemu monitor device
-            scrapli_qm_dev = {
-                "host": "127.0.0.1",
-                "port": 4000 + num,
-                "auth_bypass": True,
-                "auth_strict_key": False,
-                "transport": "telnet",
-                "timeout_socket": 3600,
-                "timeout_transport": 3600,
-                "timeout_ops": 3600,
-            }
+        # init scrapli_qm_dev -- qemu monitor device
+        scrapli_qm_dev = {
+            "host": "127.0.0.1",
+            "port": 4000 + num,
+            "auth_bypass": True,
+            "auth_strict_key": False,
+            "transport": "telnet",
+            "timeout_socket": 3600,
+            "timeout_transport": 3600,
+            "timeout_ops": 3600,
+        }
 
-            self.scrapli_qm = Driver(**scrapli_qm_dev)
+        self.scrapli_qm = Driver(**scrapli_qm_dev)
+
+        # telnetlib-compatible facades the launchers use: self.tn drives the
+        # serial console, self.qm the qemu monitor.
+        self.tn = _Console(self.scrapli_tn)
+        self.qm = _Console(self.scrapli_qm)
 
         # username / password to configure
         self.username = username
@@ -172,7 +231,6 @@ class VM:
         self.running = False
         self.spins = 0
         self.p = None
-        self.tn = None
 
         self._ram = ram
         self._cpu = cpu
@@ -365,11 +423,7 @@ class VM:
         mgmt_passthrough_coloured = format_bool_color(
             self.mgmt_passthrough, "Enabled", "Disabled"
         )
-        use_scrapli_coloured = format_bool_color(
-            self.use_scrapli, "Enabled", "Disabled"
-        )
 
-        self.logger.info(f"Scrapli: {use_scrapli_coloured}")
         self.logger.info(f"Transparent mgmt interface: {mgmt_passthrough_coloured}")
 
         self.start_time = datetime.datetime.now()
@@ -424,10 +478,7 @@ class VM:
 
         for i in range(1, MAX_RETRIES + 1):
             try:
-                if self.use_scrapli:
-                    self.scrapli_qm.open()
-                else:
-                    self.qm = telnetlib.Telnet("127.0.0.1", 4000 + self.num)
+                self.scrapli_qm.open()
                 break
             except:
                 self.logger.error(
@@ -445,13 +496,7 @@ class VM:
 
         for i in range(1, MAX_RETRIES + 1):
             try:
-                if self.use_scrapli:
-                    self.scrapli_tn.open()
-                else:
-                    self.tn = telnetlib.Telnet("127.0.0.1", 5000 + self.num)
-                    # This enables super verbose telnetlib debugging
-                    # if self.logger.isEnabledFor(logging.DEBUG):
-                    #     self.tn.set_debuglevel(2)
+                self.scrapli_tn.open()
                 break
             except:
                 self.logger.error(
@@ -477,12 +522,8 @@ class VM:
 
             # Close serial console connection to free it for external access
             try:
-                if self.use_scrapli:
-                    self.scrapli_tn.close()
-                    self.logger.info("Closed scrapli serial connection")
-                else:
-                    self.tn.close()
-                    self.logger.info("Closed telnet serial connection")
+                self.scrapli_tn.close()
+                self.logger.info("Closed scrapli serial connection")
             except Exception as e:
                 self.logger.warning(f"Could not close serial connection: {e}")
 
@@ -892,11 +933,8 @@ class VM:
         """Wait for something on the serial port and then send command
 
         Defaults to using self.tn as connection but this can be overridden
-        by passing a telnetlib.Telnet object in the con argument.
+        by passing self.qm (the qemu monitor) in the con argument.
         """
-
-        if self.use_scrapli:
-            return self.wait_write_scrapli(cmd, wait)
 
         con_name = "custom con"
         if con is None:
@@ -933,30 +971,6 @@ class VM:
 
         self.logger.debug(f"writing to {con_name}: '{cmd}'")
         con.write("{}\r".format(cmd).encode())
-
-    def wait_write_scrapli(self, cmd, wait="__defaultpattern__"):
-        """
-        Wait for something on the serial port and then send command using Scrapli telnet channel
-
-        Arguments are:
-        - cmd: command to send (string)
-        - wait: prompt to wait for before sending command, defaults to # (string)
-        """
-        if wait:
-            # use class default wait pattern if none was explicitly specified
-            if wait == "__defaultpattern__":
-                wait = self.wait_pattern
-
-            self.logger.info(f"Waiting on console for: '{wait}'")
-
-            self.con_read_until(wait)
-
-        time.sleep(0.1)  # don't write to the console too fast
-
-        self.write_to_stdout(b"\n")
-
-        self.logger.info(f"Writing to console: '{cmd}'")
-        self.scrapli_tn.channel.write(f"{cmd}\r")
 
     def con_expect(self, regex_list, timeout=None):
         """
@@ -1050,17 +1064,11 @@ class VM:
     def _qemu_monitor_cmd(self, cmd, wait=False):
         """Send command to QEMU monitor. Returns output if wait is True."""
         try:
-            if self.use_scrapli:
-                self.scrapli_qm.channel.write(f"{cmd}\r")
-            else:
-                self.qm.write(f"{cmd}\r".encode())
+            self.qm.write(f"{cmd}\r".encode())
 
             if wait:
                 time.sleep(0.5)
-                if self.use_scrapli:
-                    return self.scrapli_qm.channel.read().decode()
-                else:
-                    return self.qm.read_very_eager().decode()
+                return self.qm.read_very_eager().decode()
             return None
         except Exception as e:
             self.logger.error(f"Failed to communicate with QEMU monitor: {e}")

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -478,6 +478,10 @@ class VM:
 
         for i in range(1, MAX_RETRIES + 1):
             try:
+                try:
+                    self.scrapli_qm.close()
+                except Exception:
+                    pass
                 self.scrapli_qm.open()
                 break
             except:
@@ -496,6 +500,10 @@ class VM:
 
         for i in range(1, MAX_RETRIES + 1):
             try:
+                try:
+                    self.scrapli_tn.close()
+                except Exception:
+                    pass
                 self.scrapli_tn.open()
                 break
             except:

--- a/f5_bigip/docker/launch.py
+++ b/f5_bigip/docker/launch.py
@@ -8,7 +8,6 @@ import os
 import signal
 import subprocess
 import sys
-import telnetlib
 import tempfile
 import textwrap
 import time

--- a/hp/vsr1000/docker/launch.py
+++ b/hp/vsr1000/docker/launch.py
@@ -6,7 +6,6 @@ import os
 import re
 import signal
 import sys
-import telnetlib
 import time
 
 import vrnetlab
@@ -88,7 +87,6 @@ quit
                 self.logger.debug("Done writing to QEMU Monitor")
                 self.logger.debug("Switching to line aux0")
 
-                self.tn = telnetlib.Telnet("127.0.0.1", 5000 + self.num)
 
                 # run main config!
                 self.bootstrap_config()

--- a/nokia/sros/docker/launch.py
+++ b/nokia/sros/docker/launch.py
@@ -914,7 +914,6 @@ class SROS_vm(vrnetlab.VM):
             ram=ram,
             driveif="virtio",
             smp=f"{cpu}",
-            use_scrapli=True,
         )
 
         self.nic_type = "virtio-net-pci"

--- a/spirent/vstc/docker/launch.py
+++ b/spirent/vstc/docker/launch.py
@@ -41,7 +41,7 @@ class STC_vm(vrnetlab.VM):
                 disk_image = "/" + e
 
         super(STC_vm, self).__init__(
-            username, password, disk_image=disk_image, use_scrapli=True, min_dp_nics=1, mgmt_passthrough=True
+            username, password, disk_image=disk_image, min_dp_nics=1, mgmt_passthrough=True
         )
 
         self.hostname = hostname


### PR DESCRIPTION
telnetlib is removed in Python 3.13 and must be phased out to allow a base image / Python version bump. This PR migrates all node kinds off telnetlib to scrapli via a small compatibility shim.

**NB:** I have only been able to do limited testing on this due to my lab currently being out of service. 