### PR TITLE
huawei_vrp: configure IPv6 management address in passthrough mode

### DIFF
--- a/huawei/huawei_vrp/docker/launch.py
+++ b/huawei/huawei_vrp/docker/launch.py
@@ -169,6 +169,9 @@ class VRP_vm(vrnetlab.VM):
         self.wait_write(cmd="ip vpn-instance __MGMT_VPN__", wait="]")
         self.wait_write(cmd="ipv4-family", wait="]")
         self.wait_write(cmd="quit", wait="]")
+        if self.mgmt_address_ipv6 and self.mgmt_address_ipv6 != "dhcp":
+            self.wait_write(cmd="ipv6-family", wait="]")
+            self.wait_write(cmd="quit", wait="]")
         self.wait_write(cmd="quit", wait="]")
         if self.vm_type == "CE12800":
             mgmt_interface = "MEth"
@@ -185,10 +188,19 @@ class VRP_vm(vrnetlab.VM):
         self.wait_write(cmd="undo shutdown", wait=None)
         self.wait_write(cmd="ip binding vpn-instance __MGMT_VPN__", wait="]")
         self.wait_write(cmd=f"ip address {self.mgmt_address_ipv4.replace('/', ' ')}", wait="]")
+        if self.mgmt_address_ipv6 and self.mgmt_address_ipv6 != "dhcp":
+            self.wait_write(cmd="ipv6 enable", wait="]")
+            self.wait_write(
+                cmd=f"ipv6 address {self.mgmt_address_ipv6.replace('/', ' ')}", wait="]"
+            )
         self.wait_write(cmd="quit", wait="]")
         self.wait_write(
             cmd=f"ip route-static vpn-instance __MGMT_VPN__ 0.0.0.0 0 {self.mgmt_gw_ipv4}", wait="]"
         )
+        if self.mgmt_address_ipv6 and self.mgmt_address_ipv6 != "dhcp":
+            self.wait_write(
+                cmd=f"ipv6 route-static vpn-instance __MGMT_VPN__ :: 0 {self.mgmt_gw_ipv6}", wait="]"
+            )
 
     def bootstrap_config(self):
         """Do the actual bootstrap config"""
@@ -263,9 +275,11 @@ class VRP_vm(vrnetlab.VM):
         # Enable stelnet, sftp, scp, ssh
         self.wait_write(cmd="stelnet server enable", wait="]")
         self.wait_write(cmd="sftp ipv4 server enable", wait="]")
+        self.wait_write(cmd="sftp ipv6 server enable", wait="]")
         self.wait_write(cmd="scp server enable", wait="]")
         self.wait_write(cmd="ssh authentication-type default password", wait="]")
         self.wait_write(cmd="ssh server-source all-interface", wait="]")
+        self.wait_write(cmd="ssh ipv6 server-source all-interface", wait="]")
         self.wait_write(cmd="sftp server default-directory cfcard:/", wait="]")
 
         # Set some ciphers for compatibility


### PR DESCRIPTION
## Summary

The Huawei IPv4 management bootstrap in passthrough mode (already upstream) only ever
applied the **IPv4** mgmt address and route. When the clab management network has an
`ipv6-subnet`, `get_mgmt_address()` also returns an IPv6 address — but it was never
applied to the device, so nodes had **no OOB IPv6 connectivity**. This PR completes the
passthrough management support that the IPv4 change left half-done.

## What it adds

In `bootstrap_mgmt_interface()`, when an IPv6 mgmt address is assigned:

- `ipv6-family` under `ip vpn-instance __MGMT_VPN__` (same VRF as the IPv4 mgmt address)
- `ipv6 enable` + `ipv6 address <addr>` on the management interface
- an IPv6 default route in the `__MGMT_VPN__` instance
- `sftp ipv6 server enable` + `ssh ipv6 server-source all-interface` so the node is
  actually reachable over IPv6 for OOB management

IPv6 is kept in the **same `__MGMT_VPN__` VRF as IPv4**, matching the existing IPv4 design.

## Back-compat

Every change is guarded:

```python
if self.mgmt_address_ipv6 and self.mgmt_address_ipv6 != "dhcp":
    ...
```

so it is a complete no-op on labs whose mgmt network declares no `ipv6-subnet`. Existing
IPv4-only topologies are unaffected.

## Context

This mirrors the locally-tested change that had been sitting unmerged — the IPv6 half
that was forgotten when the original IPv4 passthrough support was merged.

## Validation

On NE40E **V800R023** with a dual-stack mgmt network: the IPv6 mgmt config applies and the
node is reachable over IPv6 — `ping6` and **SSH login over the IPv6 mgmt address both
succeed**. (Full end-to-end IPv6 SSH also relies on the boot-hang fix and the passthrough
checksum fix submitted as the companion PRs.)

## Compatibility

Against current `master` (`f0b8b75`, #488). Touches only
`huawei/huawei_vrp/docker/launch.py`.
