### PR TITLE
Standardized base image

### DIFF
--- a/arista/veos/docker/Dockerfile
+++ b/arista/veos/docker/Dockerfile
@@ -1,30 +1,9 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 LABEL maintainer="Kristian Larsson <kristian@spritelink.net>"
 LABEL maintainer="Roman Dodin <dodin.roman@gmail.com>"
-
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   socat \
-   qemu-kvm \
-   qemu-utils \
-   tcpdump \
-   tftpd-hpa \
-   ssh \
-   inetutils-ping \
-   dnsutils \
-   iptables \
-   nftables \
-   telnet \
-   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 80 161/udp 443 830 5000 6030 10000-10099 57400
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/aruba/aoscx/docker/Dockerfile
+++ b/aruba/aoscx/docker/Dockerfile
@@ -1,24 +1,10 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 MAINTAINER Stefano Sasso <stesasso@gmail.com>
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    tcpdump \
-    ssh \
-    inetutils-ping \
-    dnsutils \
-    iptables \
-    telnet \
+ && apt-get install -y --no-install-recommends \
     ftp \
     qemu-system-x86 \
-    qemu-utils \
  && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
@@ -26,5 +12,3 @@ COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 80 161/udp 443 830 5000 5678 8291 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/cisco/asav/docker/Dockerfile
+++ b/cisco/asav/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/cisco/c8000v/Makefile
+++ b/cisco/c8000v/Makefile
@@ -20,7 +20,7 @@ docker-build: docker-build-common
 	@if [ "$(MODE)" = "autonomous" ]; then \
 		echo "Running install step for autonomous mode..."; \
 		docker run --cidfile cidfile --privileged $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION) --trace --install; \
-		docker commit --change='ENTRYPOINT ["/launch.py"]' $$(cat cidfile) $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION); \
+		docker commit --change='ENTRYPOINT ["uv", "run", "/launch.py"]' $$(cat cidfile) $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION); \
 		docker rm -f $$(cat cidfile); \
 		rm -f cidfile; \
 	else \

--- a/cisco/c8000v/docker/Dockerfile
+++ b/cisco/c8000v/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG VERSION
 ENV VERSION=${VERSION}
@@ -10,5 +10,3 @@ ARG MODE=autonomous
 ENV MODE=${MODE}
 
 EXPOSE 22 161/udp 830 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/cisco/cat9kv/docker/Dockerfile
+++ b/cisco/cat9kv/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG VERSION
 ENV VERSION=${VERSION}
@@ -9,5 +9,3 @@ COPY *.py /
 COPY vswitch.xm[l] /img_dir/conf/
 
 EXPOSE 22 161/udp 830 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/cisco/csr1000v/Makefile
+++ b/cisco/csr1000v/Makefile
@@ -17,5 +17,5 @@ docker-pre-build:
 
 docker-build: docker-build-common
 	docker run --cidfile cidfile --privileged $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION) --trace --install
-	docker commit --change='ENTRYPOINT ["/launch.py"]' $$(cat cidfile) $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION)
+	docker commit --change='ENTRYPOINT ["uv", "run", "/launch.py"]' $$(cat cidfile) $(REGISTRY)$(VENDOR)_$(NAME):$(VERSION)
 	docker rm -f $$(cat cidfile)

--- a/cisco/csr1000v/docker/Dockerfile
+++ b/cisco/csr1000v/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG VERSION
 ENV VERSION=${VERSION}
@@ -7,5 +7,3 @@ COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 161/udp 830 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/cisco/ftdv/docker/Dockerfile
+++ b/cisco/ftdv/docker/Dockerfile
@@ -1,29 +1,8 @@
-FROM debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
-   && apt-get upgrade -qy \
-   && apt-get install -y \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   ssh \
-   inetutils-ping \
-   dnsutils \
-   iptables \
-   nftables \
-   telnet \
-   genisoimage \
-   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 80 161/udp 443 5000 8305 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/cisco/n9kv/docker/Dockerfile
+++ b/cisco/n9kv/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 RUN apt-get update -qy \
    && apt-get install -y --no-install-recommends \

--- a/cisco/nxos/docker/Dockerfile
+++ b/cisco/nxos/docker/Dockerfile
@@ -1,9 +1,7 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 161/udp 830 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/cisco/sdwan-components/docker/Dockerfile
+++ b/cisco/sdwan-components/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim AS builder
+FROM public.ecr.aws/docker/library/debian:trixie-slim AS builder
 
 ARG DISK_SIZE=30G
 
@@ -10,27 +10,9 @@ ARG IMAGE
 COPY $IMAGE* /
 RUN qemu-img resize /$IMAGE $DISK_SIZE
 
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
-ARG DEBIAN_FRONTEND=noninteractive
 ARG DISK_SIZE=30G
-
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends\
-   bridge-utils \
-   iproute2 \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   ssh \
-   inetutils-ping \
-   dnsutils \
-   iptables \
-   nftables \
-   telnet \
-   cloud-utils \
-   sshpass \
-   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY --from=builder $IMAGE* /
@@ -38,5 +20,3 @@ COPY *.py /
 COPY templates/ /templates/
 
 EXPOSE 22 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/cisco/vios/docker/Dockerfile
+++ b/cisco/vios/docker/Dockerfile
@@ -1,9 +1,7 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 161/udp 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/cisco/xrv/docker/Dockerfile
+++ b/cisco/xrv/docker/Dockerfile
@@ -1,9 +1,7 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 161/udp 830 5000 10000-10099 57400
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/cisco/xrv9k/docker/Dockerfile
+++ b/cisco/xrv9k/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /
@@ -6,5 +6,3 @@ COPY OVMF.fd /
 COPY *.py /
 
 EXPOSE 22 80 443 161/udp 830 5000 10000-10099 57400
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/dell/dell_sonic/docker/Dockerfile
+++ b/dell/dell_sonic/docker/Dockerfile
@@ -1,18 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   qemu-kvm \
-   qemu-utils \
-   socat \
-   ssh \
-   sshpass \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /
@@ -20,5 +6,3 @@ COPY *.py /
 COPY backup.sh /
 
 EXPOSE 22 443 5000 8080
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/dell/ftosv/docker/Dockerfile
+++ b/dell/ftosv/docker/Dockerfile
@@ -1,29 +1,10 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 LABEL maintainer="Kristian Larsson <kristian@spritelink.net>"
 LABEL maintainer="Roman Dodin <dodin.roman@gmail.com>"
 LABEL maintainer="Stefano Sasso <stesasso@gmail.com>"
-
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -qy \
- && apt-get install --no-install-recommends -y \
-    dosfstools \
-    bridge-utils \
-    iproute2 \
-    python3 \
-    socat \
-    ssh \
-    tcpdump \
-    qemu-kvm \
-    qemu-utils \
-    inetutils-ping \
-    dnsutils \
-    telnet \
- && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 80 161/udp 443 830 5000 6030 10000-10099 57400
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/extreme/exos/docker/Dockerfile
+++ b/extreme/exos/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/f5_bigip/docker/Dockerfile
+++ b/f5_bigip/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG VERSION
 ENV VERSION=${VERSION}
@@ -11,5 +11,3 @@ COPY *.py /
 RUN chmod +x /launch.py /healthcheck.py
 
 EXPOSE 22 443 5000 8443 10000-10099
-HEALTHCHECK CMD ["uv", "run", "/healthcheck.py"]
-ENTRYPOINT ["uv", "run", "/launch.py"]

--- a/fortinet/fortigate/docker/Dockerfile
+++ b/fortinet/fortigate/docker/Dockerfile
@@ -1,33 +1,14 @@
-FROM debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qy \
-   && apt-get upgrade -qy \
-   && apt-get install -y \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   tftpd-hpa \
-   ssh \
-   inetutils-ping \
-   dnsutils \
+   && apt-get install -y --no-install-recommends \
    openvswitch-switch \
-   iptables \
-   telnet \
-   genisoimage \
    dos2unix \
-   vim \
    curl \
    && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
-
-
 COPY *.py /
 COPY $IMAGE /
+
 EXPOSE 22 161/udp 830 5000 10000-10099 3443 80 443
-HEALTHCHECK CMD ["python3", "/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/freebsd/docker/Dockerfile
+++ b/freebsd/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim AS builder
+FROM public.ecr.aws/docker/library/debian:trixie-slim AS builder
 
 ARG DISK_SIZE=4G
 
@@ -10,28 +10,9 @@ ARG IMAGE
 COPY $IMAGE* /
 RUN qemu-img resize /$IMAGE $DISK_SIZE
 
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
-ARG DEBIAN_FRONTEND=noninteractive
 ARG DISK_SIZE=4G
-
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends\
-   bridge-utils \
-   iproute2 \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   ssh \
-   inetutils-ping \
-   dnsutils \
-   iptables \
-   nftables \
-   telnet \
-   cloud-utils \
-   sshpass \
-   python3-yaml \
-   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY --from=builder $IMAGE* /
@@ -39,5 +20,3 @@ COPY *.py /
 COPY --chmod=0755 backup.sh /
 
 EXPOSE 22 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/hp/vsr1000/docker/Dockerfile
+++ b/hp/vsr1000/docker/Dockerfile
@@ -1,22 +1,8 @@
-FROM debian:stretch
-MAINTAINER Kristian Larsson <kristian@spritelink.net>
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
- && apt-get upgrade -qy \
- && apt-get install -y \
-    bridge-utils \
-    iproute2 \
-    python3-ipy \
-    socat \
-    qemu-kvm \
- && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
+LABEL maintainer="Kristian Larsson <kristian@spritelink.net>"
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 161/udp 830 5000 6000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/huawei/huawei_vrp/docker/Dockerfile
+++ b/huawei/huawei_vrp/docker/Dockerfile
@@ -1,9 +1,7 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.1.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 80 443 161/udp 830 5000 10000-10099 57400
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/ipinfusion/ocnos/docker/Dockerfile
+++ b/ipinfusion/ocnos/docker/Dockerfile
@@ -1,21 +1,7 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
-   && apt-get install --no-install-recommends -y \
-   iproute2 \
-   python3 \
-   socat \
-   qemu-kvm \
-   qemu-utils \
-   telnet \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 23 161/udp 443 830 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/juniper/apstra/docker/Dockerfile
+++ b/juniper/apstra/docker/Dockerfile
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 # Juniper Apstra - vrnetlab / srl-labs Dockerfile
 # ------------------------------------------------------------------------------
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG VERSION
 ARG IMAGE

--- a/juniper/vjunosevolved/docker/Dockerfile
+++ b/juniper/vjunosevolved/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
 
 ARG IMAGE

--- a/juniper/vjunosrouter/docker/Dockerfile
+++ b/juniper/vjunosrouter/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
 
 ARG IMAGE

--- a/juniper/vjunosswitch/docker/Dockerfile
+++ b/juniper/vjunosswitch/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
 
 ARG IMAGE

--- a/juniper/vmx/docker/Dockerfile
+++ b/juniper/vmx/docker/Dockerfile
@@ -1,26 +1,12 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 LABEL org.opencontainers.image.authors="roman@dodin.dev"
-
-ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qy \
    && apt-get install -y --no-install-recommends \
-   bridge-utils \
-   iproute2 \
-   python3 \
-   socat \
-   qemu-kvm \
-   qemu-utils \
-   tcpdump \
    procps \
-   inetutils-ping \
-   dnsutils \
-   telnet \
    && rm -rf /var/lib/apt/lists/*
 
 COPY vmx /vmx
 COPY *.py /
 
 EXPOSE 22 161/udp 830 5000 10000-10099 57400
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/juniper/vqfx/docker/Dockerfile
+++ b/juniper/vqfx/docker/Dockerfile
@@ -1,16 +1,8 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 RUN apt-get update -qy \
    && apt-get install -y --no-install-recommends \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   socat \
-   qemu-kvm \
-   qemu-utils \
    procps \
-   tcpdump \
    && rm -rf /var/lib/apt/lists/*
 
 ARG RE_IMAGE
@@ -24,5 +16,3 @@ COPY vrnetlab.py /
 COPY launch.py /
 
 EXPOSE 22 161/udp 830 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/juniper/vsrx/docker/Dockerfile
+++ b/juniper/vsrx/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 LABEL org.opencontainers.image.authors="roman@dodin.dev,vista@birb.network"
 
 ARG IMAGE

--- a/makefile-install.include
+++ b/makefile-install.include
@@ -41,7 +41,7 @@ docker-build: docker-build-common
 	else \
 	echo "Current build differ from previous, running install!"; \
 	docker run --cidfile cidfile --privileged $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION) --trace --install; \
-	docker commit --change='ENTRYPOINT ["/launch.py"]' $$(cat cidfile) $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION); \
+	docker commit --change='ENTRYPOINT ["uv", "run", "/launch.py"]' $$(cat cidfile) $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION); \
 	docker rm -f $$(cat cidfile); \
 	fi
 	docker rmi -f $(REGISTRY)$(IMG_VENDOR)_$(IMG_NAME):$(VERSION)-previous-build || true

--- a/mikrotik/routeros/docker/Dockerfile
+++ b/mikrotik/routeros/docker/Dockerfile
@@ -1,38 +1,15 @@
-FROM public.ecr.aws/docker/library/debian:trixie-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
-COPY --from=ghcr.io/astral-sh/uv:0.9.13 /uv /uvx /bin/
-
-ARG DEBIAN_FRONTEND=noninteractive
-
 RUN apt-get update -qy \
-   && apt-get upgrade -qy \
-   && apt-get install -y \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   socat \
-   qemu-kvm \
+   && apt-get install -y --no-install-recommends \
    qemu-system-x86 \
    qemu-efi-aarch64 \
-   tcpdump \
-   ssh \
-   inetutils-ping \
-   dnsutils \
-   iptables \
-   nftables \
-   telnet \
    ftp \
    && rm -rf /var/lib/apt/lists/*
-
-# use uv to install python 3.12. trixie ships with 3.13, which has no telnet package
-RUN uv python install 3.12
-RUN uv python pin 3.12
 
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 161/udp 830 5000 5678 8291 10000-10099
-HEALTHCHECK CMD ["uv", "run", "/healthcheck.py"]
-ENTRYPOINT ["uv", "run", "/launch.py"]

--- a/nokia/cmglinux/docker/Dockerfile
+++ b/nokia/cmglinux/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim AS builder
+FROM public.ecr.aws/docker/library/debian:trixie-slim AS builder
 
 ARG DISK_SIZE=4G
 
@@ -10,32 +10,12 @@ ARG IMAGE
 COPY $IMAGE* /
 RUN qemu-img resize /$IMAGE $DISK_SIZE
 
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
-ARG DEBIAN_FRONTEND=noninteractive
 ARG DISK_SIZE=4G
-
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends\
-   bridge-utils \
-   iproute2 \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   ssh \
-   inetutils-ping \
-   dnsutils \
-   iptables \
-   nftables \
-   telnet \
-   cloud-utils \
-   sshpass \
-   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY --from=builder $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/nokia/sros/docker/Dockerfile
+++ b/nokia/sros/docker/Dockerfile
@@ -1,5 +1,5 @@
 # base image dockerfile is defined in https://github.com/hellt/vrnetlab
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /

--- a/nvidia/cumulus-vx/docker/Dockerfile
+++ b/nvidia/cumulus-vx/docker/Dockerfile
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 # Nvidia Cumulus VX - vrnetlab / srl-labs Dockerfile
 # ------------------------------------------------------------------------------
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG VERSION
 ARG IMAGE

--- a/openbsd/docker/Dockerfile
+++ b/openbsd/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim AS builder
+FROM public.ecr.aws/docker/library/debian:trixie-slim AS builder
 
 ARG DISK_SIZE=4G
 ARG IMAGE
@@ -10,25 +10,7 @@ RUN apt-get update -qy && \
 COPY $IMAGE* /
 RUN qemu-img resize /${IMAGE} ${DISK_SIZE}
 
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends\
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   ssh \
-   inetutils-ping \
-   dnsutils \
-   iptables \
-   nftables \
-   telnet \
-   cloud-utils \
-   sshpass \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY --from=builder $IMAGE* /
@@ -36,5 +18,3 @@ COPY *.py /
 COPY --chmod=0755 backup.sh /
 
 EXPOSE 22 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/openwrt/docker/Dockerfile
+++ b/openwrt/docker/Dockerfile
@@ -1,7 +1,6 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 LABEL maintainer="Andreas Cymbal takalele@konnex.me"
 
-ARG DEBIAN_FRONTEND=noninteractive
 
 RUN uv add click
 

--- a/paloalto/pan/docker/Dockerfile
+++ b/paloalto/pan/docker/Dockerfile
@@ -1,7 +1,6 @@
 # base image dockerfile is defined in https://github.com/hellt/vrnetlab
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.0
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
-ARG DEBIAN_FRONTEND=noninteractive
 
 RUN uv add requests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [project]
 dependencies = [
+  "click",
+  "IPy",
   "passlib>=1.7.4",
   "pyyaml>=6.0.2",
   "scrapli>=2024.7.30.post1",
@@ -8,7 +10,7 @@ dependencies = [
 description = "Building containers for VM-based Network OSes for Containerlab"
 name = "vrnetlab"
 readme = "README.md"
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.13"
 version = "0.1.0"
 
 [tool.uv.sources]

--- a/sonic/docker/Dockerfile
+++ b/sonic/docker/Dockerfile
@@ -1,18 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   qemu-kvm \
-   qemu-utils \
-   socat \
-   ssh \
-   sshpass \
-   && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG IMAGE
 COPY $IMAGE* /
@@ -20,5 +6,3 @@ COPY *.py /
 COPY backup.sh /
 
 EXPOSE 22 443 5000 8080
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/spirent/vstc/docker/Dockerfile
+++ b/spirent/vstc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
 ARG VERSION
 ENV VERSION=${VERSION}

--- a/ubuntu/docker/Dockerfile
+++ b/ubuntu/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim AS builder
+FROM public.ecr.aws/docker/library/debian:trixie-slim AS builder
 
 ARG DISK_SIZE=4G
 
@@ -10,32 +10,12 @@ ARG IMAGE
 COPY $IMAGE* /
 RUN qemu-img resize /$IMAGE $DISK_SIZE
 
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
 
-ARG DEBIAN_FRONTEND=noninteractive
 ARG DISK_SIZE=4G
-
-RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends\
-   bridge-utils \
-   iproute2 \
-   socat \
-   qemu-kvm \
-   tcpdump \
-   ssh \
-   inetutils-ping \
-   dnsutils \
-   iptables \
-   nftables \
-   telnet \
-   cloud-utils \
-   sshpass \
-   && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
 COPY --from=builder $IMAGE* /
 COPY *.py /
 
 EXPOSE 22 5000 10000-10099
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,32 @@
 version = 1
-requires-python = ">=3.11, <3.13"
+requires-python = ">=3.13"
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639 },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "ipy"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/9c0d88d95666ff1571d7baec6c5e26abc08051801feb6e6ddf40f6027e22/IPy-1.01.tar.gz", hash = "sha256:edeca741dea2d54aca568fa23740288c3fe86c0f3ea700344571e9ef14a7cc1a", size = 33641 }
 
 [[package]]
 name = "passlib"
@@ -16,24 +43,15 @@ version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612 },
-    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040 },
-    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829 },
-    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167 },
-    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952 },
-    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301 },
-    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638 },
-    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850 },
-    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980 },
-    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
-    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
-    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
-    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
-    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
-    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
-    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
-    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
-    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
 ]
 
 [[package]]
@@ -58,6 +76,8 @@ name = "vrnetlab"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "click" },
+    { name = "ipy" },
     { name = "passlib" },
     { name = "pyyaml" },
     { name = "scrapli" },
@@ -66,6 +86,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click" },
+    { name = "ipy" },
     { name = "passlib", specifier = ">=1.7.4" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "scrapli", specifier = ">=2024.7.30.post1" },

--- a/vrnetlab-base.dockerfile
+++ b/vrnetlab-base.dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+FROM public.ecr.aws/docker/library/debian:trixie-slim
 LABEL org.opencontainers.image.authors="roman@dodin.dev"
 
 COPY --from=ghcr.io/astral-sh/uv:0.5.18 /uv /uvx /bin/
@@ -25,6 +25,8 @@ RUN apt-get update -qy \
    dosfstools \
    genisoimage \
    ovmf \
+   cloud-utils \
+   sshpass \
    && rm -rf /var/lib/apt/lists/*
 
 # copying the uv project


### PR DESCRIPTION
Standardizes all platforms onto the shared vrnetlab-base image and bumps the base from Debian bookworm to trixie.

Platform specific dockerfiles have been simplified through removing redundant instructions & moving common dependencies into the base image.

I have tested this with openwrt, ubuntu, mikrotik, openbsd and most Cisco images.