### PR TITLE
cisco/xrd-vrouter: add Cisco XRd vRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Since the changes we made in this fork are VM specific, we added a few popular
 routing products:
 
 * Arista vEOS
+* Cisco XRd vRouter
 * Cisco XRv9k
 * Cisco XRv
 * Cisco FTDv

--- a/cisco/xrd-vrouter/Makefile
+++ b/cisco/xrd-vrouter/Makefile
@@ -1,0 +1,33 @@
+VENDOR=cisco
+NAME=xrd-vrouter
+IMAGE_FORMAT=tar
+IMAGE_GLOB=*.tar
+
+# Extract the version from the tarball name, e.g. xrd-vrouter-25.4.2.tar -> 25.4.2
+VERSION=$(shell echo $(IMAGE) | sed -e 's/^xrd-vrouter-\(.*\)\.tar$$/\1/')
+
+-include ../../makefile-sanity.include
+-include ../../makefile.include
+
+# The vendor artifact is the XRd vRouter *container* image (a `docker save`
+# tarball), not a VM disk. It is passed to the install step via a bind mount
+# rather than copied into an image layer, so it does not bloat the result.
+docker-build-image-copy: ;
+
+docker-pre-build:
+	-cat cidfile 2>/dev/null | xargs --no-run-if-empty docker rm -f
+	-rm -f cidfile
+
+# Build the launcher image, then bake the golden micro-VM into it: a privileged
+# run executes make-golden.sh, which provisions a fresh Ubuntu VM and preloads
+# the XRd vRouter image; the result is committed back with the launcher entrypoint.
+docker-build: docker-build-common
+	docker run --cidfile cidfile --privileged --device /dev/kvm \
+		-v "$(abspath $(IMAGE))":/xrd.tar:ro \
+		--entrypoint /make-golden.sh \
+		-e XRD_IMAGE_TAR=/xrd.tar \
+		$(IMG_REPOSITORY):$(VERSION)
+	docker commit --change='ENTRYPOINT ["uv", "run", "/launch.py"]' \
+		$$(cat cidfile) $(IMG_REPOSITORY):$(VERSION)
+	docker rm -f $$(cat cidfile)
+	rm -f cidfile

--- a/cisco/xrd-vrouter/README.md
+++ b/cisco/xrd-vrouter/README.md
@@ -1,0 +1,47 @@
+# Cisco XRd vRouter
+
+This is the vrnetlab integration for the **vRouter** form factor of Cisco XRd — the variant with the high-performance DPDK dataplane.
+
+Unlike the XRd Control Plane (which containerlab runs directly as `cisco_xrd`), XRd vRouter's dataplane interfaces are **PCI-only**; it cannot bind a veth. This integration solves that by running the XRd vRouter container inside a small KVM guest that presents emulated PCI NICs, so it can be wired with ordinary containerlab links like any other VM-based node.
+
+## Building the image
+
+XRd vRouter is distributed as a container image. Export it to a tarball named `xrd-vrouter-<version>.tar`, place it in this directory, and run `make`:
+
+```bash
+docker pull <your-registry>/xrd-vrouter:25.4.2
+docker save <your-registry>/xrd-vrouter:25.4.2 -o xrd-vrouter-25.4.2.tar
+make
+```
+
+`make` builds a fully self-contained image: it provisions a fresh Ubuntu cloud image (cgroups v1, 1 GiB hugepages, IOMMU + vfio-pci, Docker, the AppArmor profile and the guest-init service) and preloads the XRd vRouter image into it, producing `vrnetlab/cisco_xrd-vrouter:<version>`.
+
+The build runs a short throwaway VM, so the build host needs nested virtualization (`/dev/kvm`).
+
+## System requirements
+
+XRd vRouter requires, per running node: 2 vCPUs (one dedicated to the dataplane), ~5 GiB RAM and 3 GiB of 1 GiB hugepages. The launcher defaults to 4 vCPU / 10 GiB and enforces a hard floor of 8 GiB; tune with the `VCPU` / `RAM` node env in your topology. 8 GiB is feasible — in our testing an idle node booted and forwarded with ~800 MB RAM to spare — but that's tight, so give it more for feature-heavy labs.
+
+## Usage with containerlab
+
+XRd vRouter is IOS-XR, so it runs under the stock [`cisco_xrv9k`](https://containerlab.srlinux.dev/manual/kinds/vr-xrv9k/) kind. A dedicated [`cisco_xrd_vrouter`](https://containerlab.srlinux.dev/manual/kinds/cisco_xrd_vrouter/) kind is also available.
+
+```yaml
+name: xrd
+topology:
+  nodes:
+    r1:
+      kind: cisco_xrv9k
+      image: vrnetlab/cisco_xrd-vrouter:25.4.2
+      startup-config: r1.cfg
+    r2:
+      kind: cisco_xrv9k
+      image: vrnetlab/cisco_xrd-vrouter:25.4.2
+      startup-config: r2.cfg
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1"]
+```
+
+Management (SSH, gNMI on `:9339`, NETCONF on `:830`) uses the default credentials `clab` / `clab@123`. The router's `MgmtEth0/RP0/CPU0/0` carries the containerlab node IP. Data-plane interface config comes from each node's `startup-config`; `eth1`, `eth2`, … map to `GigabitEthernet0/0/0/0`, `…/1`, … in order.
+
+> Emulated NIC throughput is suitable for feature, protocol and dataplane-behaviour labs, not line-rate performance testing.

--- a/cisco/xrd-vrouter/docker/Dockerfile
+++ b/cisco/xrd-vrouter/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM ghcr.io/srl-labs/vrnetlab-base:0.3.0
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends cloud-image-utils curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY make-golden.sh guest-init.sh xrd-guest-init.service netplan-mgmt.yaml \
+     cloud-init-disable-net.cfg xrd-unconfined launch.py /
+RUN chmod +x /make-golden.sh
+
+EXPOSE 22 161/udp 830 9339 57400 10000-10099

--- a/cisco/xrd-vrouter/docker/cloud-init-disable-net.cfg
+++ b/cisco/xrd-vrouter/docker/cloud-init-disable-net.cfg
@@ -1,0 +1,1 @@
+network: {config: disabled}

--- a/cisco/xrd-vrouter/docker/guest-init.sh
+++ b/cisco/xrd-vrouter/docker/guest-init.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# guest-init.sh — runs inside the micro-VM at boot (vrnetlab/native model).
+#
+#   1. Read per-node config from the config CD the launcher attaches (/dev/sr0):
+#      nodename + first-boot.cfg (XR config: clab user, ssh/grpc/netconf + user cfg).
+#   2. Discover the virtio mgmt NIC and the emulated igb data NICs.
+#   3. Run the XRd vRouter container with host networking so XR shares the VM
+#      mgmt NIC (XR owns the management address explicitly via first-boot.cfg),
+#      and map each igb data NIC to Gi0/0/0/N.
+#   4. When XR is up and MgmtEth is up, print the readiness marker on the console
+#      so the vrnetlab launcher (watching the serial) marks the node up.
+set -euo pipefail
+
+LOG=/var/log/guest-init.log
+# Mirror everything to the serial console too, so it shows up in the vrnetlab
+# container's `docker logs` (the only window into the VM in production).
+exec > >(tee -a "$LOG" /dev/console) 2>&1
+echo "=== guest-init $(date -u +%FT%TZ) ==="
+
+IMG=$(cat /etc/xrd/image)
+READY_MARKER="CLAB_XRD_READY"
+
+# ---------------------------------------------------------------------------
+# 1. Per-node config from the launcher's config CD.
+# ---------------------------------------------------------------------------
+CFGDIR=/run/xrd-config; mkdir -p "$CFGDIR"
+NODENAME="xrd"
+FIRST_BOOT="$CFGDIR/first-boot.cfg"
+if [ -b /dev/sr0 ]; then
+    mount -o ro /dev/sr0 /mnt 2>/dev/null || true
+    [ -f /mnt/nodename ] && NODENAME=$(cat /mnt/nodename)
+    [ -f /mnt/first-boot.cfg ] && cp /mnt/first-boot.cfg "$FIRST_BOOT"
+    umount /mnt 2>/dev/null || true
+fi
+[ -f "$FIRST_BOOT" ] || printf 'hostname %s\n!\nend\n' "$NODENAME" > "$FIRST_BOOT"
+echo "node=$NODENAME image=$IMG"
+
+# ---------------------------------------------------------------------------
+# 2. Discover NICs. Mgmt = virtio_net; data = igb (8086:10c9), PCI-sorted.
+# ---------------------------------------------------------------------------
+MGMT_IF=""
+for n in /sys/class/net/*; do
+    ifc=$(basename "$n")
+    [ "$ifc" = "lo" ] && continue
+    drv=$(basename "$(readlink -f "$n/device/driver" 2>/dev/null)" 2>/dev/null || true)
+    [ "$drv" = "virtio_net" ] && { MGMT_IF=$ifc; break; }
+done
+echo "mgmt interface: ${MGMT_IF:-NONE}"
+
+mapfile -t PCIS < <(lspci -Dn | awk '$3 ~ /8086:10c9/ {print $1}' | sort)
+echo "igb data NIC(s): ${PCIS[*]:-none}"
+
+# NB: xr_name is NOT valid for pci interfaces on vRouter; XR numbers them
+# Gi0/0/0/0,1,... in the order listed here. We list in PCI order, which matches
+# the eth1,eth2,... order (each ethN -> rpN -> ascending PCI address).
+XR_IFS=""
+for d in "${PCIS[@]}"; do
+    short=${d#0000:}
+    XR_IFS+="${XR_IFS:+;}pci:${short}"
+done
+echo "XR_INTERFACES=$XR_IFS"
+
+# XR owns the mgmt address explicitly (configured in first-boot.cfg); the linux
+# mgmt NIC is just the L2 carrier (tc-mirred passthrough to the clab mgmt net).
+MGMT_ENV="linux:${MGMT_IF},chksum"
+
+# ---------------------------------------------------------------------------
+# 3. Launch XRd vRouter (host networking so XR shares the VM mgmt NIC).
+# ---------------------------------------------------------------------------
+docker rm -f xrd >/dev/null 2>&1 || true
+ARGS=(
+  -d --name xrd --restart unless-stopped --network host
+  --privileged --security-opt apparmor=xrd-unconfined
+  --mount "type=bind,source=$FIRST_BOOT,target=/etc/xrd/first-boot.cfg"
+  --env XR_FIRST_BOOT_CONFIG=/etc/xrd/first-boot.cfg
+  --env XR_MGMT_INTERFACES="$MGMT_ENV"
+)
+[ -n "$XR_IFS" ] && ARGS+=(--env XR_INTERFACES="$XR_IFS")
+echo "docker run ${ARGS[*]} $IMG"
+docker run "${ARGS[@]}" "$IMG"
+
+# ---------------------------------------------------------------------------
+# 4. Wait for XR readiness, then signal the launcher via the console.
+# ---------------------------------------------------------------------------
+xrcli(){ timeout 25 docker exec xrd /pkg/bin/xr_cli "$1" 2>/dev/null; }
+
+# Wait for the XR control plane, then confirm MgmtEth is up. XR takes ~2-3 min
+# after the CLI first answers to apply config and bring MgmtEth up — that is the
+# real readiness signal. External mgmt reachability is verified separately by the
+# containerlab healthcheck, so we do not probe the address from the Linux netns
+# (XR owns it, so it does not live there).
+echo "waiting for XR control plane + management..."
+for i in $(seq 1 120); do
+    if xrcli "show version" | grep -qi "cisco IOS XR"; then
+        # '|| true' is essential: under `set -e`, a non-matching grep would
+        # otherwise abort guest-init before it ever emits the readiness marker.
+        mgmtline=$(xrcli "show ipv4 vrf all interface brief" | grep -i Mgmt || true)
+        echo "[t=$((i*10))s] XR up; MgmtEth: ${mgmtline:-pending}"
+        case "$mgmtline" in
+            *Up*Up*) echo "XR management is up"; break ;;
+        esac
+    else
+        echo "[t=$((i*10))s] XR converging..."
+    fi
+    sleep 10
+done
+
+# Emit the readiness marker on the serial console for the vrnetlab launcher.
+# Repeat a few times so the launcher's serial poller reliably catches it.
+for n in 1 2 3 4 5; do
+    for tty in /dev/ttyS0 /dev/console; do
+        [ -w "$tty" ] && echo "${READY_MARKER}:${NODENAME}" > "$tty" 2>/dev/null || true
+    done
+    sleep 2
+done
+echo "=== guest-init done ==="

--- a/cisco/xrd-vrouter/docker/launch.py
+++ b/cisco/xrd-vrouter/docker/launch.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""vrnetlab launcher for Cisco XRd vRouter.
+
+XRd vRouter is distributed as a *container* whose dataplane needs PCI NICs, so it
+cannot run directly as a vrnetlab VM. This launcher boots a thin micro-VM (the
+"golden" qcow2) that provides q35 + Intel vIOMMU and emulated igb NICs; inside,
+guest-init runs the XRd vRouter container and binds those NICs to vfio-pci for
+its DPDK dataplane.
+
+By subclassing vrnetlab.VM we inherit the full containerlab-native machinery:
+tc-mirred datapath stitching, management port-forwarding (SSH/NETCONF/gNMI/SNMP),
+credentials, interface aliasing and health. We only override the bits that differ
+for the nested model:
+  * gen_nics(): emulated igb on per-NIC PCIe root ports (isolated IOMMU groups),
+    reusing the framework's tc taps.
+  * machine: q35 + intel-iommu (+ virtio-balloon for RAM reclaim).
+  * a config CD delivering XR first-boot config + node params to guest-init.
+  * bootstrap: wait for guest-init's readiness marker on the VM console.
+"""
+
+import os
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+
+import vrnetlab
+
+STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
+READY_MARKER = "CLAB_XRD_READY"
+
+
+def handle_SIGCHLD(_signal, _frame):
+    os.waitpid(-1, os.WNOHANG)
+
+
+def handle_SIGTERM(_signal, _frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+
+class XRd_vRouter_vm(vrnetlab.VM):
+    def __init__(self, hostname, username, password, nics, conn_mode, vcpu, ram):
+        # Locate the golden micro-VM disk baked into the image.
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if disk_image is None and re.search(r"\.qcow2$", e):
+                disk_image = "/" + e
+        if disk_image is None:
+            raise FileNotFoundError("no golden .qcow2 found in /")
+
+        # vRouter needs >=2 dedicated CPUs (dataplane) + control plane; floor at 4.
+        vcpu = max(int(vcpu), 4)
+        # Needs ~5GiB RAM + 3GiB hugepages inside the VM; default 10GiB, hard floor 8GiB.
+        ram = max(int(ram), 8192)
+
+        super().__init__(
+            username,
+            password,
+            disk_image=disk_image,
+            ram=ram,
+            smp=f"cores={vcpu},threads=1,sockets=1",
+            cpu="host,+ssse3,+sse4.1,+sse4.2",
+            driveif="virtio",
+        )
+
+        self.hostname = hostname
+        self.conn_mode = conn_mode
+        self.num_nics = nics
+        self.nic_type = "virtio-net-pci"   # management NIC type
+        self.provision_pci_bus = False     # we place data NICs on our own root ports
+
+        # Passthrough management: the framework tc-mirreds the container's eth0
+        # (the clab node IP) to the VM mgmt NIC, so XR's MgmtEth carries the real
+        # clab management IP over a transparent L2 bridge. Passthrough rather than
+        # slirp host-forwarding because XR owns the management address with its own
+        # MAC, which a NAT/DHCP NIC cannot reach.
+        self.mgmt_passthrough = True
+        self.mgmt_address_ipv4, self.mgmt_address_ipv6 = self.get_mgmt_address()
+        self.mgmt_gw_ipv4, self.mgmt_gw_ipv6 = self.get_mgmt_gw()
+
+        # Switch machine to q35 + split irqchip and add an Intel vIOMMU so the
+        # guest can bind the igb NICs to vfio-pci; add a balloon for RAM reclaim.
+        self._patch_machine_and_iommu()
+
+        # Build the config CD (node name + XR first-boot config) and attach it.
+        iso = self._build_config_iso()
+        self.qemu_args.extend(
+            ["-drive", f"file={iso},if=none,id=cfgcd,format=raw,readonly=on",
+             "-device", "ide-cd,drive=cfgcd"]
+        )
+
+    # ----------------------------------------------------------------- helpers
+    def _patch_machine_and_iommu(self):
+        args = self.qemu_args
+        for i, a in enumerate(args):
+            if a == "-machine" and i + 1 < len(args):
+                args[i + 1] = "q35,kernel-irqchip=split"
+                break
+        args.extend([
+            "-device", "intel-iommu,intremap=on,caching-mode=on",
+            "-device", "virtio-balloon,id=balloon0",
+        ])
+
+    def _gen_xr_config(self):
+        """XR first-boot config: clab user + management on MgmtEth in the global
+        VRF. XRd vRouter's SSH server only listens in the default VRF (unlike
+        gRPC), so management stays global. The mgmt subnet is directly connected,
+        so no default route is needed and the data routing table stays clean.
+        Data IPs come from the user's startup-config."""
+        import ipaddress
+        mgmt_if = ipaddress.ip_interface(self.mgmt_address_ipv4)  # e.g. 10.0.0.15/24
+        mgmt_v4 = f"{mgmt_if.ip} {mgmt_if.netmask}"
+        # Modelled on containerlab's official nodes/xrd/xrd.cfg. The bits XRd
+        # needs for working SSH: `line default / transport input ssh` and
+        # `secret` (not `secret 0`). MgmtEth gets the clab management address
+        # explicitly; that subnet is directly connected so no route is needed.
+        # gRPC/gNMI on 9339 to match clab tooling.
+        cfg = f"""hostname {self.hostname}
+username {self.username}
+ group root-lr
+ group cisco-support
+ secret {self.password}
+!
+line default
+ transport input ssh
+!
+netconf-yang agent
+ ssh
+!
+interface MgmtEth0/RP0/CPU0/0
+ ipv4 address {mgmt_v4}
+ no shutdown
+!
+ssh server v2
+ssh server netconf
+!
+grpc
+ port 9339
+ no-tls
+ address-family dual
+!
+"""
+        if os.path.exists(STARTUP_CONFIG_FILE):
+            with open(STARTUP_CONFIG_FILE) as f:
+                cfg += f.read()
+            if not cfg.rstrip().endswith("end"):
+                cfg += "\nend\n"
+        else:
+            cfg += "end\n"
+        return cfg
+
+    def _build_config_iso(self):
+        d = tempfile.mkdtemp()
+        with open(os.path.join(d, "nodename"), "w") as f:
+            f.write(self.hostname + "\n")
+        with open(os.path.join(d, "first-boot.cfg"), "w") as f:
+            f.write(self._gen_xr_config())
+        iso = "/xrd-config.iso"
+        subprocess.run(
+            ["genisoimage", "-quiet", "-output", iso, "-volid", "config",
+             "-joliet", "-rock", d],
+            check=True,
+        )
+        return iso
+
+    # ------------------------------------------------------------- overrides
+    def gen_nics(self):
+        """Emulated igb data NICs, each on its own PCIe root port (own IOMMU
+        group), wired to the framework's tc taps (tapN <-> ethN)."""
+        if self.conn_mode == "tc":
+            self.create_tc_tap_ifup()
+        # wait for containerlab to provision the data interfaces
+        self.nic_provision_delay()
+
+        res = []
+        i = self.start_nic_eth_idx
+        chassis = 1
+        while os.path.exists(f"/sys/class/net/{self.data_intf_prefix}{i}"):
+            mac = self.get_intf_mac(f"{self.data_intf_prefix}{i}") or vrnetlab.gen_mac(i)
+            netdev = f"p{i:02d}"
+            res.extend([
+                "-device", f"pcie-root-port,id=rp{i},bus=pcie.0,chassis={chassis},slot={chassis}",
+                "-device", f"igb,netdev={netdev},mac={mac},bus=rp{i}",
+            ])
+            if self.conn_mode == "tc":
+                res.extend([
+                    "-netdev",
+                    f"tap,id={netdev},ifname=tap{i},script=/etc/tc-tap-ifup,downscript=no",
+                ])
+            else:
+                res.extend(["-netdev", f"socket,id={netdev},listen=:{i + 10000:02d}"])
+            i += 1
+            chassis += 1
+        self.logger.info(f"generated {chassis - 1} igb data NIC(s)")
+        return res
+
+    def bootstrap_spin(self):
+        """Wait for guest-init to signal XR readiness on the VM console."""
+        if self.spins > 900:
+            self.logger.warning("XRd failed to come up in time; restarting VM")
+            self.stop()
+            self.start()
+            return
+
+        (ridx, match, res) = self.con_expect([READY_MARKER.encode()])
+        if match:
+            self.logger.info("XRd vRouter is ready")
+            self.running = True
+            return
+        if res != b"":
+            self.write_to_stdout(res)
+            self.spins = 0
+        self.spins += 1
+
+
+class XRd_vRouter(vrnetlab.VR):
+    def __init__(self, hostname, username, password, nics, conn_mode, vcpu, ram):
+        super().__init__(username, password)
+        self.vms = [XRd_vRouter_vm(hostname, username, password, nics, conn_mode, vcpu, ram)]
+
+
+if __name__ == "__main__":
+    import argparse
+    import logging
+
+    parser = argparse.ArgumentParser(description="XRd vRouter vrnetlab launcher")
+    parser.add_argument("--trace", action="store_true", help="enable trace logging")
+    parser.add_argument("--hostname", default="vr-xrd-vrouter", help="Router hostname")
+    parser.add_argument("--username", default="clab", help="Username")
+    parser.add_argument("--password", default="clab@123", help="Password")
+    parser.add_argument("--nics", type=int, default=128, help="Number of NICs")
+    parser.add_argument("--vcpu", type=int, default=4, help="vCPU count")
+    parser.add_argument("--ram", type=int, default=10240, help="RAM in MB")
+    parser.add_argument("--connection-mode", default="tc", help="datapath connection mode")
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    vrnetlab.boot_delay()
+    vr = XRd_vRouter(
+        args.hostname, args.username, args.password,
+        args.nics, args.connection_mode, args.vcpu, args.ram,
+    )
+    vr.start()

--- a/cisco/xrd-vrouter/docker/make-golden.sh
+++ b/cisco/xrd-vrouter/docker/make-golden.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# make-golden.sh — build the "golden" micro-VM image from scratch.
+#
+# Produces a qcow2 of a minimal Ubuntu VM prepared to host the XRd vRouter
+# container: cgroups v1, 1 GiB hugepages, IOMMU + vfio-pci, Docker (overlay2),
+# the AppArmor profile, the guest-init service, and the XRd vRouter image
+# preloaded. The only inputs are a stock Ubuntu cloud image (downloaded) and the
+# XRd vRouter container image, so the result is fully reproducible.
+#
+# Provisioning runs inside a throwaway boot of the cloud image driven by
+# cloud-init; the VM powers itself off when done and the disk is the golden.
+# Depends only on qemu, cloud-image-utils and curl (no libguestfs).
+#
+# Required env:
+#   XRD_IMAGE_TAR   path to a `docker save` tarball of the XRd vRouter image
+# Optional env:
+#   XRD_IMAGE_REF   image reference guest-init runs (default: read from the tarball)
+#   OUT             output qcow2 path (default /golden.qcow2)
+#   UBUNTU_IMG_URL  cloud image URL (default: Ubuntu 24.04 amd64)
+#   PROV_RAM        provisioning VM memory in MiB (default 4096)
+set -euo pipefail
+
+here=$(cd "$(dirname "$0")" && pwd)
+: "${XRD_IMAGE_TAR:?set XRD_IMAGE_TAR to the XRd vRouter docker-save tarball}"
+out=${OUT:-/golden.qcow2}
+ubuntu_url=${UBUNTU_IMG_URL:-https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img}
+prov_ram=${PROV_RAM:-4096}
+marker="GOLDEN_PROVISIONED_OK"
+
+# Default the image reference to the tag recorded in the tarball.
+xrd_ref=${XRD_IMAGE_REF:-$(tar -xOf "$XRD_IMAGE_TAR" manifest.json \
+    | sed -E 's/.*"RepoTags":\["([^"]+)".*/\1/')}
+[ -n "$xrd_ref" ] || { echo "ERROR: could not determine XRd image reference" >&2; exit 1; }
+echo "XRd image reference: $xrd_ref"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+echo "== fetching Ubuntu cloud image =="
+curl -fSL "$ubuntu_url" -o "$work/base.img"
+cp --sparse=always "$work/base.img" "$out"
+qemu-img resize "$out" 20G
+
+echo "== staging XRd image for the provisioning VM (9p share) =="
+share="$work/share"
+mkdir -p "$share"
+cp "$XRD_IMAGE_TAR" "$share/xrd.tar"
+
+echo "== rendering cloud-init =="
+b64() { base64 -w0 "$1"; }
+cat > "$work/meta-data" <<EOF
+instance-id: xrd-golden
+local-hostname: xrd-golden
+EOF
+cat > "$work/user-data" <<EOF
+#cloud-config
+write_files:
+  - path: /usr/local/bin/guest-init.sh
+    permissions: '0755'
+    encoding: b64
+    content: $(b64 "$here/guest-init.sh")
+  - path: /etc/systemd/system/xrd-guest-init.service
+    encoding: b64
+    content: $(b64 "$here/xrd-guest-init.service")
+  - path: /etc/netplan/90-mgmt.yaml
+    permissions: '0600'
+    encoding: b64
+    content: $(b64 "$here/netplan-mgmt.yaml")
+  - path: /etc/cloud/cloud.cfg.d/99-disable-network.cfg
+    encoding: b64
+    content: $(b64 "$here/cloud-init-disable-net.cfg")
+  - path: /etc/apparmor.d/xrd-unconfined
+    encoding: b64
+    content: $(b64 "$here/xrd-unconfined")
+  - path: /etc/docker/daemon.json
+    content: '{ "storage-driver": "overlay2", "features": { "containerd-snapshotter": false } }'
+  - path: /etc/sysctl.d/99-xrd.conf
+    content: |
+      fs.inotify.max_user_instances=64000
+      fs.inotify.max_user_watches=64000
+      net.core.netdev_max_backlog=300000
+      net.core.optmem_max=67108864
+      net.core.rmem_default=67108864
+      net.core.rmem_max=67108864
+      net.core.wmem_default=67108864
+      net.core.wmem_max=67108864
+      net.ipv4.udp_mem=1124736 10000000 67108864
+  - path: /etc/modules-load.d/xrd.conf
+    content: |
+      dummy
+      nf_tables
+      vfio-pci
+  - path: /etc/xrd/image
+    content: "$xrd_ref\n"
+  - path: /usr/local/bin/provision.sh
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+      curl -fsSL https://get.docker.com | sh
+      systemctl restart docker
+      mount -t 9p -o trans=virtio,version=9p2000.L,ro xrdshare /mnt
+      docker load -i /mnt/xrd.tar
+      umount /mnt
+      rm -f /etc/netplan/50-cloud-init.yaml
+      sed -i 's|^GRUB_CMDLINE_LINUX=.*|GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller=1 default_hugepagesz=1G hugepagesz=1G hugepages=3 intel_iommu=on iommu=pt transparent_hugepage=never"|' /etc/default/grub
+      update-grub
+      apparmor_parser -r /etc/apparmor.d/xrd-unconfined
+      systemctl enable xrd-guest-init.service
+      systemctl mask serial-getty@ttyS0.service
+      echo "$marker" > /dev/console
+      sync
+      poweroff
+runcmd:
+  - [ bash, /usr/local/bin/provision.sh ]
+EOF
+cloud-localds "$work/seed.iso" "$work/user-data" "$work/meta-data"
+
+echo "== running provisioning VM (cloud-init prepares the image, then powers off) =="
+timeout 1800 qemu-system-x86_64 \
+  -enable-kvm -machine q35 -cpu host -smp 4 -m "$prov_ram" \
+  -drive file="$out",if=virtio,format=qcow2 \
+  -drive file="$work/seed.iso",if=virtio,format=raw \
+  -netdev user,id=net0 -device virtio-net-pci,netdev=net0 \
+  -fsdev local,id=xrdfs,path="$share",security_model=none,readonly=on \
+  -device virtio-9p-pci,fsdev=xrdfs,mount_tag=xrdshare \
+  -display none -serial file:"$work/console.log" -no-reboot || true
+
+if ! grep -q "$marker" "$work/console.log"; then
+    echo "ERROR: provisioning did not complete successfully. Console tail:" >&2
+    tail -n 40 "$work/console.log" >&2 || true
+    exit 1
+fi
+
+echo "== compacting =="
+qemu-img convert -O qcow2 "$out" "$out.compact"
+mv -f "$out.compact" "$out"
+ls -lh "$out"
+echo "== golden image ready: $out =="

--- a/cisco/xrd-vrouter/docker/netplan-mgmt.yaml
+++ b/cisco/xrd-vrouter/docker/netplan-mgmt.yaml
@@ -1,0 +1,13 @@
+## Management NIC = the virtio-net device the vrnetlab framework attaches.
+## XR owns the management IP (configured explicitly on MgmtEth), so here we only
+## bring the link up with no address — it is purely the L2 carrier to the clab
+## management network. Matched by driver so the kernel name doesn't matter.
+network:
+  version: 2
+  ethernets:
+    mgmt:
+      match:
+        driver: virtio_net
+      dhcp4: false
+      dhcp6: false
+      optional: true

--- a/cisco/xrd-vrouter/docker/xrd-guest-init.service
+++ b/cisco/xrd-vrouter/docker/xrd-guest-init.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=XRd vRouter guest init (bind NICs + launch XRd container)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/guest-init.sh
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/cisco/xrd-vrouter/docker/xrd-unconfined
+++ b/cisco/xrd-vrouter/docker/xrd-unconfined
@@ -1,0 +1,16 @@
+#include <tunables/global>
+
+profile xrd-unconfined flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base> # For common system resources.
+  capability,
+  dbus,
+  file,
+  mount,
+  network,
+  pivot_root,
+  ptrace,
+  signal,
+  umount,
+  unix,
+  remount,
+}


### PR DESCRIPTION
## Cisco XRd vRouter

Adds a vrnetlab integration for **XRd vRouter**, the high-performance DPDK-dataplane form factor of containerized IOS-XR.

### Why a microVM wrapper

XRd ships as a container, and the **Control Plane** variant runs directly under containerlab's `cisco_xrd` kind. The **vRouter** variant cannot: its dataplane interfaces are PCI-only (`pci` / `pci-range` / `sriov`) and cannot bind a veth.

This integration runs the XRd vRouter container inside a small KVM guest that presents emulated `igb` PCI NICs (each in its own IOMMU group), wired to the vrnetlab `tc` datapath. The VFIO/IOMMU work happens inside the guest, so the node behaves like any other VM-based vrnetlab node.

### Building

XRd vRouter is distributed as a container image. Export it and run `make`:

```bash
docker save <registry>/xrd-vrouter:25.4.2 -o xrd-vrouter-25.4.2.tar
make
```

The build is self-contained and reproducible: it provisions a stock Ubuntu cloud image (cgroups v1, 1 GiB hugepages, IOMMU + vfio-pci, Docker, the AppArmor profile and the guest-init service) and preloads the XRd vRouter image. The build host needs nested virtualization (`/dev/kvm`).

### Validation

Built `vrnetlab/cisco_xrd-vrouter:25.4.2` and deployed a 2-node back-to-back lab under both the stock `cisco_xrv9k` kind and the dedicated `cisco_xrd_vrouter` kind:

- both nodes reach `healthy`
- native SSH (`clab` / `clab@123`), gNMI on `:9339`, NETCONF on `:830`
- `MgmtEth0/RP0/CPU0/0` carries the containerlab node IP
- 100% ICMP across the DPDK dataplane between the two routers

### Companion containerlab kind

A dedicated `cisco_xrd_vrouter` containerlab kind is proposed in a companion PR (srl-labs/containerlab#3247); this image also runs unmodified under the existing `cisco_xrv9k` kind today.
