### PR TITLE
huawei_vrp: fix bootstrap_spin race that drops the <HUAWEI> console prompt

### DIFF
--- a/huawei/huawei_vrp/docker/launch.py
+++ b/huawei/huawei_vrp/docker/launch.py
@@ -99,6 +99,9 @@ class VRP_vm(vrnetlab.VM):
             self.start()
             return
 
+        # Nudge the console so the prompt is re-printed if a previous read consumed it.
+        self.tn.write(b"\r\n")
+
         # First check for prompt
         (ridx, match, res) = self.tn.expect([b"<HUAWEI>"], 1)
 
@@ -123,8 +126,8 @@ class VRP_vm(vrnetlab.VM):
                     self.logger.info(f"DEVICE: {line}")
             self.spins = 0  # reset spin counter if we saw anything
 
-        # If prompt matched do config
-        if match and ridx == 0:
+        # If prompt matched (via expect OR drained into full_output) do config
+        if (match and ridx == 0) or (b"<HUAWEI>" in full_output):
             
             # fetch VRP version first
             self.logger.info("Fetching VRP version...")


### PR DESCRIPTION
## Summary

`VRP_vm.bootstrap_spin()` can miss the `<HUAWEI>` console prompt and stall boot
indefinitely until the 300-spin restart loop fires (then repeats). The node never
becomes healthy and management is never configured. Reproducible on VRP **V800R023**
and on hosts booting several NE40E in parallel.

## Root cause — a read race

`bootstrap_spin()` calls `telnetlib.expect([b"<HUAWEI>"], 1)` and then *immediately*
`read_very_eager()`:

```python
(ridx, match, res) = self.tn.expect([b"<HUAWEI>"], 1)
try:
    extra_output = self.tn.read_very_eager()   # <-- drains the prompt out of the stream
except EOFError:
    extra_output = b""
full_output = b"".join([res or b"", extra_output or b""])
...
if match and ridx == 0:    # only configures if expect() itself matched
    ...
```

When the `<HUAWEI>` prompt arrives appended to the post-login banner (the common case),
the 1-second `expect()` returns on timeout *without* a match and the following
`read_very_eager()` swallows the banner **and the prompt**. `full_output` is logged and
`self.spins` is reset, but `match` is `None`, so the configure branch is never taken.
The device then sits idle at `<HUAWEI>` emitting nothing, so no later spin can ever match
the prompt. Detection is purely timing-dependent and fails reliably under boot
parallelism.

## Fix

Detect the prompt from the **combined buffered output** rather than solely from
`expect()`'s return value, and nudge the console with `\r\n` each spin so the prompt is
re-emitted if a prior read consumed it:

```python
self.tn.write(b"\r\n")                       # re-print the prompt if it was consumed
(ridx, match, res) = self.tn.expect([b"<HUAWEI>"], 1)
...
if (match and ridx == 0) or (b"<HUAWEI>" in full_output):
    ...
```

The two changes are independent and complementary: `b"<HUAWEI>" in full_output` closes
the common race (prompt drained by `read_very_eager`); the per-spin `\r\n` recovers the
pathological case where the prompt was already consumed and the device is silent.

## Validation

The rebuilt `ne40e-V8.23` (V800R023) image reaches `bootstrap_config()` reliably across
repeated deploys, including 8 NE40E booting in one topology.

## Compatibility

Against current `master` (`f0b8b75`, #488). The affected `bootstrap_spin` pattern is
present unchanged upstream and on `hellt/vrnetlab` master. Touches only
`huawei/huawei_vrp/docker/launch.py`.
