### PR TITLE
routeros: Check for `/dev/kvm` on `x86_64` before setting `cpu=host`

### DIFF
--- a/mikrotik/routeros/docker/launch.py
+++ b/mikrotik/routeros/docker/launch.py
@@ -67,8 +67,8 @@ class ROS_vm(vrnetlab.VM):
             ram_size = 256
             cpu_type = "qemu64"
 
-        # the default cpu=host only works when running clab on an amd64 machine
-        extra_args = {} if platform.machine() == "x86_64" else {"cpu": cpu_type}
+        # cpu=host requires both an amd64 image and KVM available on the host
+        extra_args = {} if platform.machine() == "x86_64" and os.path.exists("/dev/kvm") else {"cpu": cpu_type}
 
         super(ROS_vm, self).__init__(username, password, disk_image=disk_image, ram=ram_size, driveif="virtio", arch=arch, **extra_args)
         if self.arch != "aarch64":


### PR DESCRIPTION
`mikrotik/routeros/launch.py` currently assumes that if it's being started on an `x86_64` host, it must be native and therefore `-cpu=host` will be OK.

Due to the way cross-platform support works however, when launching an *AMD64* image on an *ARM64* host, the container is already in an emulated `x86_64` environment, and so `launch.py` will always attempt to use `-cpu=host` even though this is not supported.

This results in the following error on boot:
```
2026-07-03 12:52:37,729: vrnetlab       INFO Launching ROS_vm arch x86_64 with 1 SMP/VCPU and 256 M of RAM
2026-07-03 12:52:37,729: vrnetlab       INFO Transparent mgmt interface: Disabled
2026-07-03 12:52:37,730: vrnetlab       DEBUG number of provisioned data plane interfaces is 0
2026-07-03 12:52:37,730: vrnetlab       DEBUG qemu cmd: qemu-system-x86_64 -display none -machine pc -chardev socket,id=monitor0,host=::,port=4000,server=on,wait=off -monitor chardev:monitor0 -chardev socket,id=serial0,host=::,port=5000,server=on,wait=off,telnet=on -serial chardev:serial0 -m 256 -cpu host -smp 1 -drive if=virtio,file=/chr-7.14.3-overlay.vdi -boot n -device pci-bridge,chassis_nr=1,id=pci.1 -device pci-bridge,chassis_nr=2,id=pci.2 -device virtio-net,speed=10000,duplex=full,romfile=,netdev=br-mgmt,mac=0C:00:d2:67:cf:00 -netdev bridge,br=br-mgmt,id=br-mgmt
2026-07-03 12:52:37,943: vrnetlab       INFO STDOUT: 
2026-07-03 12:52:37,943: vrnetlab       INFO STDERR: qemu-system-x86_64: CPU model 'host' requires KVM or HVF
```

To mitigate this, I've updated the `platform.machine() == "x86_64"` check to also confirm the presence of `/dev/kvm`.  If this doesn't exist `launch.py` will fallback to using `-cpu=qemu64` instead.

I've tested this on both AMD64 and ARM64 (Apple M4).

AMD64:
```
2026-07-03 13:26:04,224: vrnetlab   	INFO -----------------END ENVIRONMENT VARIABLES------------------
2026-07-03 13:26:04,224: vrnetlab   	INFO Launching ROS_vm arch x86_64 with 1 SMP/VCPU and 256 M of RAM
2026-07-03 13:26:04,224: vrnetlab   	INFO Scrapli: Disabled
2026-07-03 13:26:04,224: vrnetlab   	INFO Transparent mgmt interface: Disabled
2026-07-03 13:26:04,225: vrnetlab   	DEBUG number of provisioned data plane interfaces is 0
2026-07-03 13:26:04,225: vrnetlab   	DEBUG qemu cmd: qemu-system-x86_64 -enable-kvm -display none -machine pc -chardev socket,id=monitor0,host=::,port=4000,server=on,wait=off -monitor chardev:monitor0 -chardev socket,id=serial0,host=::,port=5000,server=on,wait=off,telnet=on -serial chardev:serial0 -m 256 -cpu host -smp 1 -drive if=virtio,file=/chr-7.23.1-overlay.vdi -boot n -device pci-bridge,chassis_nr=1,id=pci.1 -device pci-bridge,chassis_nr=2,id=pci.2 -device virtio-net,speed=10000,duplex=full,host_mtu=9570,romfile=,netdev=br-mgmt,mac=0C:00:7a:1d:0e:00 -netdev bridge,br=br-mgmt,id=br-mgmt
```

ARM64:
```
2026-07-03 13:25:15,055: vrnetlab       INFO -----------------END ENVIRONMENT VARIABLES------------------
2026-07-03 13:25:15,055: vrnetlab       INFO Launching ROS_vm arch x86_64 with 1 SMP/VCPU and 256 M of RAM
2026-07-03 13:25:15,055: vrnetlab       INFO Transparent mgmt interface: Disabled
2026-07-03 13:25:15,055: vrnetlab       DEBUG number of provisioned data plane interfaces is 0
2026-07-03 13:25:15,056: vrnetlab       DEBUG qemu cmd: qemu-system-x86_64 -display none -machine pc -chardev socket,id=monitor0,host=::,port=4000,server=on,wait=off -monitor chardev:monitor0 -chardev socket,id=serial0,host=::,port=5000,server=on,wait=off,telnet=on -serial chardev:serial0 -m 256 -cpu qemu64 -smp 1 -drive if=virtio,file=/chr-7.23.1-overlay.vdi -boot n -device pci-bridge,chassis_nr=1,id=pci.1 -device pci-bridge,chassis_nr=2,id=pci.2 -device virtio-net,speed=10000,duplex=full,romfile=,netdev=br-mgmt,mac=0C:00:5f:f1:7f:00 -netdev bridge,br=br-mgmt,id=br-mgmt
```

I've intentionally avoided changing this check to `platform == host` + `/dev/kvm` which would allow `-cpu=host` on ARM64 hosts for ARM64 images, as I do not have a Linux ARM64 capable host to test on.