### PR TITLE
sonic: build on vrnetlab-base image (fix scrapli ModuleNotFoundError after #470)

### DIFF
--- a/sonic/docker/Dockerfile
+++ b/sonic/docker/Dockerfile
@@ -1,17 +1,10 @@
-FROM public.ecr.aws/docker/library/debian:bookworm-slim
+# base image dockerfile is defined in https://github.com/srl-labs/vrnetlab
+FROM ghcr.io/srl-labs/vrnetlab-base:0.2.1
 
-ENV DEBIAN_FRONTEND=noninteractive
-
+ARG DEBIAN_FRONTEND=noninteractive
+# sshpass is used by backup.sh; the base image doesn't ship it.
 RUN apt-get update -qy \
-   && apt-get install -y --no-install-recommends \
-   bridge-utils \
-   iproute2 \
-   python3-ipy \
-   qemu-kvm \
-   qemu-utils \
-   socat \
-   ssh \
-   sshpass \
+   && apt-get install -y --no-install-recommends sshpass \
    && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE
@@ -20,5 +13,5 @@ COPY *.py /
 COPY backup.sh /
 
 EXPOSE 22 443 5000 8080
-HEALTHCHECK CMD ["/healthcheck.py"]
-ENTRYPOINT ["/launch.py"]
+HEALTHCHECK CMD ["uv", "run", "/healthcheck.py"]
+ENTRYPOINT ["uv", "run", "/launch.py"]


### PR DESCRIPTION
## Problem

Freshly built `sonic` images crash immediately on launch:

```
File "/launch.py", line 11, in <module>
    import vrnetlab
File "/vrnetlab.py", line 19, in <module>
    from scrapli import Driver
ModuleNotFoundError: No module named 'scrapli'
```

## Cause

#470 migrated node kinds onto the `uv`-based `ghcr.io/srl-labs/vrnetlab-base`
image (which installs `scrapli`) and switched entrypoints to `uv run`. The
`sonic` Dockerfile was not migrated — it still built on
`debian:bookworm-slim`, never installed `scrapli`, and used
`ENTRYPOINT ["/launch.py"]`, so `common/vrnetlab.py`'s `from scrapli import
Driver` fails.

## Fix

Build `sonic` on `ghcr.io/srl-labs/vrnetlab-base:0.2.1` like the other migrated
kinds. Re-add `sshpass` (used by `sonic/docker/backup.sh`) and drop the unused
`python3-ipy`.

## Testing

- Image builds against `vrnetlab-base:0.2.1`.
- `uv run python -c "from scrapli import Driver; import vrnetlab"` succeeds in
  the image; `sshpass` is present.
- A containerlab `sonic-vm` node boots to `healthy` with the rebuilt image
  (previously it crash-exited on launch).

## Note

Other kinds still on raw `debian:*` (e.g. `dell/dell_sonic`, `dell/ftosv`,
`aruba/aoscx`, `arista/veos`, `ipinfusion/ocnos`, `juniper/vqfx`) appear to have
the same gap, but this PR is scoped to `sonic` only.
