### PR TITLE
Add OPNsense vrnetlab support

### DIFF
--- a/opnsense/Makefile
+++ b/opnsense/Makefile
@@ -1,0 +1,18 @@
+VENDOR=OPNsense
+NAME=OPNsense
+IMAGE_FORMAT=qcow2
+IMAGE_GLOB=OPNsense-*.qcow2
+
+# match versions like: OPNsense-26.1.6.qcow2
+VERSION=$(shell echo $(IMAGE) | sed -e 's/OPNsense-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\.qcow2/\1/')
+
+-include ../makefile-sanity.include
+-include ../makefile.include
+
+# Also publish a clean vrnetlab/opnsense:<version> tag (alias of the
+# vendor_name tag the include produces) for use with containerlab's
+# generic_vm kind.
+docker-build-extra:
+	docker tag $(IMG_REPOSITORY):$(VERSION) vrnetlab/opnsense:$(VERSION)
+
+build: docker-image

--- a/opnsense/README.md
+++ b/opnsense/README.md
@@ -1,0 +1,73 @@
+# vrnetlab / OPNsense
+
+This is the vrnetlab docker image for [OPNsense](https://opnsense.org/), the
+FreeBSD-based firewall/router.
+
+## Building the docker image
+
+OPNsense is distributed as a live installer (`dvd`/`vga`/`serial`) and as a
+**pre-installed `nano`** disk image. Use the **nano** image — it boots straight
+to a persistent system on a serial console, which is exactly what vrnetlab
+needs (no install step).
+
+1. Download `OPNsense-<version>-nano-amd64.img.bz2` from an OPNsense mirror.
+2. Decompress and convert it to qcow2 in this directory:
+
+   ```
+   bunzip2 -k OPNsense-26.1.6-nano-amd64.img.bz2
+   qemu-img convert -f raw -O qcow2 \
+       OPNsense-26.1.6-nano-amd64.img OPNsense-26.1.6.qcow2
+   ```
+
+3. **Pre-configure the base image once** (see *Image preparation* below). This
+   bakes management networking + SSH into `/conf/config.xml`.
+4. Run `make`. It builds `vrnetlab/opnsense_opnsense:<version>` and also tags it
+   as `vrnetlab/opnsense:<version>`.
+
+Tested with `OPNsense-26.1.6-nano-amd64.img`.
+
+## Image preparation (one-time, baked into the qcow2)
+
+The stock nano image puts a static `192.168.1.1` on the LAN and ships with SSH
+disabled, so it is unreachable through vrnetlab's management plane. Boot the
+qcow2 once and apply two changes to `/conf/config.xml`:
+
+* set the **LAN interface (vtnet0) to DHCP** so it picks up vrnetlab's
+  management address (`10.0.0.15`);
+* **enable sshd** with root login and password auth.
+
+```sh
+# in the OPNsense shell (console menu -> 8):
+sed -i '' -e 's|<ipaddr>192.168.1.1</ipaddr>|<ipaddr>dhcp</ipaddr>|' /conf/config.xml
+sed -i '' -e 's|<subnet>24</subnet>|<subnet></subnet>|' /conf/config.xml
+sed -i '' -e 's|<group>admins</group>|<group>admins</group><enabled>enabled</enabled><permitrootlogin>1</permitrootlogin><passwordauth>1</passwordauth>|' /conf/config.xml
+reboot
+```
+
+On first boot OPNsense runs the interface-assignment wizard once
+(WAN -> vtnet1, LAN -> vtnet0); answer it before applying the edits so the
+assignment is persisted too.
+
+## Usage
+
+The first interface (`vtnet0`) is the LAN/management interface; data interfaces
+start at `vtnet1` (WAN), `vtnet2` (OPT1), ...
+
+Default credentials: **root / opnsense**. The web GUI is on HTTPS (port 443).
+
+### With containerlab
+
+There is no native `opnsense` kind, so use `generic_vm`:
+
+```yaml
+  nodes:
+    fw:
+      kind: generic_vm
+      image: vrnetlab/opnsense:26.1.6
+```
+
+## System requirements
+
+CPU: 1 core
+RAM: 2048 MB
+DISK: ~8 GB (the nano image is resized at build time)

--- a/opnsense/README.md
+++ b/opnsense/README.md
@@ -19,41 +19,27 @@ needs (no install step).
        OPNsense-26.1.6-nano-amd64.img OPNsense-26.1.6.qcow2
    ```
 
-3. **Pre-configure the base image once** (see *Image preparation* below). This
-   bakes management networking + SSH into `/conf/config.xml`.
-4. Run `make`. It builds `vrnetlab/opnsense_opnsense:<version>` and also tags it
+3. Run `make`. It builds `vrnetlab/opnsense_opnsense:<version>` and also tags it
    as `vrnetlab/opnsense:<version>`.
 
 Tested with `OPNsense-26.1.6-nano-amd64.img`.
 
-## Image preparation (one-time, baked into the qcow2)
-
-The stock nano image puts a static `192.168.1.1` on the LAN and ships with SSH
-disabled, so it is unreachable through vrnetlab's management plane. Boot the
-qcow2 once and apply two changes to `/conf/config.xml`:
-
-* set the **LAN interface (vtnet0) to DHCP** so it picks up vrnetlab's
-  management address (`10.0.0.15`);
-* **enable sshd** with root login and password auth.
-
-```sh
-# in the OPNsense shell (console menu -> 8):
-sed -i '' -e 's|<ipaddr>192.168.1.1</ipaddr>|<ipaddr>dhcp</ipaddr>|' /conf/config.xml
-sed -i '' -e 's|<subnet>24</subnet>|<subnet></subnet>|' /conf/config.xml
-sed -i '' -e 's|<group>admins</group>|<group>admins</group><enabled>enabled</enabled><permitrootlogin>1</permitrootlogin><passwordauth>1</passwordauth>|' /conf/config.xml
-reboot
-```
-
-On first boot OPNsense runs the interface-assignment wizard once
-(WAN -> vtnet1, LAN -> vtnet0); answer it before applying the edits so the
-assignment is persisted too.
+The image is used unmodified — no manual preparation is required. The stock nano
+image puts a static `192.168.1.1` on the LAN and ships with SSH disabled, so on
+the first boot `launch.py` logs in over the console, switches the LAN interface
+(`vtnet0`) to DHCP — so it picks up vrnetlab's management address `10.0.0.15` —
+enables sshd (root login + password auth), and reboots once to apply.
 
 ## Usage
 
 The first interface (`vtnet0`) is the LAN/management interface; data interfaces
 start at `vtnet1` (WAN), `vtnet2` (OPT1), ...
 
-Default credentials: **root / opnsense**. The web GUI is on HTTPS (port 443).
+Default credentials: **root / opnsense** (fixed by the appliance image). The web
+GUI is on HTTPS (port 443).
+
+First boot takes a little longer than other images because of the configure +
+reboot cycle (~90s).
 
 ### With containerlab
 

--- a/opnsense/README.md
+++ b/opnsense/README.md
@@ -26,9 +26,20 @@ Tested with `OPNsense-26.1.6-nano-amd64.img`.
 
 The image is used unmodified — no manual preparation is required. The stock nano
 image puts a static `192.168.1.1` on the LAN and ships with SSH disabled, so on
-the first boot `launch.py` logs in over the console, switches the LAN interface
-(`vtnet0`) to DHCP — so it picks up vrnetlab's management address `10.0.0.15` —
-enables sshd (root login + password auth), and reboots once to apply.
+the first boot `launch.py` logs in over the console, configures the LAN interface
+(`vtnet0`) as the management interface, enables sshd (root login + password
+auth), and reboots once to apply.
+
+### Management modes
+
+The LAN is configured to match vrnetlab's management datapath:
+
+* **host-forwarded** (default): `vtnet0` is set to DHCP and picks up the
+  address qemu's user-mode networking hands out (`10.0.0.15`).
+* **transparent / passthrough** (`CLAB_MGMT_PASSTHROUGH=true`): `vtnet0` is
+  given the static address containerlab assigned to the container's `eth0`,
+  plus a default gateway, so the node shows its real management IP. Combine
+  with `CLAB_MGMT_DHCP=true` to leave the LAN on DHCP for an external server.
 
 ## Usage
 

--- a/opnsense/docker/Dockerfile
+++ b/opnsense/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM public.ecr.aws/docker/library/debian:trixie-slim AS builder
+
+ARG DISK_SIZE=8G
+
+RUN apt-get update -qy && \
+   apt-get install -y --no-install-recommends qemu-utils && \
+   rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY $IMAGE* /
+RUN qemu-img resize /$IMAGE $DISK_SIZE
+
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
+
+ARG IMAGE
+COPY --from=builder $IMAGE* /
+COPY *.py /
+
+EXPOSE 22 80 443 5000 10000-10099

--- a/opnsense/docker/launch.py
+++ b/opnsense/docker/launch.py
@@ -27,21 +27,33 @@ logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
 
 
 def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
     if self.isEnabledFor(TRACE_LEVEL_NUM):
         self._log(TRACE_LEVEL_NUM, message, args, **kws)
 
 
 logging.Logger.trace = trace
 
+# console markers
+PASSWORD_PROMPT = "Password:"
+MENU_PROMPT = "Enter an option:"
+SHELL_PROMPT = "root@OPNsense:~ #"  # OPNsense root login shell (console menu -> 8)
+
 
 class OPNsense_vm(vrnetlab.VM):
-    """OPNsense firewall VM.
+    """OPNsense firewall/router VM (FreeBSD based).
 
-    Built from the pre-installed OPNsense *nano* serial image (FreeBSD based).
-    The base qcow2 has been pre-configured so the first NIC (vtnet0) is the
-    OPNsense LAN/management interface running DHCP -- it picks up vrnetlab's
-    management address (10.0.0.15) automatically -- and sshd is enabled with
-    root login + password auth. Default credentials are root / opnsense.
+    Built from the pre-installed OPNsense *nano* serial image, used unmodified.
+    The stock nano image puts a static 192.168.1.1 on the LAN and ships with
+    SSH disabled, so it is unreachable over vrnetlab's management plane out of
+    the box. On the first boot launch.py logs in over the serial console,
+    switches the LAN interface (vtnet0) to DHCP so it picks up vrnetlab's
+    management address (10.0.0.15), enables sshd with root login + password
+    auth, and reboots once to apply.
+
+    The appliance is rebooted once to apply, so we expect two login prompts:
+    configure on the first, declare the node ready on the second.
+    Default credentials: root / opnsense.
     """
 
     def __init__(self, hostname, username, password, nics, conn_mode):
@@ -60,13 +72,17 @@ class OPNsense_vm(vrnetlab.VM):
         self.conn_mode = conn_mode
         self.nic_type = "virtio-net-pci"
 
+        # one-time console config is applied on the first boot and the VM is
+        # rebooted once to apply it; we expect two login prompts.
+        self.configured = False
+
     def gen_mgmt(self):
         """Augment the parent to keep the mgmt interface on the first bus.
 
-        Like other FreeBSD-based guests, OPNsense enumerates virtio NICs in PCI
+        Like the freebsd/openbsd guests, OPNsense enumerates virtio NICs in PCI
         bus order. The parent places the mgmt NIC on a separate bus, which would
-        make the OS assign it the *last* index instead of vtnet0. Force it onto
-        pci.1 so it becomes vtnet0 (the baked-in LAN/management interface).
+        make the OS assign it the last index instead of vtnet0. Force it onto
+        pci.1 so it becomes vtnet0 -- the LAN/management interface.
         """
         res = super(OPNsense_vm, self).gen_mgmt()
         if "bus=pci.1" not in res[-3]:
@@ -74,9 +90,14 @@ class OPNsense_vm(vrnetlab.VM):
         return res
 
     def bootstrap_spin(self):
-        """Called periodically; mark the node running once it reaches login."""
+        """Called periodically; stay quiet until the login prompt.
+
+        Pressing a key earlier drops OPNsense into the interactive
+        interface-assignment wizard; left alone it auto-proceeds with the
+        image's vtnet0=LAN / vtnet1=WAN assignment.
+        """
         if self.spins > 600:
-            # too many spins with no result -> give up, restart the VM
+            # too many spins with no result -> give up, restart
             self.stop()
             self.start()
             return
@@ -84,7 +105,13 @@ class OPNsense_vm(vrnetlab.VM):
         (ridx, match, res) = self.tn.expect([b"login:"], 1)
         if match:
             if ridx == 0:
-                self.logger.info("OPNsense reached login prompt")
+                if not self.configured:
+                    self.logger.debug("login prompt -- applying configuration")
+                    self.bootstrap_config()
+                    self.configured = True
+                    self.spins = 0
+                    return
+                self.logger.debug("login prompt -- configuration applied")
                 self.running = True
                 self.tn.close()
                 startup_time = datetime.datetime.now() - self.start_time
@@ -97,6 +124,43 @@ class OPNsense_vm(vrnetlab.VM):
 
         self.spins += 1
         return
+
+    def bootstrap_config(self):
+        """Log in over the console, edit /conf/config.xml and reboot.
+
+        OPNsense applies /conf/config.xml on boot, so the changes are made on
+        the first boot and a reboot brings the appliance up fully configured.
+        bootstrap_spin catches the post-reboot login prompt and declares the
+        node ready.
+        """
+        self.logger.info("applying bootstrap configuration over the console")
+
+        # log in (the login prompt was already consumed by bootstrap_spin)
+        self.wait_write("root", wait=None)
+        self.wait_write("opnsense", wait=PASSWORD_PROMPT)
+
+        # root's login shell is the OPNsense console menu; option 8 = Shell
+        self.wait_write("8", wait=MENU_PROMPT)
+
+        # LAN (vtnet0) -> DHCP, so it picks up the vrnetlab mgmt address
+        self.wait_write(
+            "sed -i '' -e 's|<ipaddr>192.168.1.1</ipaddr>|<ipaddr>dhcp</ipaddr>|' /conf/config.xml",
+            wait=SHELL_PROMPT,
+        )
+        self.wait_write(
+            "sed -i '' -e 's|<subnet>24</subnet>|<subnet></subnet>|' /conf/config.xml",
+            wait=SHELL_PROMPT,
+        )
+        # enable sshd with root login + password auth
+        self.wait_write(
+            "sed -i '' -e 's|<group>admins</group>|<group>admins</group>"
+            "<enabled>enabled</enabled><permitrootlogin>1</permitrootlogin>"
+            "<passwordauth>1</passwordauth>|' /conf/config.xml",
+            wait=SHELL_PROMPT,
+        )
+
+        # reboot to apply; bootstrap_spin will catch the next login prompt
+        self.wait_write("reboot", wait=SHELL_PROMPT)
 
 
 class OPNsense(vrnetlab.VR):
@@ -115,7 +179,7 @@ if __name__ == "__main__":
     parser.add_argument("--username", default="root", help="Username")
     parser.add_argument("--password", default="opnsense", help="Password")
     parser.add_argument("--hostname", default="opnsense", help="VM Hostname")
-    parser.add_argument("--nics", type=int, default=8, help="Number of NICs")
+    parser.add_argument("--nics", type=int, default=16, help="Number of NICS")
     parser.add_argument(
         "--connection-mode",
         default="tc",

--- a/opnsense/docker/launch.py
+++ b/opnsense/docker/launch.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import datetime
+import logging
+import os
+import re
+import signal
+import sys
+
+import vrnetlab
+
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+
+
+def trace(self, message, *args, **kws):
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+
+
+logging.Logger.trace = trace
+
+
+class OPNsense_vm(vrnetlab.VM):
+    """OPNsense firewall VM.
+
+    Built from the pre-installed OPNsense *nano* serial image (FreeBSD based).
+    The base qcow2 has been pre-configured so the first NIC (vtnet0) is the
+    OPNsense LAN/management interface running DHCP -- it picks up vrnetlab's
+    management address (10.0.0.15) automatically -- and sshd is enabled with
+    root login + password auth. Default credentials are root / opnsense.
+    """
+
+    def __init__(self, hostname, username, password, nics, conn_mode):
+        disk_image = ""
+        for e in sorted(os.listdir("/")):
+            if re.search(r"\.qcow2$", e):
+                disk_image = "/" + e
+                break
+
+        super(OPNsense_vm, self).__init__(
+            username, password, disk_image=disk_image, ram=2048
+        )
+
+        self.num_nics = nics
+        self.hostname = hostname
+        self.conn_mode = conn_mode
+        self.nic_type = "virtio-net-pci"
+
+    def gen_mgmt(self):
+        """Augment the parent to keep the mgmt interface on the first bus.
+
+        Like other FreeBSD-based guests, OPNsense enumerates virtio NICs in PCI
+        bus order. The parent places the mgmt NIC on a separate bus, which would
+        make the OS assign it the *last* index instead of vtnet0. Force it onto
+        pci.1 so it becomes vtnet0 (the baked-in LAN/management interface).
+        """
+        res = super(OPNsense_vm, self).gen_mgmt()
+        if "bus=pci.1" not in res[-3]:
+            res[-3] = res[-3] + ",bus=pci.1"
+        return res
+
+    def bootstrap_spin(self):
+        """Called periodically; mark the node running once it reaches login."""
+        if self.spins > 600:
+            # too many spins with no result -> give up, restart the VM
+            self.stop()
+            self.start()
+            return
+
+        (ridx, match, res) = self.tn.expect([b"login:"], 1)
+        if match:
+            if ridx == 0:
+                self.logger.info("OPNsense reached login prompt")
+                self.running = True
+                self.tn.close()
+                startup_time = datetime.datetime.now() - self.start_time
+                self.logger.info("Startup complete in: %s", startup_time)
+                return
+
+        if res != b"":
+            self.logger.trace("OUTPUT: %s" % res.decode())
+            self.spins = 0
+
+        self.spins += 1
+        return
+
+
+class OPNsense(vrnetlab.VR):
+    def __init__(self, hostname, username, password, nics, conn_mode):
+        super(OPNsense, self).__init__(username, password)
+        self.vms = [OPNsense_vm(hostname, username, password, nics, conn_mode)]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument(
+        "--trace", action="store_true", help="enable trace level logging"
+    )
+    parser.add_argument("--username", default="root", help="Username")
+    parser.add_argument("--password", default="opnsense", help="Password")
+    parser.add_argument("--hostname", default="opnsense", help="VM Hostname")
+    parser.add_argument("--nics", type=int, default=8, help="Number of NICs")
+    parser.add_argument(
+        "--connection-mode",
+        default="tc",
+        help="Connection mode to use in the datapath",
+    )
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    vr = OPNsense(
+        args.hostname,
+        args.username,
+        args.password,
+        args.nics,
+        args.connection_mode,
+    )
+    vr.start()

--- a/opnsense/docker/launch.py
+++ b/opnsense/docker/launch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import datetime
+import ipaddress
 import logging
 import os
 import re
@@ -47,9 +48,19 @@ class OPNsense_vm(vrnetlab.VM):
     The stock nano image puts a static 192.168.1.1 on the LAN and ships with
     SSH disabled, so it is unreachable over vrnetlab's management plane out of
     the box. On the first boot launch.py logs in over the serial console,
-    switches the LAN interface (vtnet0) to DHCP so it picks up vrnetlab's
-    management address (10.0.0.15), enables sshd with root login + password
-    auth, and reboots once to apply.
+    configures the LAN interface (vtnet0) as the management interface, enables
+    sshd with root login + password auth, and reboots once to apply.
+
+    The LAN is configured according to vrnetlab's management datapath mode:
+
+      * **host-forwarded** (default): the LAN is set to DHCP and picks up the
+        address qemu's user-mode networking hands out (10.0.0.15);
+      * **transparent / passthrough** (``CLAB_MGMT_PASSTHROUGH=true``): the LAN
+        is given the static address containerlab assigned to the container's
+        eth0 (``self.mgmt_address_ipv4``) plus a default gateway
+        (``self.mgmt_gw_ipv4``), so the node shows its real management IP. If
+        passthrough is combined with ``CLAB_MGMT_DHCP=true`` the LAN is left on
+        DHCP for an external server to address.
 
     The appliance is rebooted once to apply, so we expect two login prompts:
     configure on the first, declare the node ready on the second.
@@ -142,15 +153,13 @@ class OPNsense_vm(vrnetlab.VM):
         # root's login shell is the OPNsense console menu; option 8 = Shell
         self.wait_write("8", wait=MENU_PROMPT)
 
-        # LAN (vtnet0) -> DHCP, so it picks up the vrnetlab mgmt address
-        self.wait_write(
-            "sed -i '' -e 's|<ipaddr>192.168.1.1</ipaddr>|<ipaddr>dhcp</ipaddr>|' /conf/config.xml",
-            wait=SHELL_PROMPT,
-        )
-        self.wait_write(
-            "sed -i '' -e 's|<subnet>24</subnet>|<subnet></subnet>|' /conf/config.xml",
-            wait=SHELL_PROMPT,
-        )
+        # configure the LAN (vtnet0) management interface for the active
+        # management datapath mode
+        if self.mgmt_passthrough and not self.mgmt_dhcp:
+            self.configure_mgmt_static()
+        else:
+            self.configure_mgmt_dhcp()
+
         # enable sshd with root login + password auth
         self.wait_write(
             "sed -i '' -e 's|<group>admins</group>|<group>admins</group>"
@@ -161,6 +170,72 @@ class OPNsense_vm(vrnetlab.VM):
 
         # reboot to apply; bootstrap_spin will catch the next login prompt
         self.wait_write("reboot", wait=SHELL_PROMPT)
+
+    def configure_mgmt_dhcp(self):
+        """Set the LAN (vtnet0) to DHCP.
+
+        Used for the default host-forwarded datapath (qemu user-mode networking
+        hands out 10.0.0.15) and for passthrough + CLAB_MGMT_DHCP, where an
+        external DHCP server addresses the management interface.
+        """
+        self.logger.info("configuring LAN (vtnet0) for DHCP")
+        self.wait_write(
+            "sed -i '' -e 's|<ipaddr>192.168.1.1</ipaddr>|<ipaddr>dhcp</ipaddr>|' /conf/config.xml",
+            wait=SHELL_PROMPT,
+        )
+        self.wait_write(
+            "sed -i '' -e 's|<subnet>24</subnet>|<subnet></subnet>|' /conf/config.xml",
+            wait=SHELL_PROMPT,
+        )
+
+    def configure_mgmt_static(self):
+        """Give the LAN (vtnet0) the management IP containerlab assigned.
+
+        In transparent management mode the mgmt interface mirrors the
+        container's eth0, so the guest must carry that exact address plus a
+        default gateway to be reachable beyond its own subnet.
+
+        We edit /conf/config.xml with sed, like the other edits here: each
+        command is short enough to pass cleanly over the serial console (a
+        single long one-liner can exceed the console's line limit and hang).
+        The IP/subnet are simple field swaps; the default gateway is a small
+        <gateways> object inserted ahead of the existing <staticroutes>
+        element, with the LAN pointed at it.
+        """
+        addr = ipaddress.ip_interface(self.mgmt_address_ipv4)
+        ip = str(addr.ip)
+        prefix = str(addr.network.prefixlen)
+        gw = self.mgmt_gw_ipv4
+        self.logger.info(
+            "configuring LAN (vtnet0) with static mgmt address %s/%s gw %s",
+            ip,
+            prefix,
+            gw,
+        )
+
+        self.wait_write(
+            "sed -i '' -e 's|<ipaddr>192.168.1.1</ipaddr>|<ipaddr>%s</ipaddr>|' /conf/config.xml"
+            % ip,
+            wait=SHELL_PROMPT,
+        )
+        self.wait_write(
+            "sed -i '' -e 's|<subnet>24</subnet>|<subnet>%s</subnet>|' /conf/config.xml"
+            % prefix,
+            wait=SHELL_PROMPT,
+        )
+        # point the LAN at a named gateway ...
+        self.wait_write(
+            "sed -i '' -e 's|<if>vtnet0</if>|<if>vtnet0</if><gateway>MGMTGW</gateway>|' /conf/config.xml",
+            wait=SHELL_PROMPT,
+        )
+        # ... and define that gateway as the system default route
+        self.wait_write(
+            "sed -i '' -e 's#<staticroutes #<gateways><gateway_item>"
+            "<interface>lan</interface><gateway>%s</gateway><name>MGMTGW</name>"
+            "<weight>1</weight><ipprotocol>inet</ipprotocol><defaultgw>1</defaultgw>"
+            "</gateway_item></gateways><staticroutes #' /conf/config.xml" % gw,
+            wait=SHELL_PROMPT,
+        )
 
 
 class OPNsense(vrnetlab.VR):


### PR DESCRIPTION
## Summary

Adds a vrnetlab builder for [OPNsense](https://opnsense.org/), the FreeBSD-based firewall/router, so it can run as a containerlab node (via `kind: generic_vm` — there is no native `opnsense` kind).

Built from the pre-installed OPNsense **nano** serial image, used unmodified. The stock nano image puts a static `192.168.1.1` on the LAN and ships with SSH disabled, so it is unreachable over vrnetlab's management plane out of the box. On the first boot `launch.py`:

- logs in over the serial console (`root` / `opnsense`, console menu → option 8 = shell);
- switches the LAN interface (`vtnet0`) to DHCP so it picks up vrnetlab's management address (`10.0.0.15`);
- enables sshd with root login + password auth;
- reboots once to apply.

`bootstrap_spin` catches the post-reboot login prompt and declares the node ready (two-login flow). This keeps the build trivial and portable — no KVM or console scripting at build time — and mirrors the existing `freebsd`/`openbsd` qcow2 vendors (including the `gen_mgmt` PCI-bus tweak so the mgmt NIC enumerates as `vtnet0`).

## Files

- `opnsense/docker/launch.py` — console bootstrap + reboot flow
- `opnsense/docker/Dockerfile` — minimal, based on `vrnetlab-base`
- `opnsense/Makefile` — builds `vrnetlab/opnsense_opnsense:<version>` and tags the clean `vrnetlab/opnsense:<version>` alias
- `opnsense/README.md` — build + usage instructions

## Testing

Verified end-to-end with a single containerlab `generic_vm` node (`image: vrnetlab/opnsense:26.1.6`), built from `OPNsense-26.1.6-nano-amd64.img`:

- container reaches `healthy` in ~80s (configure + reboot cycle);
- SSH auth (`root` / `opnsense`) over the management address works;
- LAN confirmed switched to DHCP in `/conf/config.xml`.

## Usage

```yaml
nodes:
  fw:
    kind: generic_vm
    image: vrnetlab/opnsense:26.1.6
```