### PR TITLE
routeros: Add `*.vdi` to `.gitignore` and `makefile.include`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ cisco*.bin
 *.gz
 *.xz
 *.vmdk
+*.vdi
 *.iso
 *cidfile
 

--- a/makefile.include
+++ b/makefile.include
@@ -25,7 +25,7 @@ endif
 
 docker-clean-build:
 	@echo "--> Cleaning docker build context"
-	-rm -f docker/*.qcow2* docker/*.tgz* docker/*.vmdk* docker/*.iso docker/*.xml docker/*.bin
+	-rm -f docker/*.qcow2* docker/*.tgz* docker/*.vmdk* docker/*.vdi* docker/*.iso docker/*.xml docker/*.bin
 	-rm -f docker/healthcheck.py docker/vrnetlab.py
 
 docker-pre-build: ;


### PR DESCRIPTION
Commit ab00abe added `*.vdi` as a supported image type for MikroTik RouterOS builds, but did not add it to `.gitignore` or the `docker-clean-build` stage in `makefile.include`.

This PR adds the `*.vdi` extension to both of these locations.