### PR TITLE
routeros: Add `speed` and `duplex` parameters to `nic_type` to fix issues with LACP

### DIFF
--- a/mikrotik/routeros/docker/launch.py
+++ b/mikrotik/routeros/docker/launch.py
@@ -79,7 +79,7 @@ class ROS_vm(vrnetlab.VM):
 
         self.hostname = hostname
         self.conn_mode = conn_mode
-        self.nic_type = "virtio-net"  # "e1000" is default but breaks mtu > 1500 on vlan subinterfaces on RouterOS 6.x.x
+        self.nic_type = "virtio-net,speed=10000,duplex=full"  # "e1000" is default but breaks mtu > 1500 on vlan subinterfaces on RouterOS 6.x.x
         self.num_nics = 31
 
         # set up bridge for management interface to a localhost


### PR DESCRIPTION
*tl;dr: Set speed/duplex on the RouterOS virtio-net NICs so LACP/802.3ad negotiates, without breaking #207's MTU fix.*

PR #207 changed the `nic_type` for RouterOS to `virtio-net` to correct an MTU issue that impacts RouterOS 6.x.  It's noted in this PR that it has a known side-effect of breaking LACP (https://github.com/srl-labs/vrnetlab/issues/207#issuecomment-2185362673).

The reason LACP breaks is not due to an uncorrectable driver issue, but rather that 802.3ad LACP will not come up (It wont even start sending LACP PDUs) without knowing the Speed and Duplex of a link.

This is easily corrected by providing those parameters to the `virtio-net` device:

```
$ qemu-system-x86_64 -device virtio-net,help | grep -E "speed|duplex"
  duplex=<str>
  speed=<int32>          -  (default: -1)
 ```

In this PR I've set these values to:
  * speed=10000: 10G is a pretty typical default interface speed in virtual environments.
  * duplex=full: Required for LACP to operate.

I've tested before and after using RouterOS 7.14.3, as below.

## Before
```
[admin@rtr1] > /int eth mon 1,2 once
                     name: ether2   ether3
                   status: link-ok  link-ok
              full-duplex: no       no           <-- No duplex set
                supported:
    default-cable-setting: standard standard

[admin@rtr1] > /int bond monitor bonding1 once
                  mode: 802.3ad
          active-ports: ether2
        inactive-ports: ether3                   <-- One port inactive
        lacp-system-id: AA:C1:AB:C4:30:D9        <-- System ID only, no partner ID
  lacp-system-priority: 65535

[admin@rtr1] > /int bond monitor bonding1 once
                  mode: 802.3ad
          active-ports: ether2
        inactive-ports: ether3
        lacp-system-id: AA:C1:AB:C4:30:D9
  lacp-system-priority: 65535
[admin@rtr1] > /int bond monitor-slaves bond=bonding1 once=yes
Flags: A - active; P - partner
 A  port=ether2 key=0 flags="A-GS--F-"           <-- `F` == Defaulted; No LACP PDU received from partner 
    port=ether3 key=0 flags="A-G---F-"           <-- Second port inactive
```

## After
```
[admin@rtr1] > /int eth mon 1,2 once
                     name: ether2   ether3
                   status: link-ok  link-ok
                     rate: 10Gbps   10Gbps       <-- 10G
              full-duplex: yes      yes          <-- Full-duplex!
                supported:
    default-cable-setting: standard standard

[admin@rtr1] > /int bond monitor bonding1 once
                    mode: 802.3ad
            active-ports: ether2,ether3          <-- Both ports active
          inactive-ports:
          lacp-system-id: AA:C1:AB:9B:17:1A
    lacp-system-priority: 65535
  lacp-partner-system-id: AA:C1:AB:CF:8D:82      <-- Partner System ID visible

[admin@rtr1] > /int bond monitor-slaves bond=bonding1 once=yes
Flags: A - active; P - partner
 AP port=ether2 key=15 flags="A-GSCD--" partner-sys-id=AA:C1:AB:CF:8D:82 partner-sys-priority=65535 partner-key=15 partner-flags="A-GSCD--"
 AP port=ether3 key=15 flags="A-GSCD--" partner-sys-id=AA:C1:AB:CF:8D:82 partner-sys-priority=65535 partner-key=15 partner-flags="A-GSCD--"
```

I have also tested with RouterOS 6.49.19, where these attributes appear to have no tangible effect.  Most importantly, the MTU fix #207 implemented is still intact.

```
[admin@rtr1] > /ip neigh pr
 # INTERFACE ADDRESS                                                                         MAC-ADDRESS       IDENTITY   VERSION    BOARD
 0 ether2    10.1.1.2                                                                        AA:C1:AB:CE:9F:31 rtr2       6.49.19... CHR
 1 ether3                                                                                    AA:C1:AB:07:6E:A1 rtr2       6.49.19... CHR
 
 [admin@rtr1] > ping 10.1.1.2 src-address=10.1.1.1 size=1500 count=5 do-not-fragment
  SEQ HOST                                     SIZE TTL TIME  STATUS
    0 10.1.1.2                                 1500  64 1ms
    1 10.1.1.2                                 1500  64 2ms
    2 10.1.1.2                                 1500  64 2ms
    3 10.1.1.2                                 1500  64 2ms
    4 10.1.1.2                                 1500  64 1ms
    sent=5 received=5 packet-loss=0% min-rtt=1ms avg-rtt=1ms max-rtt=2ms
```