### PR TITLE
common: add optional macvtap passthru datapath

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -591,6 +591,45 @@ class VM:
             f.write(ifup_script)
         os.chmod("/etc/tc-tap-ifup", 0o777)
 
+    def create_macvtap(self, i):
+        """Create a passthru macvtap for data interface eth<i>.
+
+        Returns (mac, tapidx): the macvtap's MAC (the guest NIC must use it)
+        and its ifindex, which names the /dev/tap<ifindex> character device
+        qemu attaches to.
+
+        This backs the optional "macvtap" datapath: each data interface is
+        attached to the VM through a passthru macvtap. It is useful on host
+        kernels where the default tc-mirred egress redirect into the tap does
+        not deliver frames to the guest.
+        """
+        intf = f"{self.data_intf_prefix}{i}"
+        macvtap = f"macvtap{i}"
+        run_command(
+            ["ip", "link", "add", "link", intf, "name", macvtap,
+             "type", "macvtap", "mode", "passthru"]
+        )
+        with open(f"/sys/class/net/{intf}/mtu") as f:
+            mtu = f.readline().strip()
+        run_command(["ip", "link", "set", "dev", macvtap, "mtu", mtu])
+        run_command(["ip", "link", "set", "dev", macvtap, "up"])
+        # allmulticast + promisc so the guest receives reserved multicast
+        # (e.g. LACP), not just unicast/broadcast.
+        run_command(["ip", "link", "set", "dev", macvtap, "promisc", "on"])
+        run_command(["ip", "link", "set", "dev", macvtap, "allmulticast", "on"])
+        with open(f"/sys/class/net/{macvtap}/address") as f:
+            mac = f.readline().strip()
+        with open(f"/sys/class/net/{macvtap}/ifindex") as f:
+            tapidx = f.readline().strip()
+        # Some container runtimes have no devtmpfs, so /dev/tap<ifindex> may
+        # not exist. Create it so qemu opens the macvtap character device
+        # instead of the shell fd redirect creating a regular file.
+        with open(f"/sys/class/macvtap/tap{tapidx}/dev") as f:
+            major, minor = f.readline().strip().split(":")
+        run_command(["rm", "-f", f"/dev/tap{tapidx}"])
+        run_command(["mknod", f"/dev/tap{tapidx}", "c", major, minor])
+        return mac, tapidx
+
     def create_tc_tap_mgmt_ifup(self):
         """Create tap ifup script that is used in tc datapath mode, specifically for the management interface"""
         ifup_script = """#!/bin/bash
@@ -901,6 +940,31 @@ class VM:
                         "-netdev",
                         f"socket,id=p{i:02d},listen=:{i + 10000:02d}",
                     ]
+                )
+                continue
+
+            # macvtap passthru datapath (opt-in via CONNECTION_MODE=macvtap).
+            # The guest NIC uses the macvtap's MAC, and qemu attaches to the
+            # macvtap character device over the vhost fd path (a raw macvtap
+            # fd cannot answer TUNGETIFF). start() runs qemu through a shell,
+            # so the fds are opened with bash redirection.
+            if self.conn_mode == "macvtap":
+                mac, tapidx = self.create_macvtap(i)
+                res.append("-device")
+                res.append(
+                    f"{self.nic_type},netdev=p{i:02d},mac={mac}"
+                    + (
+                        f",bus=pci.{pci_bus},addr=0x{addr:x}"
+                        if self.provision_pci_bus
+                        else ""
+                    ),
+                )
+                fd = 100 + i
+                vhfd = 400 + i
+                res.append("-netdev")
+                res.append(
+                    f"tap,id=p{i:02d},fd={fd},vhost=on,vhostfd={vhfd} "
+                    f"{fd}<>/dev/tap{tapidx} {vhfd}<>/dev/vhost-net"
                 )
                 continue
 


### PR DESCRIPTION
## Why

The default **tc** datapath connects each container data interface to the
VM tap with a `tc mirred egress redirect`. On some host kernels that
redirect is **not delivered into the guest**, so all data-plane traffic is
dropped (management still works because it uses QEMU user-mode networking,
not tap/mirred). Details and hop-by-hop diagnosis in #504.

A plain Linux bridge delivers unicast/broadcast but **cannot forward LACP**
(`01:80:c2:00:00:02` is rejected by `group_fwd_mask`), so LAGs still fail.
A **passthru macvtap** is transparent to reserved multicast and fixes both.

## What

Adds an **opt-in** `macvtap` datapath, selectable with
`CONNECTION_MODE=macvtap`. **`tc` remains the default**, so existing setups
are unchanged.

For each data interface it creates a passthru macvtap and attaches qemu to
it. Three details make it robust:

1. qemu attaches to the macvtap char device via the **vhost fd** path — a
   raw macvtap fd cannot answer `TUNGETIFF`;
2. `/dev/tap<ifindex>` is created explicitly for runtimes without devtmpfs,
   otherwise the shell fd redirect creates a regular file and qemu fails to
   start;
3. **promisc + allmulticast** are set on the macvtap so the guest receives
   reserved multicast (e.g. LACPDUs); without it LAGs stay `defaulted`.

## How to test

Deploy any vrnetlab VM node with `CONNECTION_MODE=macvtap` on a host where
the tc datapath drops traffic, e.g. a topology with two hosts on one L2
segment and a LACP LAG uplink:

- **Before (tc):** hosts can't ping across the VM, ARP never resolves, the
  LAG never leaves `defaulted`.
- **After (macvtap):** L2/L3 forwarding works and the LAG reaches
  `Selected`/`Up`.

I verified a full lab (server-to-server L2, inter-VLAN routing, and a
4-member LACP LAG) go from all-dropping to fully passing with
`CONNECTION_MODE=macvtap`, and confirmed `tc` behaviour is unchanged.

## Compatibility

- Default datapath is still `tc` — no behaviour change unless a user
  explicitly opts into `macvtap`.
- Requires `/dev/vhost-net` and the `macvtap` kernel module on the host.

Fixes #504