### PR TITLE
cisco/xrd-vrouter: selectable dataplane NIC, default vmxnet3

### DIFF
--- a/cisco/xrd-vrouter/README.md
+++ b/cisco/xrd-vrouter/README.md
@@ -1,8 +1,8 @@
-# Cisco XRd vRouter
+# Cisco IOS XRd vRouter
 
-This is the vrnetlab integration for the **vRouter** form factor of Cisco XRd — the variant with the high-performance DPDK dataplane.
+This is the vrnetlab integration for **Cisco IOS XRd vRouter** — the high-performance DPDK-dataplane form factor of Cisco IOS XRd.
 
-Unlike the XRd Control Plane (which containerlab runs directly as `cisco_xrd`), XRd vRouter's dataplane interfaces are **PCI-only**; it cannot bind a veth. This integration solves that by running the XRd vRouter container inside a small KVM guest that presents emulated PCI NICs, so it can be wired with ordinary containerlab links like any other VM-based node.
+Unlike the XRd Control Plane (which containerlab runs directly as `cisco_xrd`), XRd vRouter's dataplane interfaces are **PCI-only**; it cannot bind a veth. This integration solves that by running the XRd vRouter container inside a small KVM guest (a micro-VM) that presents emulated PCI NICs, so it can be wired with ordinary containerlab links like any other VM-based node.
 
 ## Building the image
 
@@ -20,28 +20,60 @@ The build runs a short throwaway VM, so the build host needs nested virtualizati
 
 ## System requirements
 
-XRd vRouter requires, per running node: 2 vCPUs (one dedicated to the dataplane), ~5 GiB RAM and 3 GiB of 1 GiB hugepages. The launcher defaults to 4 vCPU / 10 GiB and enforces a hard floor of 8 GiB; tune with the `VCPU` / `RAM` node env in your topology. 8 GiB is feasible — in our testing an idle node booted and forwarded with ~800 MB RAM to spare — but that's tight, so give it more for feature-heavy labs.
+Per running node, XRd vRouter needs:
+
+- **vCPU** — at least 4 cores; the launcher defaults to and floors at 4.
+- **RAM** — ~5 GiB minimum; the launcher defaults to **10 GiB**, with a hard floor of **8 GiB**.
+- **Hugepages** — 3 GiB of 1 GiB hugepages.
+
+Tune vCPU/RAM with the `VCPU` / `RAM` node env. The 10 GiB default is comfortable; drop toward the 8 GiB floor only to fit more nodes on a host — at 8 GiB an idle node booted and forwarded with ~800 MB to spare, which leaves little headroom for feature-heavy configs.
+
+Unlike the control-plane `cisco_xrd`, the elevated inotify limits XR needs are tuned inside the micro-VM, so no host inotify tuning is required.
 
 ## Usage with containerlab
 
-XRd vRouter is IOS-XR, so it runs under the stock [`cisco_xrv9k`](https://containerlab.srlinux.dev/manual/kinds/vr-xrv9k/) kind. A dedicated [`cisco_xrd_vrouter`](https://containerlab.srlinux.dev/manual/kinds/cisco_xrd_vrouter/) kind is also available.
+Use the dedicated [`cisco_xrd_vrouter`](https://containerlab.srlinux.dev/manual/kinds/cisco_xrd_vrouter/) kind — it ships XRd vRouter's tuned defaults (4 vCPU / 10 GiB). The stock [`cisco_xrv9k`](https://containerlab.srlinux.dev/manual/kinds/vr-xrv9k/) kind is **also** compatible (XRd vRouter is IOS XR), but it defaults to XRv9k's heavier 2 vCPU / 16 GiB, so set `RAM` explicitly there.
 
 ```yaml
 name: xrd
 topology:
   nodes:
     r1:
-      kind: cisco_xrv9k
+      kind: cisco_xrd_vrouter
       image: vrnetlab/cisco_xrd-vrouter:25.4.2
       startup-config: r1.cfg
     r2:
-      kind: cisco_xrv9k
+      kind: cisco_xrd_vrouter
       image: vrnetlab/cisco_xrd-vrouter:25.4.2
       startup-config: r2.cfg
   links:
     - endpoints: ["r1:eth1", "r2:eth1"]
 ```
 
-Management (SSH, gNMI on `:9339`, NETCONF on `:830`) uses the default credentials `clab` / `clab@123`. The router's `MgmtEth0/RP0/CPU0/0` carries the containerlab node IP. Data-plane interface config comes from each node's `startup-config`; `eth1`, `eth2`, … map to `GigabitEthernet0/0/0/0`, `…/1`, … in order.
+Management (SSH, gNMI on `:9339`, NETCONF on `:830`) uses the default credentials `clab` / `clab@123`. The router's `MgmtEth0/RP0/CPU0/0` carries the containerlab node IP. Dataplane interface config comes from each node's `startup-config`; `eth1`, `eth2`, … map to the data interfaces in order — `TenGigE0/0/0/0`, `…/1`, … by default (see [Dataplane NIC](#dataplane-nic) for the interface naming).
 
 > Emulated NIC throughput is suitable for feature, protocol and dataplane-behaviour labs, not line-rate performance testing.
+
+## Dataplane NIC
+
+`XRD_NIC_TYPE` selects the emulated data-NIC model — both are on XRd vRouter's supported-PCI allowlist:
+
+| `XRD_NIC_TYPE`        | XR interface              | Speed  | Notes                          |
+| --------------------- | ------------------------- | ------ | ------------------------------ |
+| `vmxnet3` *(default)* | `TenGigE0/0/0/X`          | 10 GbE | ~1.5× faster bulk forwarding   |
+| `igb`                 | `GigabitEthernet0/0/0/X`  | 1 GbE  | alternative                    |
+
+Either way `eth1`, `eth2`, … map to the data interfaces in order — just make sure your `startup-config` uses the matching interface names. `XRD_NIC_TYPE` affects only the data interfaces; the management NIC is always a lightweight paravirtual virtio-net.
+
+```yaml
+    r1:
+      kind: cisco_xrd_vrouter
+      image: vrnetlab/cisco_xrd-vrouter:25.4.2
+      env:
+        XRD_NIC_TYPE: igb   # optional; default is vmxnet3
+      startup-config: r1.cfg   # with igb, interface names must be GigabitEthernet0/0/0/X
+```
+
+## Troubleshooting
+
+**Bulk TCP between a Linux host and the node stalls, while ping and UDP work.** The emulated host↔node datapath can silently drop full-size (1500-byte) frames in a sustained TCP flow even though equally large single packets pass — a path-MTU black hole in the emulated datapath, not an XRd forwarding issue. Lower the MTU on the Linux endpoints (`ip link set eth1 mtu 1400`) or clamp TCP MSS; the node itself needs no change.

--- a/cisco/xrd-vrouter/docker/guest-init.sh
+++ b/cisco/xrd-vrouter/docker/guest-init.sh
@@ -3,10 +3,10 @@
 #
 #   1. Read per-node config from the config CD the launcher attaches (/dev/sr0):
 #      nodename + first-boot.cfg (XR config: clab user, ssh/grpc/netconf + user cfg).
-#   2. Discover the virtio mgmt NIC and the emulated igb data NICs.
+#   2. Discover the virtio mgmt NIC and the emulated data NICs (igb or vmxnet3).
 #   3. Run the XRd vRouter container with host networking so XR shares the VM
 #      mgmt NIC (XR owns the management address explicitly via first-boot.cfg),
-#      and map each igb data NIC to Gi0/0/0/N.
+#      and map each data NIC to an XR data interface (Gi.. for igb, Te.. for vmxnet3).
 #   4. When XR is up and MgmtEth is up, print the readiness marker on the console
 #      so the vrnetlab launcher (watching the serial) marks the node up.
 set -euo pipefail
@@ -36,7 +36,12 @@ fi
 echo "node=$NODENAME image=$IMG"
 
 # ---------------------------------------------------------------------------
-# 2. Discover NICs. Mgmt = virtio_net; data = igb (8086:10c9), PCI-sorted.
+# 2. Discover NICs. Mgmt = the virtio_net interface (on bus 0000:00). Data NICs
+#    are whatever the launcher placed on the PCIe root ports (bus != 00) -- igb
+#    or vmxnet3 depending on XRD_NIC_TYPE. We match by PCI topology (Ethernet-
+#    controller class, not on bus 00) rather than a fixed device ID, so one path serves both
+#    NIC models, and via lspci so it works before any kernel driver binds them
+#    (XR binds them to vfio-pci anyway).
 # ---------------------------------------------------------------------------
 MGMT_IF=""
 for n in /sys/class/net/*; do
@@ -47,12 +52,13 @@ for n in /sys/class/net/*; do
 done
 echo "mgmt interface: ${MGMT_IF:-NONE}"
 
-mapfile -t PCIS < <(lspci -Dn | awk '$3 ~ /8086:10c9/ {print $1}' | sort)
-echo "igb data NIC(s): ${PCIS[*]:-none}"
+mapfile -t PCIS < <(lspci -Dn | awk '$2 ~ /^0200/ && $1 !~ /^0000:00:/ {print $1}' | sort)
+echo "data NIC(s): ${PCIS[*]:-none}"
 
 # NB: xr_name is NOT valid for pci interfaces on vRouter; XR numbers them
-# Gi0/0/0/0,1,... in the order listed here. We list in PCI order, which matches
-# the eth1,eth2,... order (each ethN -> rpN -> ascending PCI address).
+# Te0/0/0/0,1,... (vmxnet3, the default) or Gi0/0/0/0,1,... (igb) in the order
+# listed here. We list in PCI order, which matches the eth1,eth2,... order
+# (each ethN -> rpN -> ascending PCI address).
 XR_IFS=""
 for d in "${PCIS[@]}"; do
     short=${d#0000:}

--- a/cisco/xrd-vrouter/docker/launch.py
+++ b/cisco/xrd-vrouter/docker/launch.py
@@ -3,16 +3,16 @@
 
 XRd vRouter is distributed as a *container* whose dataplane needs PCI NICs, so it
 cannot run directly as a vrnetlab VM. This launcher boots a thin micro-VM (the
-"golden" qcow2) that provides q35 + Intel vIOMMU and emulated igb NICs; inside,
-guest-init runs the XRd vRouter container and binds those NICs to vfio-pci for
-its DPDK dataplane.
+"golden" qcow2) that provides q35 + Intel vIOMMU and emulated data NICs (vmxnet3
+by default, or igb); inside, guest-init runs the XRd vRouter container and binds
+those NICs to vfio-pci for its DPDK dataplane.
 
 By subclassing vrnetlab.VM we inherit the full containerlab-native machinery:
 tc-mirred datapath stitching, management port-forwarding (SSH/NETCONF/gNMI/SNMP),
 credentials, interface aliasing and health. We only override the bits that differ
 for the nested model:
-  * gen_nics(): emulated igb on per-NIC PCIe root ports (isolated IOMMU groups),
-    reusing the framework's tc taps.
+  * gen_nics(): emulated data NICs (vmxnet3 or igb) on per-NIC PCIe root ports
+    (isolated IOMMU groups), reusing the framework's tc taps.
   * machine: q35 + intel-iommu (+ virtio-balloon for RAM reclaim).
   * a config CD delivering XR first-boot config + node params to guest-init.
   * bootstrap: wait for guest-init's readiness marker on the VM console.
@@ -54,7 +54,7 @@ class XRd_vRouter_vm(vrnetlab.VM):
         if disk_image is None:
             raise FileNotFoundError("no golden .qcow2 found in /")
 
-        # vRouter needs >=2 dedicated CPUs (dataplane) + control plane; floor at 4.
+        # vRouter needs >=4 cores (dataplane + control plane); floor at 4.
         vcpu = max(int(vcpu), 4)
         # Needs ~5GiB RAM + 3GiB hugepages inside the VM; default 10GiB, hard floor 8GiB.
         ram = max(int(ram), 8192)
@@ -75,6 +75,16 @@ class XRd_vRouter_vm(vrnetlab.VM):
         self.nic_type = "virtio-net-pci"   # management NIC type
         self.provision_pci_bus = False     # we place data NICs on our own root ports
 
+        # Dataplane NIC model. vmxnet3 (default) is paravirtual, ~1.5× faster
+        # than igb for bulk forwarding, and XRd models it as TenGigE (10G). igb
+        # (GigabitEthernet, 1G) stays available via XRD_NIC_TYPE. Both device IDs
+        # are on XRd vRouter's supported-PCI allowlist.
+        self.data_nic = os.getenv("XRD_NIC_TYPE", "vmxnet3").strip().lower()
+        if self.data_nic not in ("vmxnet3", "igb"):
+            raise ValueError(
+                f"XRD_NIC_TYPE must be 'vmxnet3' or 'igb', got {self.data_nic!r}"
+            )
+
         # Passthrough management: the framework tc-mirreds the container's eth0
         # (the clab node IP) to the VM mgmt NIC, so XR's MgmtEth carries the real
         # clab management IP over a transparent L2 bridge. Passthrough rather than
@@ -85,7 +95,7 @@ class XRd_vRouter_vm(vrnetlab.VM):
         self.mgmt_gw_ipv4, self.mgmt_gw_ipv6 = self.get_mgmt_gw()
 
         # Switch machine to q35 + split irqchip and add an Intel vIOMMU so the
-        # guest can bind the igb NICs to vfio-pci; add a balloon for RAM reclaim.
+        # guest can bind the data NICs to vfio-pci; add a balloon for RAM reclaim.
         self._patch_machine_and_iommu()
 
         # Build the config CD (node name + XR first-boot config) and attach it.
@@ -171,8 +181,9 @@ grpc
 
     # ------------------------------------------------------------- overrides
     def gen_nics(self):
-        """Emulated igb data NICs, each on its own PCIe root port (own IOMMU
-        group), wired to the framework's tc taps (tapN <-> ethN)."""
+        """Emulated data NICs (vmxnet3 or igb, per XRD_NIC_TYPE), each on its own
+        PCIe root port (own IOMMU group), wired to the framework's tc taps
+        (tapN <-> ethN)."""
         if self.conn_mode == "tc":
             self.create_tc_tap_ifup()
         # wait for containerlab to provision the data interfaces
@@ -186,7 +197,7 @@ grpc
             netdev = f"p{i:02d}"
             res.extend([
                 "-device", f"pcie-root-port,id=rp{i},bus=pcie.0,chassis={chassis},slot={chassis}",
-                "-device", f"igb,netdev={netdev},mac={mac},bus=rp{i}",
+                "-device", f"{self.data_nic},netdev={netdev},mac={mac},bus=rp{i}",
             ])
             if self.conn_mode == "tc":
                 res.extend([
@@ -197,7 +208,7 @@ grpc
                 res.extend(["-netdev", f"socket,id={netdev},listen=:{i + 10000:02d}"])
             i += 1
             chassis += 1
-        self.logger.info(f"generated {chassis - 1} igb data NIC(s)")
+        self.logger.info(f"generated {chassis - 1} {self.data_nic} data NIC(s)")
         return res
 
     def bootstrap_spin(self):


### PR DESCRIPTION
Follow-up to #484 (the merged base integration). Adds an `XRD_NIC_TYPE` node env to select the emulated dataplane NIC:

| `XRD_NIC_TYPE` | XR interface | Speed |
| --- | --- | --- |
| `vmxnet3` (new default) | `TenGigE0/0/0/X` | 10 GbE |
| `igb` (previous) | `GigabitEthernet0/0/0/X` | 1 GbE |

vmxnet3 forwards bulk traffic ~1.5× faster than igb in a nested-VM benchmark; `igb` stays available via `XRD_NIC_TYPE=igb`. Both device IDs are on XRd vRouter's supported-PCI allowlist (modern virtio is rejected by XRd's platform check, so vmxnet3 is the fast paravirtual option).

Also in this PR:

- `guest-init` NIC discovery is now NIC-model-agnostic — it matches data NICs by PCI topology via `lspci` instead of a fixed igb device ID, so one code path serves both NIC models.
- README documents `XRD_NIC_TYPE`, the interface-naming implication, and an MTU-stall troubleshooting note.

Changing the default is safe while the kind is still pre-release (not in a release, no users yet). Validated with a full reproducible `make` build plus two-node deploys of both NIC types — boot, startup-config and forwarding all confirmed.

Companion containerlab kind PR: srl-labs/containerlab#3248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
