### PR TITLE
vrnetlab: recompute checksums on the passthrough mgmt datapath so OOB TCP/SSH works

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -596,8 +596,12 @@ class VM:
         tc filter add dev {MGMT_INTF} ingress prio 1 protocol ip flower ip_proto tcp dst_port 5000-5007 action pass
         # mirror ARP traffic to container
         tc filter add dev {MGMT_INTF} ingress prio 2 protocol arp flower action mirred egress mirror dev tap0
-        # redirect rest of ingress traffic of eth0 to egress of tap0
-        tc filter add dev {MGMT_INTF} ingress prio 3 flower action mirred egress redirect dev tap0
+        # redirect rest of ingress traffic of eth0 to egress of tap0, recomputing
+        # L3/L4 checksums first: the host offloads checksums (CHECKSUM_PARTIAL), and
+        # the tc-mirred path to the VM would otherwise deliver packets with bad
+        # checksums that a checksum-strict NOS (e.g. Huawei VRP) silently drops -
+        # breaking all TCP (SSH/NETCONF) to the mgmt IP while ICMP still works.
+        tc filter add dev {MGMT_INTF} ingress prio 3 flower action csum ip and tcp and udp and icmp pipe action mirred egress redirect dev tap0
 
         tc qdisc add dev tap0 clsact
         # redirect all ingress traffic of tap0 to egress of eth0
@@ -605,6 +609,15 @@ class VM:
 
         # clone management MAC of the VM
         ip link set dev {MGMT_INTF} address {MGMT_MAC}
+
+        # The clab-assigned mgmt IP lives on the container eth0 *and* on the VM.
+        # The MAC clone above is meant to keep them indistinguishable, but some
+        # NOSes (e.g. Huawei VRP) assign their mgmt port a different MAC, so the
+        # container would shadow the VM in ARP (host resolves the v4 mgmt IP to
+        # eth0, not the VM). Make the container never answer ARP for the mgmt IP
+        # so only the VM does. (IPv6 already defers via duplicate-address detection.)
+        sysctl -qw net.ipv4.conf.{MGMT_INTF}.arp_ignore=8 || true
+        sysctl -qw net.ipv4.conf.{MGMT_INTF}.arp_announce=2 || true
         """
 
         ifup_script = ifup_script.replace("{MGMT_INTF}", self.mgmt_intf)

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -598,9 +598,8 @@ class VM:
         tc filter add dev {MGMT_INTF} ingress prio 2 protocol arp flower action mirred egress mirror dev tap0
         # redirect rest of ingress traffic of eth0 to egress of tap0, recomputing
         # L3/L4 checksums first: the host offloads checksums (CHECKSUM_PARTIAL), and
-        # the tc-mirred path to the VM would otherwise deliver packets with bad
-        # checksums that a checksum-strict NOS (e.g. Huawei VRP) silently drops -
-        # breaking all TCP (SSH/NETCONF) to the mgmt IP while ICMP still works.
+        # the tc-mirred path to the VM would otherwise deliver packets with fake
+        # checksums that a checksum-strict NOSes silently drop.
         tc filter add dev {MGMT_INTF} ingress prio 3 flower action csum ip and tcp and udp and icmp pipe action mirred egress redirect dev tap0
 
         tc qdisc add dev tap0 clsact


### PR DESCRIPTION
## Summary

In **management passthrough mode** (`CLAB_MGMT_PASSTHROUGH=true`) out-of-band TCP to a VM's
management IP is broken for any NOS that validates inbound checksums: **ICMP works, but all TCP
(SSH/22, NETCONF/830) silently fails — no SYN-ACK.** This makes a freshly-booted node unreachable
over SSH even though it pings.

This PR fixes the passthrough management datapath in `common/vrnetlab.py` (the `tc-tap-mgmt-ifup`
script that wires the container's `eth0` to the VM's `tap0`). It is **not platform-specific** — it
was found with Huawei VRP but affects any guest with a checksum-strict stack.

## Root cause

In passthrough mode the container keeps the clab-assigned mgmt IP on `eth0` and forwards
`eth0` ⇄ `tap0` with `tc` clsact/mirred:

```
tc filter add dev eth0 ingress prio 3 flower action mirred egress redirect dev tap0
tc filter add dev tap0 ingress flower action mirred egress redirect dev eth0
```

The host originates packets to the mgmt IP with **TX checksum offload** — the L4 checksum is left
incomplete (`CHECKSUM_PARTIAL`), to be filled in by hardware on egress. In this purely virtual
`veth → tc-mirred → tap` path there is no NIC to do that, so the packet reaches the VM with an
**incorrect/zero TCP/UDP checksum**. A checksum-strict NOS drops it.

ICMP keeps working because `ping` (and the kernel for locally-generated ICMP) computes the ICMP
checksum in software, so it arrives valid.

### Evidence (Huawei NE40E, VRP V800R023)

Packet capture on the VM-side `tap0` while connecting to `:22`:

```
IP 172.23.23.1.54522 > 172.23.23.2.22: Flags [S] ...   <- SYN reaches the VM
IP 172.23.23.1 > 172.23.23.2: ICMP echo request        <- ICMP round-trips
IP 172.23.23.2 > 172.23.23.1: ICMP echo reply
# ...but no SYN-ACK is ever emitted by the VM
```

The VM's own TCP counters confirm the drop:

```
<r1> display tcp statistics
  ...
  Checksum error: 24        <- inbound SYNs dropped here
```

Proven both directions: disabling TX checksum offload on the host-side veth made SSH work
immediately; re-enabling it broke it again.

## Fix

Two changes in the `tc-tap-mgmt-ifup` script:

**1. Recompute checksums before handing the packet to the VM.** Add a `csum` action to the
`eth0 → tap0` ingress redirect so the kernel computes the IPv4 header and L4 checksums in software:

```diff
- tc filter add dev {MGMT_INTF} ingress prio 3 flower action mirred egress redirect dev tap0
+ tc filter add dev {MGMT_INTF} ingress prio 3 flower action csum ip and tcp and udp and icmp pipe action mirred egress redirect dev tap0
```

Only the `eth0 → tap0` (host → VM) direction needs it; the VM computes correct checksums itself,
so the return path is unaffected.

**2. Stop the container from shadowing the VM's ARP (IPv4).** The mgmt IP exists on both the
container `eth0` and the VM. The existing `ip link set dev eth0 address {MGMT_MAC}` is meant to
make them indistinguishable, but some NOSes (e.g. Huawei VRP) assign their management port a
**different MAC** than the cloned one, so the container answers ARP for the mgmt IP and the host
resolves it to `eth0` instead of the VM. IPv6 is unaffected because duplicate-address detection
makes the container defer. Make only the VM answer ARP:

```diff
+ sysctl -qw net.ipv4.conf.{MGMT_INTF}.arp_ignore=8 || true
+ sysctl -qw net.ipv4.conf.{MGMT_INTF}.arp_announce=2 || true
```

## Why it's safe / backwards compatible

- The `csum` action recomputes checksums that are *already correct* to the same value, so guests
  that were working are unaffected; it only repairs the offloaded-but-uncomputed case.
- It runs only on the management passthrough datapath (a few packets/sec of mgmt traffic), so the
  per-packet cost is negligible.
- `arp_ignore`/`arp_announce` only change who answers ARP for the duplicate mgmt IP; the VM
  (the intended responder) is unaffected, and the `|| true` keeps it a no-op if unsupported.

## Validation

Built `vrnetlab/huawei_vrp:ne40e-V8.23` (V800R023) and deployed a node with a dual-stack mgmt
network. **Out of the box** (no manual steps), with mgmt kept in the `__MGMT_VPN__` VRF:

| | ping | TCP/22 | SSH login |
|---|---|---|---|
| IPv4 | ok | open | ✅ `display clock` returns the device time |
| IPv6 | ok | open | ✅ login succeeds (`... through SSH`) |

## Compatibility

Rebased on current `master` (`f0b8b75`, #488); applies cleanly, no conflicts. The edited
`VM` passthrough-datapath block is unchanged upstream.
